### PR TITLE
fix: light-mode Home project context menu contrast

### DIFF
--- a/src/components/library/Library.tsx
+++ b/src/components/library/Library.tsx
@@ -684,7 +684,7 @@ export function Library() {
                     />
                   </div>
                 </ContextMenuTrigger>
-                <ContextMenuContent className="w-52 bg-[#181818]">
+                <ContextMenuContent className="w-52">
                   <ContextMenuItem onClick={() => void openProject(p.id)}>
                     <FileText className="mr-2 size-4" /> Open project
                   </ContextMenuItem>
@@ -706,7 +706,7 @@ export function Library() {
                     <ContextMenuSubTrigger>
                       <Palette className="mr-2 size-4" /> Change book color
                     </ContextMenuSubTrigger>
-                    <ContextMenuSubContent className="w-44 bg-[#181818]">
+                    <ContextMenuSubContent className="w-44">
                       {BOOK_COLOR_OPTIONS.map((c) => {
                         const active = (projectColors[p.id] ?? (p.color || DEFAULT_BOOK_COLOR)) === c.hex;
                         return (


### PR DESCRIPTION
## Summary
Fixes #37.

**Root cause:** The Home project context menu forced a hardcoded dark background (`bg-[#181818]`) on the main menu and the “Change book color” submenu. That overrode the shared themed `bg-popover` / `text-popover-foreground` styles, so in light mode menu items kept dark text on a dark surface.

**Fix:** Remove the hardcoded backgrounds so the menus use the normal themed popover colors in both light and dark mode.

## Test plan
- [x] Light mode → Home → right-click a project → menu is readable
- [x] “Change book color” submenu is readable in light mode
- [x] Dark mode still looks correct