### PR TITLE
fix: let the draft-ready job see draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,7 +352,11 @@ jobs:
     if: ${{ always() && inputs.publish != true }}
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
+      # A draft release is only visible to a token with push access, so
+      # contents:read cannot see it and `gh release view` fails with
+      # "release not found". This job only reads, but write is what makes the
+      # draft visible at all.
+      contents: write
     steps:
       - name: Require every platform artifact, then stop
         env:


### PR DESCRIPTION
## Summary
The **Draft is complete** job fails with `release not found` even when every platform build succeeded and the draft has all assets.

**Root cause:** `contents: read` cannot see draft releases via the GitHub API. The job only needs to read, but draft visibility requires push/`contents: write`.

**Fix:** Grant the job `contents: write` (same as the local unpushed fix from the v0.3.3 attempt).

This does not change packaging; it only makes the verification step able to inspect the draft.

## Test plan
- [x] Confirmed v0.3.4 draft exists with dmg/msi/exe/AppImage/deb/latest.json
- [ ] After merge, re-run Release workflow for `v0.3.4` (or publish the existing draft)