### PR TITLE
fix: pin Biber for biblatex and harden PDF export (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,17 @@ jobs:
         if: steps.cache-tectonic.outputs.cache-hit != 'true'
         run: bash scripts/fetch-tectonic.sh x86_64-unknown-linux-gnu
 
+      - name: Cache Biber sidecar
+        id: cache-biber
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-biber-*
+          key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
+
+      - name: Fetch Biber sidecar
+        if: steps.cache-biber.outputs.cache-hit != 'true'
+        run: bash scripts/fetch-biber.sh x86_64-unknown-linux-gnu
+
       - name: Cache Typst sidecar
         id: cache-typst
         uses: actions/cache@v6
@@ -241,6 +252,17 @@ jobs:
       - name: Fetch Tectonic sidecar
         if: steps.cache-tectonic-e2e.outputs.cache-hit != 'true'
         run: bash scripts/fetch-tectonic.sh aarch64-apple-darwin
+
+      - name: Cache Biber sidecar
+        id: cache-biber-e2e
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-biber-*
+          key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
+
+      - name: Fetch Biber sidecar
+        if: steps.cache-biber-e2e.outputs.cache-hit != 'true'
+        run: bash scripts/fetch-biber.sh aarch64-apple-darwin
 
       - name: Cache Typst sidecar
         id: cache-typst-e2e
@@ -380,6 +402,17 @@ jobs:
         if: steps.cache-tectonic-e2e-linux.outputs.cache-hit != 'true'
         run: bash scripts/fetch-tectonic.sh x86_64-unknown-linux-gnu
 
+      - name: Cache Biber sidecar
+        id: cache-biber-e2e-linux
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-biber-*
+          key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
+
+      - name: Fetch Biber sidecar
+        if: steps.cache-biber-e2e-linux.outputs.cache-hit != 'true'
+        run: bash scripts/fetch-biber.sh x86_64-unknown-linux-gnu
+
       - name: Cache Typst sidecar
         id: cache-typst-e2e-linux
         uses: actions/cache@v6
@@ -490,6 +523,18 @@ jobs:
         if: steps.cache-tectonic-e2e-windows.outputs.cache-hit != 'true'
         shell: bash
         run: bash scripts/fetch-tectonic.sh x86_64-pc-windows-msvc
+
+      - name: Cache Biber sidecar
+        id: cache-biber-e2e-windows
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-biber-*
+          key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
+
+      - name: Fetch Biber sidecar
+        if: steps.cache-biber-e2e-windows.outputs.cache-hit != 'true'
+        shell: bash
+        run: bash scripts/fetch-biber.sh x86_64-pc-windows-msvc
 
       - name: Cache Typst sidecar
         id: cache-typst-e2e-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,12 @@ jobs:
         shell: bash
         run: bash scripts/fetch-tectonic.sh ${{ matrix.rust_target }}
 
+      # Biber 2.17 matched to Tectonic's biblatex; declared as externalBin
+      # tectonic-biber. Missing here breaks the Tauri bundler on release.
+      - name: Fetch checksum-pinned Biber sidecar
+        shell: bash
+        run: bash scripts/fetch-biber.sh ${{ matrix.rust_target }}
+
       - name: Stage checksum-pinned Tinymist resource archive
         shell: bash
         run: node scripts/fetch-language-servers.mjs --server tinymist --target ${{ matrix.rust_target }} --install-mode resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **biblatex / Biber for Overleaf and journal imports.** LaTeX compiles now put a
+  pinned Biber 2.17 (`tectonic-biber`, matched to Tectonic 0.16’s biblatex 3.17)
+  on the compile child’s `PATH`, recover with an explicit Biber + re-typeset when
+  a `.bcf` is left without a usable `.bbl`, and surface clear mode A (missing)
+  vs mode B (version skew) notes in the log. Opening a project also scans for
+  Overleaf-style requirements (biblatex, minted, glossaries, shell-escape, fonts).
+
 ## [0.3.4] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ To run from source:
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
 ./scripts/fetch-tectonic.sh all
+./scripts/fetch-biber.sh all
 ./scripts/fetch-typst.sh all
 pnpm install
 pnpm tauri dev

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -24,6 +24,7 @@ cargo install cargo-about && cargo about generate about.hbs   # Rust / backend
 | Component | Purpose | License |
 |---|---|---|
 | [Tectonic](https://tectonic-typesetting.github.io/) | LaTeX compiler (sidecar) | MIT |
+| [Biber 2.17](https://sourceforge.net/projects/biblatex-biber/) | Bibliography backend for biblatex (`tectonic-biber` sidecar, version-pinned to Tectonic’s biblatex) | Artistic-2.0 / GPL-1.0-or-later |
 | [Typst](https://github.com/typst/typst) | Typst compiler 0.15.0 (sidecar) | Apache-2.0 |
 | [Tinymist 0.15.2](https://github.com/Myriad-Dreamin/tinymist/tree/v0.15.2) | Typst language server (checksum-pinned upstream archive resource), © 2023–2025 Myriad Dreamin and Nathan Varner | Apache-2.0 |
 

--- a/docs/CompilationEngines.md
+++ b/docs/CompilationEngines.md
@@ -10,10 +10,20 @@ engine-specific policy.
 - Default engine: bundled Tectonic sidecar.
 - Supports multi-file projects, images, bibliography files, SyncTeX, and
   cached/offline compilation when packages are available.
-- Compile logs are normalized into editor diagnostics.
+- **biblatex / Biber:** Tectonic 0.16 ships biblatex 3.17, which requires Biber
+  2.17. Oleafly packages a pinned `tectonic-biber` sidecar (see
+  `scripts/fetch-biber.sh`), puts it on `PATH` for the compile child, and if a
+  `.bcf` is left without a usable `.bbl`, runs that Biber explicitly and
+  re-typesets once. This avoids GUI `PATH` misses and system-Biber version skew.
+- Compile logs are normalized into editor diagnostics. Incomplete bibliography
+  steps surface as `[Oleafly]` notes distinguishing “Biber not found” from
+  “Biber/biblatex version mismatch”.
 - Optional LuaLaTeX support can prepare and verify tagged PDF output for
   accessibility-oriented workflows; it is separate from the default Tectonic
   path.
+- Import scan (`@oleafly/latex` `scanImportCompatibility`) flags Overleaf-style
+  requirements (biblatex, minted, glossaries, shell-escape, fonts) when a
+  project is opened.
 
 ## Typst
 

--- a/docs/CompilationEngines.md
+++ b/docs/CompilationEngines.md
@@ -27,6 +27,12 @@ engine-specific policy.
 - Import scan (`@oleafly/latex` `scanImportCompatibility`) flags Overleaf-style
   requirements (biblatex, minted, glossaries, shell-escape, fonts) when a
   project is opened.
+- **Supervised PATH:** every supervised compile child (LaTeX, Typst, Markdown
+  tooling that goes through the same helper) gets TeX-related directories and the
+  sidecar directory prepended to `PATH`. Non-LaTeX engines simply ignore unused
+  entries; directories are only added when they exist on disk.
+- **Linux aarch64:** upstream has no Biber 2.17 binary; packaging ships a stub
+  that exits with a clear error so the bundler still has an `externalBin` file.
 
 ## Typst
 
@@ -35,6 +41,8 @@ engine-specific policy.
 - Advertises current capability limits truthfully: SyncTeX, offline, and
   isolated-compile support are currently disabled.
 - Typst-specific UI behavior is driven by the descriptor, not extensions.
+- Receives the same supervised `PATH` prepending as LaTeX (see above); Typst
+  does not use Biber or TeX Live bins.
 
 ## Markdown
 

--- a/docs/CompilationEngines.md
+++ b/docs/CompilationEngines.md
@@ -12,9 +12,12 @@ engine-specific policy.
   cached/offline compilation when packages are available.
 - **biblatex / Biber:** Tectonic 0.16 ships biblatex 3.17, which requires Biber
   2.17. Oleafly packages a pinned `tectonic-biber` sidecar (see
-  `scripts/fetch-biber.sh`), puts it on `PATH` for the compile child, and if a
-  `.bcf` is left without a usable `.bbl`, runs that Biber explicitly and
-  re-typesets once. This avoids GUI `PATH` misses and system-Biber version skew.
+  `scripts/fetch-biber.sh`) and puts its directory on `PATH` for the compile
+  child. **Primary path:** Tectonic discovers `tectonic-biber` mid-build and
+  runs it itself. **Recovery path:** if a `.bcf` is left without a usable
+  `.bbl` (PATH miss, mid-build tool failure), Oleafly runs the same sidecar via
+  the supervised process helper (timeout + cancel) and re-typesets once. This
+  avoids GUI `PATH` misses and system-Biber version skew.
 - Compile logs are normalized into editor diagnostics. Incomplete bibliography
   steps surface as `[Oleafly]` notes distinguishing “Biber not found” from
   “Biber/biblatex version mismatch”.

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,6 +21,7 @@ localeaf/
 │   ├── resources/          templates, licenses, and pinned runtime archives
 │   └── tauri.conf.json
 ├── scripts/fetch-tectonic.sh
+│   ├── fetch-biber.sh
 ├── scripts/fetch-typst.sh
 ├── scripts/fetch-language-servers.mjs
 └── docs/
@@ -43,6 +44,7 @@ covers the port pattern, the contribution registry, and the alias wiring.
 
 ```bash
 ./scripts/fetch-tectonic.sh all     # fetch compiler sidecars for all platforms
+./scripts/fetch-biber.sh all        # pinned Biber 2.17 (biblatex / tectonic-biber)
 ./scripts/fetch-typst.sh all
 pnpm install
 pnpm language-servers:fetch         # current-host policy; see note below

--- a/packages/latex/src/compile-log/latex-log.test.ts
+++ b/packages/latex/src/compile-log/latex-log.test.ts
@@ -182,7 +182,6 @@ describe("parseLatexLog", () => {
 
   it("returns [] for empty and garbage input without throwing", () => {
     expect(parseLatexLog("")).toEqual([]);
-
     const garbage = [
       "This is pdfTeX, Version 3.141592653-2.6-1.7.11 (TeX Live 2024) (preloaded format=pdflatex)",
       " restricted \\write18 enabled.",
@@ -191,6 +190,23 @@ describe("parseLatexLog", () => {
       "\u0000\u0001 binary junk \u0002",
     ].join("\n");
     expect(parseLatexLog(garbage)).toEqual([]);
+  });
+
+  it("surfaces Oleafly Biber mode diagnostics and biblatex rerun warnings", () => {
+    const log = [
+      "Package biblatex Warning: Please (re)run Biber on the file:",
+      "(biblatex)                _oleafly_entry",
+      "(biblatex)                and rerun LaTeX afterwards.",
+      "[Oleafly] Bibliography needs Biber (biblatex), but a usable .bbl was not produced.",
+      "[Oleafly] Biber was not found (mode A): GUI launches often have a minimal PATH",
+    ].join("\n");
+    const diags = parseLatexLog(log);
+    expect(diags.some((d) => d.category === "biber" && d.message.includes("Bibliography needs Biber"))).toBe(
+      true,
+    );
+    expect(diags.some((d) => d.category === "biber" && d.severity === "error" && d.message.includes("mode A"))).toBe(
+      true,
+    );
   });
 
   it("only parses the first MAX_COMPILE_LOG_BYTES of the log", () => {

--- a/packages/latex/src/compile-log/latex-log.ts
+++ b/packages/latex/src/compile-log/latex-log.ts
@@ -30,6 +30,11 @@ const latexMissChar = /^\s*(Missing character:.*?!)/;
 const latexNoPageOutput = /^No pages of output\.$/;
 const bibEmpty = /^Empty `thebibliography' environment/;
 const biberWarn = /^Biber warning:.*WARN - I didn't find a database entry for '([^']+)'/;
+const biblatexRerunBiber =
+  /^Package biblatex Warning: Please \(re\)run Biber on the file:/;
+const oleaflyBiberModeA = /^\[Oleafly\] Biber was not found \(mode A\)/;
+const oleaflyBiberModeB = /^\[Oleafly\] Biber\/biblatex version mismatch \(mode B\)/;
+const oleaflyBiberGap = /^\[Oleafly\] Bibliography needs Biber/;
 
 // LaTeX Warning: Reference `non-exist' on page 1 undefined on input line 10.
 // LaTeX Warning: Citation `also-nothing' on page 1 undefined on input line 12.
@@ -131,6 +136,24 @@ function parseLine(line: string, state: ParserState) {
     state.insideBoxWarn = false;
     return;
   }
+  // Oleafly annotations must not be absorbed into a multi-line package warning.
+  if (
+    oleaflyBiberModeA.test(line) ||
+    oleaflyBiberModeB.test(line) ||
+    oleaflyBiberGap.test(line)
+  ) {
+    pushCurrent(state);
+    state.searchEmptyLine = false;
+    state.insideError = false;
+    state.current = {
+      severity: "error",
+      category: "biber",
+      file: null,
+      line: null,
+      text: line.replace(/^\[Oleafly\]\s*/, "").trim(),
+    };
+    return;
+  }
   // Append the read line, since we have a corresponding result in the matching
   if (state.searchEmptyLine) {
     const context = state.insideError ? state.current?.contextLines : undefined;
@@ -216,6 +239,19 @@ function parseLine(line: string, state: ParserState) {
   }
   result = line.match(latexWarn);
   if (result) {
+    // Prefer the dedicated Biber diagnostic over a generic package warning.
+    if (biblatexRerunBiber.test(line)) {
+      pushCurrent(state);
+      state.current = {
+        severity: "warning",
+        category: "biber",
+        file: null,
+        line: null,
+        text: "Bibliography needs Biber (biblatex). Oleafly should run pinned tectonic-biber automatically; if citations stay undefined, see [Oleafly] notes in this log.",
+      };
+      state.searchEmptyLine = false;
+      return;
+    }
     pushCurrent(state);
     state.current = {
       severity: "warning",
@@ -239,6 +275,21 @@ function parseLine(line: string, state: ParserState) {
     };
     state.searchEmptyLine = false;
     parseLine(line.substring(result[0].length), state);
+    return;
+  }
+
+  if (biblatexRerunBiber.test(line)) {
+    pushCurrent(state);
+    state.current = {
+      severity: "warning",
+      category: "biber",
+      file: null,
+      line: null,
+      text: "Bibliography needs Biber (biblatex). Oleafly should run pinned tectonic-biber automatically; if citations stay undefined, see [Oleafly] notes in this log.",
+    };
+    // Do not absorb following "(biblatex) ..." continuation lines as a
+    // multi-line package warning — the message is already complete.
+    state.searchEmptyLine = false;
     return;
   }
 

--- a/packages/latex/src/compile-log/latex-log.ts
+++ b/packages/latex/src/compile-log/latex-log.ts
@@ -278,21 +278,6 @@ function parseLine(line: string, state: ParserState) {
     return;
   }
 
-  if (biblatexRerunBiber.test(line)) {
-    pushCurrent(state);
-    state.current = {
-      severity: "warning",
-      category: "biber",
-      file: null,
-      line: null,
-      text: "Bibliography needs Biber (biblatex). Oleafly should run pinned tectonic-biber automatically; if citations stay undefined, see [Oleafly] notes in this log.",
-    };
-    // Do not absorb following "(biblatex) ..." continuation lines as a
-    // multi-line package warning — the message is already complete.
-    state.searchEmptyLine = false;
-    return;
-  }
-
   result = line.match(latexError);
   if (result) {
     pushCurrent(state);

--- a/packages/latex/src/import-compat.test.ts
+++ b/packages/latex/src/import-compat.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { loadsPackage, scanImportCompatibility } from "./import-compat";
+import {
+  loadsPackage,
+  scanImportCompatibility,
+  stripLineComments,
+} from "./import-compat";
 
 describe("scanImportCompatibility", () => {
   it("flags biblatex + biber journal-style projects", () => {
@@ -64,26 +68,29 @@ describe("scanImportCompatibility", () => {
     );
   });
 
-  it("does not flag plain comments or unrelated package names", () => {
+  it("ignores commented-out usepackage lines", () => {
     const findings = scanImportCompatibility({
       texFiles: [
         {
           path: "main.tex",
           content: [
-            String.raw`% \usepackage{minted} is commented out`,
-            String.raw`% mentions of biber in comments should not match latexmkrc alone`,
+            String.raw`% \usepackage{minted}`,
+            String.raw`% \usepackage{glossaries}`,
+            String.raw`% \usepackage{pythontex}`,
             String.raw`\documentclass{article}`,
             String.raw`\usepackage{amsmath}`,
-            String.raw`\usepackage{graphicx}`,
             String.raw`\begin{document}Hello\end{document}`,
           ].join("\n"),
         },
       ],
     });
-    // Comment lines still contain package-like text; this documents current
-    // heuristic limits. Uncommented plain packages must stay quiet.
-    expect(findings.filter((f) => f.id === "pythontex")).toEqual([]);
-    expect(findings.filter((f) => f.id === "fontspec")).toEqual([]);
+    expect(findings.map((f) => f.id)).toEqual([]);
+  });
+
+  it("stripLineComments keeps escaped percent", () => {
+    expect(stripLineComments(String.raw`100\% done % trailing`)).toBe(
+      String.raw`100\% done `,
+    );
   });
 
   it("returns empty for a plain article", () => {

--- a/packages/latex/src/import-compat.test.ts
+++ b/packages/latex/src/import-compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { scanImportCompatibility } from "./import-compat";
+import { loadsPackage, scanImportCompatibility } from "./import-compat";
 
 describe("scanImportCompatibility", () => {
   it("flags biblatex + biber journal-style projects", () => {
@@ -11,6 +11,19 @@ describe("scanImportCompatibility", () => {
 \addbibresource{references.bib}`,
         },
       ],
+    });
+    expect(findings.some((f) => f.id === "biblatex-biber")).toBe(true);
+  });
+
+  it("flags biblatex when latexmkrc selects biber", () => {
+    const findings = scanImportCompatibility({
+      texFiles: [
+        {
+          path: "main.tex",
+          content: String.raw`\documentclass{article}\begin{document}Hi\end{document}`,
+        },
+      ],
+      latexmkrc: "$bibtex = 'biber %O %S';\n",
     });
     expect(findings.some((f) => f.id === "biblatex-biber")).toBe(true);
   });
@@ -30,6 +43,49 @@ describe("scanImportCompatibility", () => {
     expect(findings.filter((f) => f.level === "blocker").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("flags pythontex, shell-escape, fontspec, and pdftex-oriented packages", () => {
+    const findings = scanImportCompatibility({
+      texFiles: [
+        {
+          path: "main.tex",
+          content: [
+            String.raw`\usepackage{pythontex}`,
+            String.raw`\write18{echo hi}`,
+            String.raw`\usepackage{fontspec}`,
+            String.raw`\setmainfont{Times}`,
+            String.raw`\usepackage{inputenc}`,
+          ].join("\n"),
+        },
+      ],
+    });
+    const ids = findings.map((f) => f.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["pythontex", "shell-escape", "fontspec", "pdftex-only"]),
+    );
+  });
+
+  it("does not flag plain comments or unrelated package names", () => {
+    const findings = scanImportCompatibility({
+      texFiles: [
+        {
+          path: "main.tex",
+          content: [
+            String.raw`% \usepackage{minted} is commented out`,
+            String.raw`% mentions of biber in comments should not match latexmkrc alone`,
+            String.raw`\documentclass{article}`,
+            String.raw`\usepackage{amsmath}`,
+            String.raw`\usepackage{graphicx}`,
+            String.raw`\begin{document}Hello\end{document}`,
+          ].join("\n"),
+        },
+      ],
+    });
+    // Comment lines still contain package-like text; this documents current
+    // heuristic limits. Uncommented plain packages must stay quiet.
+    expect(findings.filter((f) => f.id === "pythontex")).toEqual([]);
+    expect(findings.filter((f) => f.id === "fontspec")).toEqual([]);
+  });
+
   it("returns empty for a plain article", () => {
     const findings = scanImportCompatibility({
       texFiles: [
@@ -40,5 +96,14 @@ describe("scanImportCompatibility", () => {
       ],
     });
     expect(findings).toEqual([]);
+  });
+
+  it("loadsPackage matches option lists and multi-package braces linearly", () => {
+    expect(loadsPackage(String.raw`\usepackage{graphicx}`, "graphicx")).toBe(true);
+    expect(
+      loadsPackage(String.raw`\usepackage[backend=biber]{biblatex}`, "biblatex"),
+    ).toBe(true);
+    expect(loadsPackage(String.raw`\usepackage{amsmath,minted}`, "minted")).toBe(true);
+    expect(loadsPackage(String.raw`\usepackage{amsmath}`, "minted")).toBe(false);
   });
 });

--- a/packages/latex/src/import-compat.test.ts
+++ b/packages/latex/src/import-compat.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { scanImportCompatibility } from "./import-compat";
+
+describe("scanImportCompatibility", () => {
+  it("flags biblatex + biber journal-style projects", () => {
+    const findings = scanImportCompatibility({
+      texFiles: [
+        {
+          path: "main.tex",
+          content: String.raw`\usepackage[backend=biber,style=authoryear]{biblatex}
+\addbibresource{references.bib}`,
+        },
+      ],
+    });
+    expect(findings.some((f) => f.id === "biblatex-biber")).toBe(true);
+  });
+
+  it("flags minted and glossaries as blockers", () => {
+    const findings = scanImportCompatibility({
+      texFiles: [
+        {
+          path: "main.tex",
+          content: String.raw`\usepackage{minted}\usepackage{glossaries}\makeglossaries`,
+        },
+      ],
+    });
+    expect(findings.map((f) => f.id).sort()).toEqual(
+      expect.arrayContaining(["minted", "glossaries-index"]),
+    );
+    expect(findings.filter((f) => f.level === "blocker").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns empty for a plain article", () => {
+    const findings = scanImportCompatibility({
+      texFiles: [
+        {
+          path: "main.tex",
+          content: String.raw`\documentclass{article}\begin{document}Hi\end{document}`,
+        },
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -18,6 +18,38 @@ export type ImportCompatFinding = {
 /** Cap combined TeX size so import scan stays cheap and predictable. */
 const MAX_SCAN_CHARS = 512 * 1024;
 
+/** True if `tex[i]` starts a TeX line comment (`%` not escaped by `\`). */
+function isCommentPercent(tex: string, i: number): boolean {
+  if (tex[i] !== "%") return false;
+  let backslashes = 0;
+  for (let j = i - 1; j >= 0 && tex[j] === "\\"; j -= 1) backslashes += 1;
+  return backslashes % 2 === 0;
+}
+
+/**
+ * Drop line comments (`%` … EOL) so commented-out `\usepackage{…}` does not
+ * produce false-positive import toasts. Linear scan; leaves `\%` alone.
+ */
+export function stripLineComments(tex: string): string {
+  let out = "";
+  let i = 0;
+  while (i < tex.length) {
+    const ch = tex[i];
+    if (ch === "\n") {
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (isCommentPercent(tex, i)) {
+      while (i < tex.length && tex[i] !== "\n") i += 1;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
 /**
  * True if `\usepackage[...]{...}` (or without options) loads a package whose
  * name equals `pkg` or appears in a comma-separated package list.
@@ -72,8 +104,9 @@ export function scanImportCompatibility(sources: {
 }): ImportCompatFinding[] {
   const findings: ImportCompatFinding[] = [];
   const texRaw = (sources.texFiles ?? []).map((f) => f.content).join("\n\n");
-  const tex =
+  const capped =
     texRaw.length > MAX_SCAN_CHARS ? texRaw.slice(0, MAX_SCAN_CHARS) : texRaw;
+  const tex = stripLineComments(capped);
   const latexmkrc = sources.latexmkrc ?? "";
 
   const usesBiblatex =

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -1,0 +1,112 @@
+/**
+ * Lightweight static scan of LaTeX sources for Overleaf-style requirements
+ * that need extra tools beyond a single Tectonic typesetting pass.
+ */
+
+export type ImportCompatLevel = "info" | "warning" | "blocker";
+
+export type ImportCompatFinding = {
+  id: string;
+  level: ImportCompatLevel;
+  title: string;
+  detail: string;
+};
+
+const BIBLATEX =
+  /\\usepackage(?:\[[^\]]*\])?\{[^}]*biblatex[^}]*\}|\\addbibresource\s*\{/;
+const BIBER_BACKEND = /backend\s*=\s*biber|\\usepackage\[[^\]]*backend\s*=\s*biber/;
+const MINTED = /\\usepackage(?:\[[^\]]*\])?\{[^}]*minted[^}]*\}|\\begin\{minted\}/;
+const GLOSSARIES =
+  /\\usepackage(?:\[[^\]]*\])?\{[^}]*(?:glossaries|imakeidx|makeidx)[^}]*\}|\\makeglossaries|\\printglossar/;
+const PYTHONTEX = /\\usepackage(?:\[[^\]]*\])?\{[^}]*pythontex[^}]*\}|\\begin\{pycode\}/;
+const SHELL_ESCAPE = /\\write18|\\ShellEscape|\\input\{\|/;
+const FONTSPEC = /\\usepackage(?:\[[^\]]*\])?\{[^}]*fontspec[^}]*\}|\\setmainfont\s*\{/;
+const PDFTEX_ONLY =
+  /\\usepackage(?:\[[^\]]*\])?\{[^}]*(?:cmap|inputenc)[^}]*\}|\\pdfoutput|\\pdfliteral/;
+
+/**
+ * Scan concatenated project TeX (and optional latexmkrc) for known import gaps.
+ * Pure and synchronous — safe to call from the editor or compile UI.
+ */
+export function scanImportCompatibility(sources: {
+  texFiles?: ReadonlyArray<{ path: string; content: string }>;
+  latexmkrc?: string | null;
+}): ImportCompatFinding[] {
+  const findings: ImportCompatFinding[] = [];
+  const tex = (sources.texFiles ?? [])
+    .map((f) => f.content)
+    .join("\n\n");
+  const latexmkrc = sources.latexmkrc ?? "";
+
+  if (BIBLATEX.test(tex) || BIBER_BACKEND.test(tex) || /biber/i.test(latexmkrc)) {
+    findings.push({
+      id: "biblatex-biber",
+      level: "warning",
+      title: "Bibliography uses biblatex / Biber",
+      detail:
+        "This project needs Biber to build the reference list. Oleafly ships a pinned tectonic-biber matched to its Tectonic engine. If citations stay as “?” after compile, check the log for a Biber note.",
+    });
+  }
+
+  if (MINTED.test(tex)) {
+    findings.push({
+      id: "minted",
+      level: "blocker",
+      title: "minted needs shell-escape and Pygments",
+      detail:
+        "Code listings via minted require \\write18 and a system pygmentize. Oleafly does not enable shell-escape by default; expect failures until that toolchain is available.",
+    });
+  }
+
+  if (GLOSSARIES.test(tex)) {
+    findings.push({
+      id: "glossaries-index",
+      level: "blocker",
+      title: "Glossary / index external tool",
+      detail:
+        "glossaries or makeindex need an external index run (makeindex/xindy), which is not yet orchestrated by Oleafly.",
+    });
+  }
+
+  if (PYTHONTEX.test(tex)) {
+    findings.push({
+      id: "pythontex",
+      level: "blocker",
+      title: "pythontex",
+      detail:
+        "pythontex needs a Python helper pass outside the core Tectonic compile loop.",
+    });
+  }
+
+  if (SHELL_ESCAPE.test(tex)) {
+    findings.push({
+      id: "shell-escape",
+      level: "warning",
+      title: "Shell-escape commands",
+      detail:
+        "The source uses \\write18 / shell escapes. These are disabled by default for safety and often fail when host tools are missing.",
+    });
+  }
+
+  if (FONTSPEC.test(tex)) {
+    findings.push({
+      id: "fontspec",
+      level: "info",
+      title: "Custom fonts (fontspec)",
+      detail:
+        "fontspec needs the named fonts installed on this machine. Overleaf often ships fonts that are not present locally.",
+    });
+  }
+
+  if (PDFTEX_ONLY.test(tex)) {
+    findings.push({
+      id: "pdftex-only",
+      level: "info",
+      title: "pdfTeX-oriented packages",
+      detail:
+        "Oleafly’s default engine is Tectonic (XeTeX-class). Some pdfTeX-only packages or primitives may need small source adjustments.",
+    });
+  }
+
+  return findings;
+}

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -1,6 +1,9 @@
 /**
  * Lightweight static scan of LaTeX sources for Overleaf-style requirements
  * that need extra tools beyond a single Tectonic typesetting pass.
+ *
+ * Matching is linear-time (indexOf / fixed-window scans) so adversarial
+ * project text cannot trigger ReDoS. Input is capped before scanning.
  */
 
 export type ImportCompatLevel = "info" | "warning" | "blocker";
@@ -12,17 +15,52 @@ export type ImportCompatFinding = {
   detail: string;
 };
 
-const BIBLATEX =
-  /\\usepackage(?:\[[^\]]*\])?\{[^}]*biblatex[^}]*\}|\\addbibresource\s*\{/;
-const BIBER_BACKEND = /backend\s*=\s*biber|\\usepackage\[[^\]]*backend\s*=\s*biber/;
-const MINTED = /\\usepackage(?:\[[^\]]*\])?\{[^}]*minted[^}]*\}|\\begin\{minted\}/;
-const GLOSSARIES =
-  /\\usepackage(?:\[[^\]]*\])?\{[^}]*(?:glossaries|imakeidx|makeidx)[^}]*\}|\\makeglossaries|\\printglossar/;
-const PYTHONTEX = /\\usepackage(?:\[[^\]]*\])?\{[^}]*pythontex[^}]*\}|\\begin\{pycode\}/;
-const SHELL_ESCAPE = /\\write18|\\ShellEscape|\\input\{\|/;
-const FONTSPEC = /\\usepackage(?:\[[^\]]*\])?\{[^}]*fontspec[^}]*\}|\\setmainfont\s*\{/;
-const PDFTEX_ONLY =
-  /\\usepackage(?:\[[^\]]*\])?\{[^}]*(?:cmap|inputenc)[^}]*\}|\\pdfoutput|\\pdfliteral/;
+/** Cap combined TeX size so import scan stays cheap and predictable. */
+const MAX_SCAN_CHARS = 512 * 1024;
+
+/**
+ * True if `\usepackage[...]{...}` (or without options) loads a package whose
+ * name equals `pkg` or appears in a comma-separated package list.
+ * Scans with indexOf only — no nested quantifiers.
+ */
+export function loadsPackage(tex: string, pkg: string): boolean {
+  const needle = "\\usepackage";
+  let from = 0;
+  while (from < tex.length) {
+    const idx = tex.indexOf(needle, from);
+    if (idx === -1) return false;
+    let j = idx + needle.length;
+    while (j < tex.length && (tex[j] === " " || tex[j] === "\t")) j += 1;
+    if (tex[j] === "[") {
+      const closeOpt = tex.indexOf("]", j + 1);
+      if (closeOpt === -1) {
+        from = idx + 1;
+        continue;
+      }
+      // Optional args can contain backend=biber etc.
+      const opts = tex.slice(j + 1, closeOpt);
+      if (pkg === "biber" && opts.includes("backend=biber")) return true;
+      j = closeOpt + 1;
+      while (j < tex.length && (tex[j] === " " || tex[j] === "\t")) j += 1;
+    }
+    if (tex[j] !== "{") {
+      from = idx + 1;
+      continue;
+    }
+    const close = tex.indexOf("}", j + 1);
+    if (close === -1) return false;
+    const list = tex.slice(j + 1, close);
+    for (const part of list.split(",")) {
+      if (part.trim() === pkg) return true;
+    }
+    from = close + 1;
+  }
+  return false;
+}
+
+function includesLiteral(tex: string, snippet: string): boolean {
+  return tex.includes(snippet);
+}
 
 /**
  * Scan concatenated project TeX (and optional latexmkrc) for known import gaps.
@@ -33,12 +71,18 @@ export function scanImportCompatibility(sources: {
   latexmkrc?: string | null;
 }): ImportCompatFinding[] {
   const findings: ImportCompatFinding[] = [];
-  const tex = (sources.texFiles ?? [])
-    .map((f) => f.content)
-    .join("\n\n");
+  const texRaw = (sources.texFiles ?? []).map((f) => f.content).join("\n\n");
+  const tex =
+    texRaw.length > MAX_SCAN_CHARS ? texRaw.slice(0, MAX_SCAN_CHARS) : texRaw;
   const latexmkrc = sources.latexmkrc ?? "";
 
-  if (BIBLATEX.test(tex) || BIBER_BACKEND.test(tex) || /biber/i.test(latexmkrc)) {
+  const usesBiblatex =
+    loadsPackage(tex, "biblatex") ||
+    includesLiteral(tex, "\\addbibresource{") ||
+    includesLiteral(tex, "backend=biber") ||
+    latexmkrc.toLowerCase().includes("biber");
+
+  if (usesBiblatex) {
     findings.push({
       id: "biblatex-biber",
       level: "warning",
@@ -48,7 +92,7 @@ export function scanImportCompatibility(sources: {
     });
   }
 
-  if (MINTED.test(tex)) {
+  if (loadsPackage(tex, "minted") || includesLiteral(tex, "\\begin{minted}")) {
     findings.push({
       id: "minted",
       level: "blocker",
@@ -58,7 +102,13 @@ export function scanImportCompatibility(sources: {
     });
   }
 
-  if (GLOSSARIES.test(tex)) {
+  if (
+    loadsPackage(tex, "glossaries") ||
+    loadsPackage(tex, "imakeidx") ||
+    loadsPackage(tex, "makeidx") ||
+    includesLiteral(tex, "\\makeglossaries") ||
+    includesLiteral(tex, "\\printglossar")
+  ) {
     findings.push({
       id: "glossaries-index",
       level: "blocker",
@@ -68,7 +118,7 @@ export function scanImportCompatibility(sources: {
     });
   }
 
-  if (PYTHONTEX.test(tex)) {
+  if (loadsPackage(tex, "pythontex") || includesLiteral(tex, "\\begin{pycode}")) {
     findings.push({
       id: "pythontex",
       level: "blocker",
@@ -78,7 +128,11 @@ export function scanImportCompatibility(sources: {
     });
   }
 
-  if (SHELL_ESCAPE.test(tex)) {
+  if (
+    includesLiteral(tex, "\\write18") ||
+    includesLiteral(tex, "\\ShellEscape") ||
+    includesLiteral(tex, "\\input{|")
+  ) {
     findings.push({
       id: "shell-escape",
       level: "warning",
@@ -88,7 +142,7 @@ export function scanImportCompatibility(sources: {
     });
   }
 
-  if (FONTSPEC.test(tex)) {
+  if (loadsPackage(tex, "fontspec") || includesLiteral(tex, "\\setmainfont{")) {
     findings.push({
       id: "fontspec",
       level: "info",
@@ -98,7 +152,12 @@ export function scanImportCompatibility(sources: {
     });
   }
 
-  if (PDFTEX_ONLY.test(tex)) {
+  if (
+    loadsPackage(tex, "cmap") ||
+    loadsPackage(tex, "inputenc") ||
+    includesLiteral(tex, "\\pdfoutput") ||
+    includesLiteral(tex, "\\pdfliteral")
+  ) {
     findings.push({
       id: "pdftex-only",
       level: "info",

--- a/packages/latex/src/index.ts
+++ b/packages/latex/src/index.ts
@@ -6,3 +6,4 @@ export * from "./compile-log/types";
 export * from "./compile-log/latex-log";
 export * from "./compile-log/bibtex-log";
 export * from "./compile-log/biber-log";
+export * from "./import-compat";

--- a/scripts/ensure-e2e-sidecars.sh
+++ b/scripts/ensure-e2e-sidecars.sh
@@ -12,11 +12,18 @@ EXT=""
 [[ "$HOST" == *windows* ]] && EXT=".exe"
 TYPST="$ROOT/src-tauri/binaries/typst-$HOST$EXT"
 TECTONIC="$ROOT/src-tauri/binaries/tectonic-$HOST$EXT"
+BIBER="$ROOT/src-tauri/binaries/tectonic-biber-$HOST$EXT"
 
 bash "$ROOT/scripts/fetch-typst.sh" "$HOST"
 bash "$ROOT/scripts/fetch-tectonic.sh" "$HOST"
+bash "$ROOT/scripts/fetch-biber.sh" "$HOST"
 
 TYPST_VERSION="$("$TYPST" --version)"
 TECTONIC_VERSION="$("$TECTONIC" --version)"
 grep -Fi "typst 0.15.0" <<<"$TYPST_VERSION" >/dev/null
 grep -Fi "tectonic 0.16.9" <<<"$TECTONIC_VERSION" >/dev/null
+# Biber is optional on aarch64 Linux (no upstream 2.17 binary).
+if [[ -f "$BIBER" ]]; then
+  BIBER_VERSION="$("$BIBER" --version 2>&1 || true)"
+  grep -Fi "2.17" <<<"$BIBER_VERSION" >/dev/null
+fi

--- a/scripts/fetch-biber.sh
+++ b/scripts/fetch-biber.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# Fetch a Biber binary pinned to match Tectonic 0.16.x's bundled biblatex (3.17).
+#   ./scripts/fetch-biber.sh aarch64-apple-darwin
+#   ./scripts/fetch-biber.sh all
+#
+# Output: src-tauri/binaries/tectonic-biber-<triple>[.exe]
+# Tectonic prefers a binary named `tectonic-biber` on PATH over a generic `biber`,
+# which avoids version skew with system TeX Live.
+set -euo pipefail
+
+# biblatex 3.17 (Tectonic 0.16.9 bundle) requires Biber 2.17.
+VERSION="2.17"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN_DIR="$ROOT/src-tauri/binaries"
+CACHE_DIR="${OLEAFLY_SIDECAR_CACHE_DIR:-$ROOT/src-tauri/target/e2e-sidecars}"
+mkdir -p "$BIN_DIR"
+mkdir -p "$CACHE_DIR"
+TMP=""
+
+cleanup_fetch() {
+  if [[ -n "$TMP" ]]; then
+    rm -rf "$TMP"
+    TMP=""
+  fi
+}
+trap cleanup_fetch EXIT INT TERM
+
+# "<relative-path-under-binaries>:<archive-kind>:<sha256>[:lipo-arch]"
+# lipo-arch is optional: when set, extract a universal binary and thin to that arch.
+asset_for() {
+  case "$1" in
+    aarch64-apple-darwin)
+      # Universal 2.17 binary; thin to arm64 to keep the sidecar smaller.
+      echo "MacOS/biber-darwin_universal.tar.gz:tar:182e1efa074d8a2a23a8893f2a22440d4e463cce55e4ed02076ac4c0ee0614b2:arm64"
+      ;;
+    x86_64-apple-darwin)
+      echo "MacOS/biber-darwin_x86_64.tar.gz:tar:aa72ccdd01d59367b919d517f7a116e5dc40848abc1909cd812b485f791df7f4"
+      ;;
+    x86_64-unknown-linux-gnu)
+      echo "Linux/biber-linux_x86_64.tar.gz:tar:129d2e0332a57e985ffa253e5e9fbd28ef99af5a068d1b141145211969aa8999"
+      ;;
+    x86_64-pc-windows-msvc)
+      echo "Windows/biber-MSWIN64.zip:zip:c103bffc5ae0a7f513e7c26b6d394e9be6cf41952959c5d604ee2e6581b5dea2"
+      ;;
+    aarch64-unknown-linux-gnu)
+      # Upstream did not publish a native 2.17 aarch64 Linux binary.
+      # Marker: handled specially with a clear-error stub so externalBin packaging
+      # still has a file for this triple.
+      echo "STUB"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+ALL_TARGETS="aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu x86_64-pc-windows-msvc"
+
+checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+write_stub() {
+  local target="$1"
+  local out="$BIN_DIR/tectonic-biber-$target"
+  cat > "$out" <<'STUB'
+#!/bin/sh
+echo "Oleafly: pinned Biber 2.17 is not available for this platform (no upstream aarch64 Linux binary)." >&2
+echo "Install a matching Biber yourself or compile on x86_64 / macOS / Windows." >&2
+exit 1
+STUB
+  chmod +x "$out"
+  echo "✓ $out (stub — no upstream Biber $VERSION binary for $target)"
+}
+
+fetch() {
+  local target="$1"
+  local entry
+  entry="$(asset_for "$target")"
+  if [[ "$entry" == "STUB" ]]; then
+    write_stub "$target"
+    return 0
+  fi
+  if [[ -z "$entry" ]]; then
+    echo "unknown target: $target" >&2
+    exit 1
+  fi
+
+  local asset="${entry%%:*}"
+  local rest="${entry#*:}"
+  local kind="${rest%%:*}"
+  rest="${rest#*:}"
+  local expected_sha="${rest%%:*}"
+  local lipo_arch=""
+  if [[ "$rest" == *:* ]]; then
+    lipo_arch="${rest#*:}"
+  fi
+
+  local ext=""
+  [[ "$target" == *windows* ]] && ext=".exe"
+  local out="$BIN_DIR/tectonic-biber-$target$ext"
+  local base="https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/$VERSION/binaries"
+  local url="$base/$asset"
+  local cache_name="biber-$VERSION-$(basename "$asset")"
+  local archive="$CACHE_DIR/$cache_name"
+
+  TMP="$(mktemp -d)"
+  local tmp="$TMP"
+  local actual_sha=""
+  if [[ -f "$archive" && ! -L "$archive" ]]; then
+    actual_sha="$(checksum "$archive")"
+  fi
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    rm -f "$archive"
+    echo "→ fetching $target ($asset)"
+    if ! curl -fSL --retry 5 --retry-delay 3 --retry-connrefused \
+        -o "$tmp/download" "$url"; then
+      echo "failed to download $url" >&2
+      exit 1
+    fi
+    actual_sha="$(checksum "$tmp/download")"
+    if [[ "$actual_sha" == "$expected_sha" ]]; then
+      mv "$tmp/download" "$archive"
+    fi
+  fi
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "checksum mismatch for $asset: expected $expected_sha, got $actual_sha" >&2
+    exit 1
+  fi
+
+  case "$kind" in
+    tar)
+      tar xzf "$archive" -C "$tmp"
+      if [[ ! -f "$tmp/biber" || -L "$tmp/biber" ]]; then
+        echo "could not locate biber binary in archive for $target" >&2
+        exit 1
+      fi
+      if [[ -n "$lipo_arch" ]]; then
+        if ! command -v lipo >/dev/null 2>&1; then
+          echo "lipo is required to thin the macOS universal Biber binary" >&2
+          exit 1
+        fi
+        lipo "$tmp/biber" -thin "$lipo_arch" -output "$tmp/biber-thin"
+        mv "$tmp/biber-thin" "$tmp/biber"
+      fi
+      local bin="$tmp/biber"
+      ;;
+    zip)
+      unzip -oq "$archive" -d "$tmp"
+      local bin=""
+      if [[ -f "$tmp/biber.exe" ]]; then
+        bin="$tmp/biber.exe"
+      else
+        bin="$(find "$tmp" -type f -name 'biber.exe' | head -n 1 || true)"
+      fi
+      if [[ -z "$bin" || ! -f "$bin" ]]; then
+        echo "could not locate biber.exe in archive for $target" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "unknown archive kind: $kind" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ -f "$out" && ! -L "$out" ]] && cmp -s "$bin" "$out"; then
+    chmod +x "$out" 2>/dev/null || true
+    if [[ "$(uname)" == "Darwin" ]]; then
+      xattr -d com.apple.quarantine "$out" 2>/dev/null || true
+    fi
+    cleanup_fetch
+    echo "✓ $out"
+    return
+  fi
+  cp "$bin" "$out"
+  chmod +x "$out" 2>/dev/null || true
+  if [[ "$(uname)" == "Darwin" ]]; then
+    xattr -d com.apple.quarantine "$out" 2>/dev/null || true
+  fi
+  cleanup_fetch
+  echo "✓ $out"
+}
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: $0 <target-triple> | all"
+  echo "targets: $ALL_TARGETS"
+  echo "pinned Biber version: $VERSION (matches Tectonic 0.16.x / biblatex 3.17)"
+  exit 0
+fi
+
+if [[ "$1" == "all" ]]; then
+  for t in $ALL_TARGETS; do fetch "$t"; done
+else
+  fetch "$1"
+fi

--- a/src-tauri/src/biber_toolchain.rs
+++ b/src-tauri/src/biber_toolchain.rs
@@ -1,0 +1,315 @@
+//! Pinned Biber support for biblatex projects.
+//!
+//! Tectonic 0.16 bundles biblatex 3.17, which requires Biber 2.17. System TeX
+//! Live often ships a newer Biber that rejects Tectonic's control files. Oleafly
+//! therefore prefers a co-packaged `tectonic-biber` (the name Tectonic looks up
+//! first) and injects its directory onto PATH for the compile child.
+
+use std::path::{Path, PathBuf};
+
+use crate::proc::NoConsole;
+
+/// Locate a version-pinned `tectonic-biber` binary for the current app layout.
+pub fn find_tectonic_biber() -> Option<PathBuf> {
+    tectonic_biber_candidates()
+        .into_iter()
+        .find(|path| path.is_file())
+}
+
+/// Directories that should precede PATH when spawning Tectonic so it can find
+/// `tectonic-biber` and common system TeX helpers.
+pub fn compile_path_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            let base = if parent.ends_with("deps") {
+                parent.parent().unwrap_or(parent)
+            } else {
+                parent
+            };
+            push_unique(&mut dirs, base.to_path_buf());
+        }
+    }
+
+    if let Some(biber) = find_tectonic_biber() {
+        if let Some(parent) = biber.parent() {
+            push_unique(&mut dirs, parent.to_path_buf());
+        }
+    }
+
+    for dir in tex_bin_search_dirs() {
+        if dir.is_dir() {
+            push_unique(&mut dirs, dir);
+        }
+    }
+
+    dirs
+}
+
+/// Build a PATH value with toolchain directories first.
+pub fn compile_path_env() -> std::ffi::OsString {
+    let dirs = compile_path_dirs();
+    let mut path = std::env::var_os("PATH").unwrap_or_default();
+    if dirs.is_empty() {
+        return path;
+    }
+    #[cfg(windows)]
+    let sep = std::ffi::OsString::from(";");
+    #[cfg(not(windows))]
+    let sep = std::ffi::OsString::from(":");
+
+    let mut prefix = std::ffi::OsString::new();
+    for (index, dir) in dirs.iter().enumerate() {
+        if index > 0 {
+            prefix.push(&sep);
+        }
+        prefix.push(dir.as_os_str());
+    }
+    if !path.is_empty() {
+        prefix.push(&sep);
+        prefix.push(&path);
+        path = prefix;
+    } else {
+        path = prefix;
+    }
+    path
+}
+
+/// True when the compile produced a biblatex control file that still needs Biber.
+pub fn bibliography_needs_biber(log: &str, out_dir: &Path, entry_stem: &str) -> bool {
+    let bcf = out_dir.join(format!("{entry_stem}.bcf"));
+    if bcf.is_file() {
+        return true;
+    }
+    log.contains("Please (re)run Biber")
+        || log.contains("Please (re)run Biber on the file")
+        || log.contains(&format!("file '{entry_stem}.bbl' not found"))
+        || log.contains(&format!("No file {entry_stem}.bbl"))
+}
+
+/// True when Biber did not produce a usable .bbl for the entry stem.
+pub fn biber_output_missing(out_dir: &Path, entry_stem: &str) -> bool {
+    let bbl = out_dir.join(format!("{entry_stem}.bbl"));
+    match std::fs::metadata(&bbl) {
+        Ok(meta) => meta.len() == 0,
+        Err(_) => true,
+    }
+}
+
+/// Classify a failed or incomplete Biber step for the user-facing log.
+pub fn diagnose_biber_gap(log: &str, biber: Option<&Path>) -> String {
+    let mut message = String::from(
+        "\n[Oleafly] Bibliography needs Biber (biblatex), but a usable .bbl was not produced.\n",
+    );
+    if log.contains("versions are incompatible") || log.contains("control file version") {
+        message.push_str(
+            "[Oleafly] Biber/biblatex version mismatch (mode B): the Biber on PATH does not match \
+Tectonic's bundled biblatex. Prefer the packaged tectonic-biber (Biber 2.17 for Tectonic 0.16).\n",
+        );
+    } else if biber.is_none()
+        || log.contains("No such file or directory (os error 2)")
+        || (log.contains("Running external tool biber") && log.contains("No such file"))
+    {
+        message.push_str(
+            "[Oleafly] Biber was not found (mode A): GUI launches often have a minimal PATH, and \
+Oleafly could not locate the packaged tectonic-biber sidecar. Reinstall Oleafly or run \
+scripts/fetch-biber.sh for your platform, then compile again.\n",
+        );
+    } else {
+        message.push_str(
+            "[Oleafly] Biber was available but the bibliography step still failed. Check the Biber \
+messages above, then recompile.\n",
+        );
+        if let Some(path) = biber {
+            message.push_str(&format!("[Oleafly] Using Biber at: {}\n", path.display()));
+        }
+    }
+    message
+}
+
+/// Run Biber on the entry stem in the build directory (explicit recovery path).
+pub fn run_biber(
+    biber: &Path,
+    out_dir: &Path,
+    project_dir: &Path,
+    entry_stem: &str,
+) -> Result<String, String> {
+    use std::process::Command;
+    // Biber reads the .bcf next to the jobname; Tectonic writes it to out_dir.
+    let mut cmd = Command::new(biber);
+    cmd.no_console()
+        .arg("--output-directory")
+        .arg(out_dir)
+        .arg("--input-directory")
+        .arg(out_dir)
+        .arg(entry_stem)
+        .current_dir(project_dir)
+        .env("PATH", compile_path_env());
+    // Also search the project for .bib files relative to the project root.
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to run biber {}: {e}", biber.display()))?;
+    let log = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success() {
+        return Err(if log.trim().is_empty() {
+            format!(
+                "biber exited with status {}",
+                output.status.code().unwrap_or(-1)
+            )
+        } else {
+            log
+        });
+    }
+    Ok(log)
+}
+
+fn tectonic_biber_candidates() -> Vec<PathBuf> {
+    let name = if cfg!(windows) {
+        "tectonic-biber.exe"
+    } else {
+        "tectonic-biber"
+    };
+    let mut candidates = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            let base = if parent.ends_with("deps") {
+                parent.parent().unwrap_or(parent)
+            } else {
+                parent
+            };
+            candidates.push(base.join(name));
+        }
+    }
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    candidates.push(manifest.join("target/debug").join(name));
+    candidates.push(manifest.join("target/release").join(name));
+    if let Some(triple) = host_triple_guess() {
+        let triple_name = if cfg!(windows) {
+            format!("tectonic-biber-{triple}.exe")
+        } else {
+            format!("tectonic-biber-{triple}")
+        };
+        candidates.push(manifest.join("binaries").join(&triple_name));
+    }
+    candidates
+}
+
+fn host_triple_guess() -> Option<&'static str> {
+    match (std::env::consts::ARCH, std::env::consts::OS) {
+        ("aarch64", "macos") => Some("aarch64-apple-darwin"),
+        ("x86_64", "macos") => Some("x86_64-apple-darwin"),
+        ("x86_64", "linux") => Some("x86_64-unknown-linux-gnu"),
+        ("aarch64", "linux") => Some("aarch64-unknown-linux-gnu"),
+        ("x86_64", "windows") => Some("x86_64-pc-windows-msvc"),
+        _ => None,
+    }
+}
+
+fn tex_bin_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![
+        PathBuf::from("/Library/TeX/texbin"),
+        PathBuf::from("/usr/local/bin"),
+        PathBuf::from("/opt/homebrew/bin"),
+    ];
+    if let Ok(home) = std::env::var("HOME") {
+        let home = PathBuf::from(home);
+        dirs.push(home.join(".oleafly/tinytex/bin"));
+        dirs.push(home.join(".TinyTeX/bin"));
+        // TinyTeX nests bin/<platform>/
+        if let Ok(entries) = std::fs::read_dir(home.join(".oleafly/tinytex")) {
+            for entry in entries.flatten() {
+                let bin = entry.path().join("bin");
+                if bin.is_dir() {
+                    dirs.push(bin.clone());
+                    if let Ok(platforms) = std::fs::read_dir(&bin) {
+                        for platform in platforms.flatten() {
+                            if platform.path().is_dir() {
+                                dirs.push(platform.path());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    dirs
+}
+
+fn push_unique(dirs: &mut Vec<PathBuf>, dir: PathBuf) {
+    if !dirs.iter().any(|existing| existing == &dir) {
+        dirs.push(dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "oleafly-biber-test-{}-{}",
+            label,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn bibliography_detects_bcf_or_log_request() {
+        let dir = scratch_dir("bcf");
+        assert!(!bibliography_needs_biber("clean", &dir, "main"));
+        assert!(bibliography_needs_biber(
+            "Package biblatex Warning: Please (re)run Biber on the file:",
+            &dir,
+            "main"
+        ));
+        std::fs::write(dir.join("_oleafly_entry.bcf"), b"<bcf/>").unwrap();
+        assert!(bibliography_needs_biber("ok", &dir, "_oleafly_entry"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bbl_missing_when_absent_or_empty() {
+        let dir = scratch_dir("bbl");
+        assert!(biber_output_missing(&dir, "main"));
+        std::fs::write(dir.join("main.bbl"), b"").unwrap();
+        assert!(biber_output_missing(&dir, "main"));
+        std::fs::write(dir.join("main.bbl"), b"\\begin{thebibliography}").unwrap();
+        assert!(!biber_output_missing(&dir, "main"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn diagnose_mode_a_when_biber_missing() {
+        let msg = diagnose_biber_gap(
+            "note: Running external tool biber ...\nerror: No such file or directory (os error 2)",
+            None,
+        );
+        assert!(msg.contains("mode A"));
+        assert!(msg.contains("not found"));
+    }
+
+    #[test]
+    fn diagnose_mode_b_on_version_skew() {
+        let msg = diagnose_biber_gap(
+            "ERROR - Error: Found biblatex control file version 3.8, expected version 3.11.\n\
+This means that your biber (2.20) and biblatex (3.17) versions are incompatible.",
+            Some(Path::new("/Library/TeX/texbin/biber")),
+        );
+        assert!(msg.contains("mode B"));
+        assert!(msg.contains("version mismatch"));
+    }
+
+    #[test]
+    fn compile_path_env_is_non_empty() {
+        let env = compile_path_env();
+        assert!(!env.is_empty());
+    }
+}

--- a/src-tauri/src/biber_toolchain.rs
+++ b/src-tauri/src/biber_toolchain.rs
@@ -7,8 +7,6 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::proc::NoConsole;
-
 /// Locate a version-pinned `tectonic-biber` binary for the current app layout.
 pub fn find_tectonic_biber() -> Option<PathBuf> {
     tectonic_biber_candidates()
@@ -128,44 +126,17 @@ messages above, then recompile.\n",
     message
 }
 
-/// Run Biber on the entry stem in the build directory (explicit recovery path).
-pub fn run_biber(
-    biber: &Path,
-    out_dir: &Path,
-    project_dir: &Path,
-    entry_stem: &str,
-) -> Result<String, String> {
-    use std::process::Command;
-    // Biber reads the .bcf next to the jobname; Tectonic writes it to out_dir.
-    let mut cmd = Command::new(biber);
-    cmd.no_console()
-        .arg("--output-directory")
-        .arg(out_dir)
-        .arg("--input-directory")
-        .arg(out_dir)
-        .arg(entry_stem)
-        .current_dir(project_dir)
-        .env("PATH", compile_path_env());
-    // Also search the project for .bib files relative to the project root.
-    let output = cmd
-        .output()
-        .map_err(|e| format!("failed to run biber {}: {e}", biber.display()))?;
-    let log = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    if !output.status.success() {
-        return Err(if log.trim().is_empty() {
-            format!(
-                "biber exited with status {}",
-                output.status.code().unwrap_or(-1)
-            )
-        } else {
-            log
-        });
-    }
-    Ok(log)
+/// CLI args for running Biber on the entry stem written under `out_dir`.
+/// Callers should spawn via the supervised compile process path so timeout,
+/// cancel, and process-group isolation match Tectonic.
+pub fn biber_cli_args(out_dir: &Path, entry_stem: &str) -> Vec<String> {
+    vec![
+        "--output-directory".into(),
+        out_dir.to_string_lossy().into_owned(),
+        "--input-directory".into(),
+        out_dir.to_string_lossy().into_owned(),
+        entry_stem.into(),
+    ]
 }
 
 fn tectonic_biber_candidates() -> Vec<PathBuf> {
@@ -311,5 +282,20 @@ This means that your biber (2.20) and biblatex (3.17) versions are incompatible.
     fn compile_path_env_is_non_empty() {
         let env = compile_path_env();
         assert!(!env.is_empty());
+    }
+
+    #[test]
+    fn biber_cli_args_target_out_dir_and_entry_stem() {
+        let args = biber_cli_args(Path::new("/build"), "_oleafly_entry");
+        assert_eq!(
+            args,
+            [
+                "--output-directory",
+                "/build",
+                "--input-directory",
+                "/build",
+                "_oleafly_entry"
+            ]
+        );
     }
 }

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -860,44 +860,58 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
                         )
                         .as_bytes(),
                     );
-                    match crate::biber_toolchain::run_biber(
+                    let biber_args = crate::biber_toolchain::biber_cli_args(out_dir, stem);
+                    // Same supervised path as Tectonic: timeout, cancel, isolation.
+                    let biber_run = run_supervised_process(
                         &biber,
-                        out_dir,
+                        &biber_args,
                         &spec.working_dir,
-                        stem,
-                    ) {
-                        Ok(biber_log) => {
+                        Some((request.app.clone(), request.log_event.to_owned())),
+                        COMPILE_TIMEOUT,
+                        request.cancel,
+                    )
+                    .await;
+                    match biber_run {
+                        Ok((biber_log, biber_code)) => {
                             append_bounded(&mut biber_notes, biber_log.as_bytes());
-                            append_bounded(
-                                &mut biber_notes,
-                                b"\n[Oleafly] Re-running Tectonic after Biber...\n",
-                            );
-                            let (retry_out, retry_code) = match &spec.executable {
-                                EngineExecutable::BundledSidecar(name) => {
-                                    run_bundled(
-                                        request.app,
-                                        name,
-                                        &spec.args,
-                                        &spec.working_dir,
-                                        request.log_event,
-                                        request.cancel,
-                                    )
-                                    .await?
-                                }
-                                EngineExecutable::ExternalPath(path) => {
-                                    run_external(
-                                        request.app,
-                                        path,
-                                        &spec.args,
-                                        &spec.working_dir,
-                                        request.log_event,
-                                        request.cancel,
-                                    )
-                                    .await?
-                                }
-                            };
-                            stdout_buf = retry_out;
-                            exit_code = retry_code;
+                            if biber_code.unwrap_or(-1) != 0 {
+                                let diagnosis = crate::biber_toolchain::diagnose_biber_gap(
+                                    &biber_log,
+                                    Some(biber.as_path()),
+                                );
+                                append_bounded(&mut biber_notes, diagnosis.as_bytes());
+                            } else {
+                                append_bounded(
+                                    &mut biber_notes,
+                                    b"\n[Oleafly] Re-running Tectonic after Biber...\n",
+                                );
+                                let (retry_out, retry_code) = match &spec.executable {
+                                    EngineExecutable::BundledSidecar(name) => {
+                                        run_bundled(
+                                            request.app,
+                                            name,
+                                            &spec.args,
+                                            &spec.working_dir,
+                                            request.log_event,
+                                            request.cancel,
+                                        )
+                                        .await?
+                                    }
+                                    EngineExecutable::ExternalPath(path) => {
+                                        run_external(
+                                            request.app,
+                                            path,
+                                            &spec.args,
+                                            &spec.working_dir,
+                                            request.log_event,
+                                            request.cancel,
+                                        )
+                                        .await?
+                                    }
+                                };
+                                stdout_buf = retry_out;
+                                exit_code = retry_code;
+                            }
                         }
                         Err(error) => {
                             append_bounded(&mut biber_notes, error.as_bytes());

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -807,7 +807,7 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
             .map_err(|e| format!("failed to write engine entry {}: {e}", path.display()))?;
     }
     let compile_start = std::time::Instant::now();
-    let (stdout_buf, exit_code) = match &spec.executable {
+    let (mut stdout_buf, mut exit_code) = match &spec.executable {
         EngineExecutable::BundledSidecar(name) => {
             run_bundled(
                 request.app,
@@ -832,15 +832,129 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
         }
     };
 
+    // Biblatex recovery: if Tectonic wrote a .bcf but no usable .bbl, run the
+    // pinned tectonic-biber ourselves and re-run Tectonic once. PATH injection
+    // usually makes Tectonic call Biber mid-build; this covers edge cases.
+    let mut biber_notes = String::new();
+    if request.engine.id() == DocumentEngineId::Latex
+        && matches!(request.target, CompileTarget::Main { .. })
+    {
+        let out_dir = &spec.artifacts.output_dir;
+        let stem = crate::paths::ENTRY_STEM;
+        let combined_for_check = spec
+            .artifacts
+            .log
+            .as_ref()
+            .and_then(|path| read_log_bounded(path).ok())
+            .unwrap_or_else(|| stdout_buf.clone());
+        if crate::biber_toolchain::bibliography_needs_biber(&combined_for_check, out_dir, stem)
+            && crate::biber_toolchain::biber_output_missing(out_dir, stem)
+        {
+            match crate::biber_toolchain::find_tectonic_biber() {
+                Some(biber) => {
+                    append_bounded(
+                        &mut biber_notes,
+                        format!(
+                            "\n[Oleafly] Running pinned Biber ({}) on {stem}...\n",
+                            biber.display()
+                        )
+                        .as_bytes(),
+                    );
+                    match crate::biber_toolchain::run_biber(
+                        &biber,
+                        out_dir,
+                        &spec.working_dir,
+                        stem,
+                    ) {
+                        Ok(biber_log) => {
+                            append_bounded(&mut biber_notes, biber_log.as_bytes());
+                            append_bounded(
+                                &mut biber_notes,
+                                b"\n[Oleafly] Re-running Tectonic after Biber...\n",
+                            );
+                            let (retry_out, retry_code) = match &spec.executable {
+                                EngineExecutable::BundledSidecar(name) => {
+                                    run_bundled(
+                                        request.app,
+                                        name,
+                                        &spec.args,
+                                        &spec.working_dir,
+                                        request.log_event,
+                                        request.cancel,
+                                    )
+                                    .await?
+                                }
+                                EngineExecutable::ExternalPath(path) => {
+                                    run_external(
+                                        request.app,
+                                        path,
+                                        &spec.args,
+                                        &spec.working_dir,
+                                        request.log_event,
+                                        request.cancel,
+                                    )
+                                    .await?
+                                }
+                            };
+                            stdout_buf = retry_out;
+                            exit_code = retry_code;
+                        }
+                        Err(error) => {
+                            append_bounded(&mut biber_notes, error.as_bytes());
+                            append_bounded(
+                                &mut biber_notes,
+                                crate::biber_toolchain::diagnose_biber_gap(
+                                    &error,
+                                    Some(biber.as_path()),
+                                )
+                                .as_bytes(),
+                            );
+                        }
+                    }
+                }
+                None => {
+                    append_bounded(
+                        &mut biber_notes,
+                        crate::biber_toolchain::diagnose_biber_gap(&combined_for_check, None)
+                            .as_bytes(),
+                    );
+                }
+            }
+        }
+    }
+
     let stopped = request
         .cancel
         .is_some_and(crate::state::CompileCancel::detach);
-    let log = spec
+    let mut log = spec
         .artifacts
         .log
         .as_ref()
         .and_then(|path| read_log_bounded(path).ok())
         .unwrap_or(stdout_buf);
+    if !biber_notes.is_empty() {
+        append_bounded(&mut log, biber_notes.as_bytes());
+    }
+    // If bibliography is still incomplete after recovery, surface a clear note.
+    if request.engine.id() == DocumentEngineId::Latex
+        && matches!(request.target, CompileTarget::Main { .. })
+        && crate::biber_toolchain::bibliography_needs_biber(
+            &log,
+            &spec.artifacts.output_dir,
+            crate::paths::ENTRY_STEM,
+        )
+        && crate::biber_toolchain::biber_output_missing(
+            &spec.artifacts.output_dir,
+            crate::paths::ENTRY_STEM,
+        )
+        && !log.contains("[Oleafly] Bibliography needs Biber")
+    {
+        let diagnosis = crate::biber_toolchain::diagnose_biber_gap(
+            &log,
+            crate::biber_toolchain::find_tectonic_biber().as_deref(),
+        );
+        append_bounded(&mut log, diagnosis.as_bytes());
+    }
     let pdf_path = spec.artifacts.pdf.clone();
     let output_id = if capabilities.produces_pdf {
         tokio::task::spawn_blocking(move || {
@@ -858,7 +972,6 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
     let has_pdf = output_id.is_some();
     let errors = request.engine.parse_errors(&log);
     let has_reported_errors = errors.iter().any(|e| e.kind == "error");
-    let mut log = log;
     if stopped {
         append_bounded(&mut log, b"\nOleafly stopped the compile on request.\n");
     }
@@ -1049,6 +1162,7 @@ async fn run_supervised_process(
         .no_console()
         .args(args)
         .current_dir(working_dir)
+        .env("PATH", crate::biber_toolchain::compile_path_env())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     isolate_process_tree(&mut command);

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -836,6 +836,7 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
     // pinned tectonic-biber ourselves and re-run Tectonic once. PATH injection
     // usually makes Tectonic call Biber mid-build; this covers edge cases.
     let mut biber_notes = String::new();
+    let mut resolved_biber: Option<PathBuf> = None;
     if request.engine.id() == DocumentEngineId::Latex
         && matches!(request.target, CompileTarget::Main { .. })
     {
@@ -852,6 +853,7 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
         {
             match crate::biber_toolchain::find_tectonic_biber() {
                 Some(biber) => {
+                    resolved_biber = Some(biber.clone());
                     append_bounded(
                         &mut biber_notes,
                         format!(
@@ -885,6 +887,9 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
                                     &mut biber_notes,
                                     b"\n[Oleafly] Re-running Tectonic after Biber...\n",
                                 );
+                                // Reuse the same compile args: tectonic flags are
+                                // deterministic for this entry (no cache-busting /
+                                // --fresh), so a second pass is a normal multipass.
                                 let (retry_out, retry_code) = match &spec.executable {
                                     EngineExecutable::BundledSidecar(name) => {
                                         run_bundled(
@@ -963,10 +968,8 @@ pub async fn compile(request: CompileRequest<'_>) -> Result<CompileResult, Strin
         )
         && !log.contains("[Oleafly] Bibliography needs Biber")
     {
-        let diagnosis = crate::biber_toolchain::diagnose_biber_gap(
-            &log,
-            crate::biber_toolchain::find_tectonic_biber().as_deref(),
-        );
+        let biber_for_diag = resolved_biber.or_else(crate::biber_toolchain::find_tectonic_biber);
+        let diagnosis = crate::biber_toolchain::diagnose_biber_gap(&log, biber_for_diag.as_deref());
         append_bounded(&mut log, diagnosis.as_bytes());
     }
     let pdf_path = spec.artifacts.pdf.clone();
@@ -1176,6 +1179,8 @@ async fn run_supervised_process(
         .no_console()
         .args(args)
         .current_dir(working_dir)
+        // TeX bin dirs + tectonic-biber for all supervised children (LaTeX primary;
+        // Typst/others ignore extra PATH entries that are not present or unused).
         .env("PATH", crate::biber_toolchain::compile_path_env())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod assets;
+mod biber_toolchain;
 mod chats;
 mod citation;
 mod commands;

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -201,7 +201,7 @@ impl AtomicFile {
         // From here the destination file exists. Nothing after this point may
         // turn a successful publish into a user-facing export failure.
         self.committed = true;
-        let _ = sync_parent(&self.destination);
+        sync_parent(&self.destination);
         Ok(())
     }
 }
@@ -275,33 +275,19 @@ fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
     unreachable!("the bounded Windows replacement loop always returns")
 }
 
+/// Best-effort directory fsync after a successful rename. Never fails the
+/// caller: macOS TCC (Desktop/Downloads), iCloud, and some network volumes
+/// reject directory fsync even when the file itself was published.
 #[cfg(unix)]
-fn sync_parent(destination: &Path) -> Result<(), String> {
-    let parent = destination
-        .parent()
-        .ok_or_else(|| "file destination has no parent folder".to_string())?;
-    match std::fs::File::open(parent).and_then(|directory| directory.sync_all()) {
-        Ok(()) => Ok(()),
-        // macOS TCC (Desktop/Downloads/Documents), iCloud, and some network
-        // volumes reject fsync on directories the app did not create, even when
-        // the user-chosen file rename already succeeded. The PDF is already at
-        // the destination; treat this as best-effort durability, not a failure.
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Unsupported
-            ) || matches!(error.raw_os_error(), Some(libc::EPERM) | Some(libc::EACCES)) =>
-        {
-            Ok(())
-        }
-        Err(error) => Err(format!("failed to sync destination folder: {error}")),
-    }
+fn sync_parent(destination: &Path) {
+    let Some(parent) = destination.parent() else {
+        return;
+    };
+    let _ = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
 }
 
 #[cfg(not(unix))]
-fn sync_parent(_destination: &Path) -> Result<(), String> {
-    Ok(())
-}
+fn sync_parent(_destination: &Path) {}
 
 #[cfg(test)]
 mod tests {
@@ -399,24 +385,13 @@ mod tests {
     }
 
     #[test]
-    fn sync_parent_tolerates_permission_denied_on_directory_fsync() {
-        // /dev is not a normal export target; open+fsync may fail with EPERM
-        // on some platforms. The helper must not turn that into a hard error
-        // when the destination file path's parent is restricted.
-        let destination = PathBuf::from("/dev/null-oleafly-export-probe");
-        // If the parent cannot be opened at all with PermissionDenied, we still
-        // accept that as non-fatal. Other failures (missing parent name) remain
-        // errors only when they are not permission-related.
-        let result = sync_parent(&destination);
-        // On systems where /dev is openable and fsync works, Ok is fine too.
-        // PermissionDenied paths must not surface as Err.
-        if let Err(message) = result {
-            assert!(
-                !message.contains("Operation not permitted")
-                    && !message.contains("Permission denied"),
-                "permission errors on directory fsync must be best-effort: {message}"
-            );
-        }
+    fn sync_parent_is_best_effort_and_never_panics() {
+        // Restricted parents (e.g. some Desktop/Downloads layouts) may reject
+        // open/fsync; the helper must not panic or block commit.
+        sync_parent(Path::new("/dev/null-oleafly-export-probe"));
+        let root = temp_root();
+        sync_parent(&root.join("out.pdf"));
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -185,19 +185,23 @@ impl AtomicFile {
                 )?;
             }
         }
-        std::fs::OpenOptions::new()
+        // Staging-file fsync is best-effort. Some volumes reject fsync while
+        // still accepting rename; failing the whole export after a good write
+        // would tell the user the PDF was not saved when it was.
+        let _ = std::fs::OpenOptions::new()
             // Windows maps sync_all() to FlushFileBuffers, which rejects a
             // handle opened without GENERIC_WRITE. A read-only reopen works
             // on Unix but makes every atomic write fail with access denied on
             // Windows, so reopen the completed staging file for writing.
             .write(true)
             .open(&self.staging)
-            .and_then(|file| file.sync_all())
-            .map_err(|error| format!("failed to sync staged artifact: {error}"))?;
+            .and_then(|file| file.sync_all());
         replace_file(&self.staging, &self.destination)
             .map_err(|error| format!("failed to publish staged artifact: {error}"))?;
+        // From here the destination file exists. Nothing after this point may
+        // turn a successful publish into a user-facing export failure.
         self.committed = true;
-        sync_parent(&self.destination)?;
+        let _ = sync_parent(&self.destination);
         Ok(())
     }
 }
@@ -276,9 +280,22 @@ fn sync_parent(destination: &Path) -> Result<(), String> {
     let parent = destination
         .parent()
         .ok_or_else(|| "file destination has no parent folder".to_string())?;
-    std::fs::File::open(parent)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|error| format!("failed to sync destination folder: {error}"))
+    match std::fs::File::open(parent).and_then(|directory| directory.sync_all()) {
+        Ok(()) => Ok(()),
+        // macOS TCC (Desktop/Downloads/Documents), iCloud, and some network
+        // volumes reject fsync on directories the app did not create, even when
+        // the user-chosen file rename already succeeded. The PDF is already at
+        // the destination; treat this as best-effort durability, not a failure.
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Unsupported
+            ) || matches!(error.raw_os_error(), Some(libc::EPERM) | Some(libc::EACCES)) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(format!("failed to sync destination folder: {error}")),
+    }
 }
 
 #[cfg(not(unix))]
@@ -379,6 +396,27 @@ mod tests {
         assert_eq!(std::fs::read(&destination).unwrap(), b"complete artifact");
         assert_eq!(std::fs::read_dir(&root).unwrap().count(), 1);
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn sync_parent_tolerates_permission_denied_on_directory_fsync() {
+        // /dev is not a normal export target; open+fsync may fail with EPERM
+        // on some platforms. The helper must not turn that into a hard error
+        // when the destination file path's parent is restricted.
+        let destination = PathBuf::from("/dev/null-oleafly-export-probe");
+        // If the parent cannot be opened at all with PermissionDenied, we still
+        // accept that as non-fatal. Other failures (missing parent name) remain
+        // errors only when they are not permission-related.
+        let result = sync_parent(&destination);
+        // On systems where /dev is openable and fsync works, Ok is fine too.
+        // PermissionDenied paths must not surface as Err.
+        if let Err(message) = result {
+            assert!(
+                !message.contains("Operation not permitted")
+                    && !message.contains("Permission denied"),
+                "permission errors on directory fsync must be best-effort: {message}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,6 +45,7 @@
     ],
     "externalBin": [
       "binaries/tectonic",
+      "binaries/tectonic-biber",
       "binaries/typst"
     ],
     "resources": [

--- a/src/components/preview/PreviewPane.tsx
+++ b/src/components/preview/PreviewPane.tsx
@@ -1088,19 +1088,31 @@ export function PreviewPane() {
       });
       if (!destination) return;
       await writeBytesFile(destination, uint8ToBase64(exportBytes));
+      const fileName =
+        destination.split(/[/\\]/).pop() || (isImage ? "image.png" : "document.pdf");
       toast.success(
-        isImage ? "Image downloaded" : "PDF downloaded",
+        isImage ? `Image saved · ${fileName}` : `PDF saved · ${fileName}`,
         {
-          label: "View File",
-          onClick: () => void revealInDir(destination),
+          label: "Show in folder",
+          onClick: () => {
+            void revealInDir(destination).catch(() => {
+              toast.info(
+                "File was saved, but Oleafly could not open its folder (permission denied). Check the location you chose in the save dialog.",
+              );
+            });
+          },
         },
         true,
       );
     } catch (error) {
+      const detail =
+        error instanceof Error ? error.message : typeof error === "string" ? error : "";
       notifyError(
         "download preview",
         error,
-        `Couldn't download the ${isImage ? "image" : "PDF"}.`,
+        detail
+          ? `Couldn't download the ${isImage ? "image" : "PDF"}: ${detail}`
+          : `Couldn't download the ${isImage ? "image" : "PDF"}.`,
       );
     } finally {
       setExporting(false);

--- a/src/features/export.ts
+++ b/src/features/export.ts
@@ -4,6 +4,24 @@ import { useFilesStore } from "@/store/files";
 import { useCompileStore } from "@/store/compile";
 import { notifyError, toast } from "@/lib/toast";
 
+/** Show in Finder/Explorer; never flip a successful save into a failure toast. */
+function revealExportedFile(dest: string): void {
+  void revealInDir(dest).catch(() => {
+    toast.info(
+      "File was saved, but Oleafly could not open its folder (permission denied). Check the location you chose in the save dialog.",
+    );
+  });
+}
+
+function exportSuccessToast(kind: "PDF" | "PNG", dest: string): void {
+  const fileName = dest.split(/[/\\]/).pop() || kind.toLowerCase();
+  toast.success(
+    `${kind} saved · ${fileName}`,
+    { label: "Show in folder", onClick: () => revealExportedFile(dest) },
+    true,
+  );
+}
+
 export async function exportCurrentPdf(): Promise<void> {
   const { projectId, projectName } = useFilesStore.getState();
   const { pdfBytes } = useCompileStore.getState();
@@ -16,13 +34,15 @@ export async function exportCurrentPdf(): Promise<void> {
   if (!dest) return;
   try {
     await exportPdf(projectId, dest);
-    toast.success(
-      "Export PDF complete",
-      { label: "View File", onClick: () => void revealInDir(dest) },
-      true,
-    );
+    // Destination path is known and the file was published — always success.
+    exportSuccessToast("PDF", dest);
   } catch (e) {
-    notifyError("export pdf", e, "Couldn't save the PDF");
+    const detail = e instanceof Error ? e.message : typeof e === "string" ? e : "";
+    notifyError(
+      "export pdf",
+      e,
+      detail ? `Couldn't save the PDF: ${detail}` : "Couldn't save the PDF",
+    );
   }
 }
 
@@ -41,12 +61,13 @@ export async function exportCurrentImagePng(scale = 3): Promise<void> {
     const { pdfPageToPng } = await import("@/lib/pdf-image");
     const dataUrl = await pdfPageToPng(pdfBytes, 1, scale);
     await writeBytesFile(dest, dataUrl.slice(dataUrl.indexOf(",") + 1));
-    toast.success(
-      "Export PNG complete",
-      { label: "View File", onClick: () => void revealInDir(dest) },
-      true,
-    );
+    exportSuccessToast("PNG", dest);
   } catch (e) {
-    notifyError("export png", e, "Couldn't save the PNG");
+    const detail = e instanceof Error ? e.message : typeof e === "string" ? e : "";
+    notifyError(
+      "export png",
+      e,
+      detail ? `Couldn't save the PNG: ${detail}` : "Couldn't save the PNG",
+    );
   }
 }

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -26,7 +26,8 @@ import {
 } from "@/lib/tauri";
 import { UNKNOWN_ENGINE } from "@/lib/document-engine";
 import { flushAutoCommit, scheduleAutoCommit } from "@/lib/auto-commit";
-import { notifyError } from "@/lib/toast";
+import { notifyError, toast } from "@/lib/toast";
+import { scanImportCompatibility } from "@oleafly/latex";
 import { cancelProofreading } from "@/lib/proofreading/client";
 import { useDiffStore } from "@/store/diff";
 import { nextTabSeq } from "@/store/tab-order";
@@ -340,6 +341,35 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
         }
       }
       await get().openFile(meta.main_doc || "main.tex");
+      // Overleaf-import compatibility: surface known tool gaps early (biblatex,
+      // minted, glossaries, …) so compile failures are less mysterious.
+      if (seq === openSeq) {
+        try {
+          const mainPath = meta.main_doc || "main.tex";
+          const mainContent =
+            get().files[mainPath]?.content ??
+            (await readFileContent(id, mainPath).catch(() => ""));
+          let latexmkrc: string | null = null;
+          if (tree.some((f) => !f.is_dir && f.path === "latexmkrc")) {
+            latexmkrc = await readFileContent(id, "latexmkrc").catch(() => null);
+          }
+          const findings = scanImportCompatibility({
+            texFiles: [{ path: mainPath, content: mainContent }],
+            latexmkrc,
+          });
+          const blockers = findings.filter((f) => f.level === "blocker");
+          const warnings = findings.filter((f) => f.level === "warning");
+          if (blockers.length > 0) {
+            toast.info(
+              `${blockers[0].title}${blockers.length > 1 ? ` (+${blockers.length - 1} more)` : ""}`,
+            );
+          } else if (warnings.some((f) => f.id === "biblatex-biber")) {
+            toast.info("This project uses biblatex/Biber for the bibliography.");
+          }
+        } catch {
+          /* scan is best-effort */
+        }
+      }
     } catch (e) {
       // Surface the failure and fall back to the library rather than leaving the
       // app wedged in a half-open project with an empty tree.

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -360,11 +360,18 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
           const blockers = findings.filter((f) => f.level === "blocker");
           const warnings = findings.filter((f) => f.level === "warning");
           if (blockers.length > 0) {
-            toast.info(
-              `${blockers[0].title}${blockers.length > 1 ? ` (+${blockers.length - 1} more)` : ""}`,
-            );
-          } else if (warnings.some((f) => f.id === "biblatex-biber")) {
-            toast.info("This project uses biblatex/Biber for the bibliography.");
+            const extra = blockers.length > 1 ? ` (+${blockers.length - 1} more)` : "";
+            toast.info(`${blockers[0].title}${extra}`);
+          } else if (warnings.length > 0) {
+            if (warnings.some((f) => f.id === "biblatex-biber") && warnings.length === 1) {
+              toast.info("This project uses biblatex/Biber for the bibliography.");
+            } else {
+              toast.info(
+                `${warnings.length} import note${warnings.length === 1 ? "" : "s"}: ${warnings[0].title}${
+                  warnings.length > 1 ? ` (+${warnings.length - 1} more)` : ""
+                }`,
+              );
+            }
           }
         } catch {
           /* scan is best-effort */


### PR DESCRIPTION
## Summary

Fixes #40.

- Ship pinned Biber 2.17 as `tectonic-biber` so biblatex journal projects get a working bibliography under Tectonic.
- Put the sidecar on the compile PATH and recover when a `.bcf` is left without a usable `.bbl`.
- Scan imports for Overleaf-style tool needs (biblatex, minted, glossaries, etc.).
- After a successful PDF write, treat folder fsync / reveal failures as non-fatal so export is not reported as failed when the file is already saved.

## Test plan

- [x] Unit tests for biber toolchain, latex log, import-compat, sandbox
- [x] Manual: import biblatex seed, compile, citations resolve
- [x] Manual: export PDF to Desktop/Downloads succeeds
- [ ] CI green on this PR