### PR TITLE
Overleaf import and latexmk engine for full compile parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resumes interrupted downloads across app launches, pauses a running compile
   and re-queues it, and intercepts window close and Cmd+Q with a clear
   confirmation while an install is running.
+- **Missing packages install themselves.** When a latexmk compile fails on a
+  missing `.sty` or `.cls`, Oleafly names the packages and offers a one-click
+  install through tlmgr, then recompiles automatically.
 - **Reproducible projects.** `project.json` now carries the compile engine and
   a TeX pin (distribution plus tlmgr package versions) so collaborators open
   the same setup. Coauthors are prompted to install missing pinned packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Import from Overleaf.** The Library and the template chooser now import an
+  Overleaf ZIP export or a plain folder as a new project. The main document is
+  inferred automatically: a `% !TeX root` magic comment wins, otherwise
+  `\documentclass` and `\begin{document}` scoring picks the entry, and a lone
+  `.tex` file is used as is. Extraction is hardened with path, size, and depth
+  limits, junk files are filtered, and a single wrapping folder is unwrapped.
+  Full issue: https://github.com/Oleafly/Oleafly/issues/42
+- **latexmk engine for full Overleaf parity.** Projects can compile through a
+  system TeX distribution (MacTeX, TeX Live, MiKTeX, or TinyTeX) driven by
+  `latexmk`, which orchestrates Biber, makeindex/makeglossaries, pythontex,
+  shell-escape, and multi-pass builds the way Overleaf does. The TeX flavor is
+  chosen from the source (`% !TeX program` comment, fontspec detection,
+  pdfLaTeX default) and shell-escape is enabled only when the document needs
+  it. Imported LaTeX projects pick latexmk automatically when a system TeX is
+  detected; everything else stays on the bundled Tectonic engine.
+- **Engine choice that explains itself.** Opening a project scans the whole
+  tree for Tectonic gaps (minted, glossaries, pythontex, shell-escape,
+  biblatex, pdfTeX-only classes) and a failed compile that matches a known gap
+  opens a three-option engine picker: use system TeX, download TinyTeX, or
+  keep Tectonic. Errors that originate in a publisher class or style file are
+  recognized as engine gaps too. The per-project choice lives in the compile
+  options menu, and Settings gains a default engine for new projects plus a
+  panel listing detected TeX distributions.
+- **Seamless TinyTeX install.** The on-demand TinyTeX download checks free
+  disk space first, shows phased progress for download, unpack, and packages,
+  resumes interrupted downloads across app launches, pauses a running compile
+  and re-queues it, and intercepts window close and Cmd+Q with a clear
+  confirmation while an install is running.
+- **Reproducible projects.** `project.json` now carries the compile engine and
+  a TeX pin (distribution plus tlmgr package versions) so collaborators open
+  the same setup. Coauthors are prompted to install missing pinned packages
+  with one click, a differing distribution gets a one-time heads-up, and every
+  successful compile writes a provenance record under `.oleafly/builds/`.
+
 ### Fixed
 
 - **biblatex / Biber for Overleaf and journal imports.** LaTeX compiles now put a

--- a/docs/CompilationEngines.md
+++ b/docs/CompilationEngines.md
@@ -26,7 +26,64 @@ engine-specific policy.
   path.
 - Import scan (`@oleafly/latex` `scanImportCompatibility`) flags Overleaf-style
   requirements (biblatex, minted, glossaries, shell-escape, fonts) when a
-  project is opened.
+  project is opened. The same taxonomy (`IMPORT_COMPAT_CATALOG`) drives the
+  compile-failure classifier (`classifyCompileFailure`) and the engine-picker
+  modal, so every surface describes a gap in the same words.
+
+## latexmk (full Overleaf parity)
+
+Projects that need tools Tectonic does not orchestrate — `minted`
+(shell-escape + Pygments), `glossaries`/`makeidx` (external index runs),
+`pythontex`, shell-escape-heavy publisher classes — can pin the `latexmk`
+engine instead. It drives a **system TeX distribution** (MacTeX, TeX Live,
+MiKTeX, or TinyTeX) via `latexmk`, exactly the way Overleaf compiles.
+
+- Detection is shared (`src-tauri/src/tex_distro.rs`): managed TinyTeX under
+  `~/.oleafly/tinytex`, MacTeX, `/usr/local/texlive/<year>`, MiKTeX (Windows),
+  and `~/.TinyTeX` are probed stat-only. The same list feeds the compile
+  child's `PATH`.
+- The underlying TeX engine is chosen from the source: a
+  `% !TeX program = xelatex|lualatex|pdflatex` magic comment wins; fontspec /
+  polyglossia / unicode-math force XeLaTeX; everything else uses pdfLaTeX
+  (Overleaf's default).
+- `-shell-escape` is enabled only when the source needs it (minted, pythontex,
+  `\write18`, svg) — Overleaf runs sandboxed and enables it globally; a desktop
+  app should not.
+- latexmk runs the *real* main document with `-jobname=_oleafly_entry`, so all
+  artifact paths (PDF, log, SyncTeX) match the Tectonic layout and the preview,
+  log pane, and SyncTeX work unchanged.
+- TinyTeX can be installed on demand (Settings → LaTeX Engine, or the
+  engine-picker modal). The installer checks free disk space first, reports
+  phased progress (download / unpack / packages), resumes interrupted
+  downloads across launches, and intercepts app quit while running.
+
+## Why `project.json` matters
+
+`project.json` is the project's **portable contract**, and it is the reason two
+people opening the same Oleafly project see the same output:
+
+- `engine` pins how the project compiles (`xetex` = bundled Tectonic,
+  `latexmk` = system TeX). A coauthor who clones the project compiles with the
+  same engine automatically — the choice never lives only in one person's
+  app settings (the Settings default applies to *new* projects only).
+- `tex` (written when a project switches to latexmk) records the TeX
+  distribution and the `tlmgr` package versions present when the pin was made
+  — the `package-lock.json` role. On open, coauthors are prompted to install
+  missing pinned packages, and a distribution mismatch (e.g. pinned
+  "TeX Live 2025", local "MacTeX 2024") gets a heads-up that rendering may
+  differ.
+- `main_doc`, `name`, `color`, and export history ride along too.
+
+It lives at the project **root** (not under `.oleafly/`) precisely so that git
+and ZIP export carry it: the app-internal `.oleafly/` directory is gitignored
+and skipped by exports by design. Do not move engine or pin data into
+`.oleafly/` — coauthors would silently stop receiving it.
+
+Every successful compile also writes a small provenance record to
+`.oleafly/builds/` (engine, distribution, lockfile hash, output fingerprint;
+local-only, pruned to the last 20) so "my coauthor's bibliography looks
+different" is a diagnosable question — compare the two machines' latest build
+records.
 - **Supervised PATH:** every supervised compile child (LaTeX, Typst, Markdown
   tooling that goes through the same helper) gets TeX-related directories and the
   sidecar directory prepended to `PATH`. Non-LaTeX engines simply ignore unused

--- a/e2e/tests/63-overleaf-import.spec.ts
+++ b/e2e/tests/63-overleaf-import.spec.ts
@@ -24,6 +24,19 @@ function writeZip(name: string, entries: Record<string, string>): string {
   return zipPath;
 }
 
+// Radix dropdown triggers and menu items react to pointer events, not to a
+// synthetic element.click() (same pattern as 28-ai-chat.spec.ts).
+function pressWithPointer(selectorExpr: string): string {
+  return `(() => {
+    const el = ${selectorExpr};
+    if (!el) return false;
+    el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerId: 1 }));
+    el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true, pointerId: 1 }));
+    el.click();
+    return true;
+  })()`;
+}
+
 async function importZip(page: Page, zipPath: string) {
   await waitLong(
     page,
@@ -31,8 +44,21 @@ async function importZip(page: Page, zipPath: string) {
     30_000,
   );
   await setNextImportPaths(page, [zipPath]);
-  await page.click('[data-testid="import-project-button"]');
-  await page.getByText("Overleaf ZIP").click();
+  const opened = await page.evaluate<boolean>(
+    pressWithPointer(`document.querySelector('[data-testid="import-project-button"]')`),
+  );
+  if (!opened) throw new Error("import dropdown trigger not found");
+  await waitLong(
+    page,
+    `[...document.querySelectorAll('[role="menuitem"]')].some((i) => (i.textContent ?? "").includes("Overleaf ZIP"))`,
+    10_000,
+  );
+  const clicked = await page.evaluate<boolean>(
+    pressWithPointer(
+      `[...document.querySelectorAll('[role="menuitem"]')].find((i) => (i.textContent ?? "").includes("Overleaf ZIP"))`,
+    ),
+  );
+  if (!clicked) throw new Error("Overleaf ZIP menu item not found");
   await waitLong(
     page,
     `!!document.querySelector('[data-tour="project-editor"] .cm-content')`,

--- a/e2e/tests/63-overleaf-import.spec.ts
+++ b/e2e/tests/63-overleaf-import.spec.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { strToU8, zipSync } from "fflate";
+import { test, expect } from "../fixtures";
+import {
+  openProject,
+  setNextImportPaths,
+  waitLong,
+  type Page,
+} from "../helpers";
+
+// Overleaf import end to end: ZIP in, main document inferred, engine flow
+// wired. Fixtures are built at run time so the specs stay hermetic.
+
+function writeZip(name: string, entries: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "oleafly-ovl-"));
+  const files: Record<string, Uint8Array> = {};
+  for (const [path, content] of Object.entries(entries)) {
+    files[path] = strToU8(content);
+  }
+  const zipPath = join(dir, name);
+  writeFileSync(zipPath, zipSync(files));
+  return zipPath;
+}
+
+async function importZip(page: Page, zipPath: string) {
+  await waitLong(
+    page,
+    `!!document.querySelector('[data-testid="library"][data-projects-loaded="true"]')`,
+    30_000,
+  );
+  await setNextImportPaths(page, [zipPath]);
+  await page.click('[data-testid="import-project-button"]');
+  await page.getByText("Overleaf ZIP").click();
+  await waitLong(
+    page,
+    `!!document.querySelector('[data-tour="project-editor"] .cm-content')`,
+    45_000,
+  );
+}
+
+async function projectState(page: Page) {
+  return page.evaluate<{
+    main: string;
+    name: string;
+    paths: string[];
+    engineId: string;
+  }>(
+    `import("/src/store/files.ts").then((m) => {
+      const s = m.useFilesStore.getState();
+      return {
+        main: s.mainDoc,
+        name: s.projectName,
+        paths: s.tree.filter((f) => !f.is_dir).map((f) => f.path),
+        engineId: s.engine.id,
+      };
+    })`,
+  );
+}
+
+test("wrapped Overleaf ZIP unwraps and follows the TeX root magic comment", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(120_000);
+  const zipPath = writeZip("wrapped-thesis.zip", {
+    "wrapped-thesis/thesis.tex":
+      "\\documentclass{report}\n\\input{preamble}\n\\begin{document}\\input{chapters/ch1}\\end{document}\n",
+    "wrapped-thesis/preamble.tex": "\\usepackage{amsmath}\n",
+    "wrapped-thesis/chapters/ch1.tex":
+      "% !TeX root = ../thesis.tex\n\\chapter{One}\nHello.\n",
+    "wrapped-thesis/refs.bib": "@book{k, title={T}, author={A}, year={2024}}\n",
+  });
+  await importZip(tauriPage, zipPath);
+  const state = await projectState(tauriPage);
+  // No file named main.tex: the magic root comment selects thesis.tex.
+  expect(state.main).toBe("thesis.tex");
+  expect(state.name).toBe("wrapped-thesis");
+  // The single top-level folder from the ZIP was unwrapped.
+  expect(state.paths).toContain("thesis.tex");
+  expect(state.paths).toContain("chapters/ch1.tex");
+  expect(state.paths.some((p) => p.startsWith("wrapped-thesis/"))).toBe(false);
+});
+
+test("a lone .tex file becomes the compile entry", async ({ tauriPage }) => {
+  test.setTimeout(120_000);
+  const zipPath = writeZip("single-paper.zip", {
+    "paper.tex":
+      "\\documentclass{article}\n\\begin{document}Single file.\\end{document}\n",
+    "notes.md": "not a tex file\n",
+  });
+  await importZip(tauriPage, zipPath);
+  const state = await projectState(tauriPage);
+  expect(state.main).toBe("paper.tex");
+});
+
+test("a Tectonic project with an engine gap offers the engine picker", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(150_000);
+  const zipPath = writeZip("minted-gap.zip", {
+    "main.tex":
+      "\\documentclass{article}\n\\usepackage{minted}\n\\begin{document}\\begin{minted}{python}\nprint(1)\n\\end{minted}\\end{document}\n",
+  });
+  await importZip(tauriPage, zipPath);
+  // Machines with a system TeX import straight onto latexmk. Pin the bundled
+  // engine so the scan flow under test is the same on every machine.
+  await tauriPage.evaluate(
+    `import("/src/store/files.ts").then((m) => m.useFilesStore.getState().setEngine("xetex"))`,
+  );
+  await waitLong(
+    tauriPage,
+    `import("/src/store/files.ts").then((m) => m.useFilesStore.getState().engine.id === "latex")`,
+    15_000,
+  );
+  // Reopening the project runs the import scan against the Tectonic engine.
+  await tauriPage.click('[title="Back to library"]');
+  await openProject(tauriPage, "minted-gap");
+  await waitLong(
+    tauriPage,
+    `!!document.querySelector('[data-tour="project-editor"] .cm-content')`,
+    30_000,
+  );
+  // The blocker toast carries the entry point into the engine picker.
+  await waitLong(
+    tauriPage,
+    `[...document.querySelectorAll("button")].some((b) => (b.textContent ?? "").includes("Choose engine"))`,
+    20_000,
+  );
+  await tauriPage.getByText("Choose engine").click();
+  await waitLong(
+    tauriPage,
+    `!!document.querySelector('[data-testid="engine-picker-modal"]')`,
+    10_000,
+  );
+  const modalText = await tauriPage.evaluate<string>(
+    `document.querySelector('[data-testid="engine-picker-modal"]')?.textContent ?? ""`,
+  );
+  expect(modalText).toContain("minted");
+  expect(modalText).toContain("Keep using Tectonic");
+  await tauriPage.click('[data-testid="engine-picker-keep-tectonic"]');
+  await waitLong(
+    tauriPage,
+    `!document.querySelector('[data-testid="engine-picker-modal"]')`,
+    10_000,
+  );
+  // The choice is remembered: the project stays on the bundled engine.
+  const state = await projectState(tauriPage);
+  expect(state.engineId).toBe("latex");
+});

--- a/packages/latex/src/import-compat.test.ts
+++ b/packages/latex/src/import-compat.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyCompileFailure,
+  importCompatFinding,
+  latexmkFixesFinding,
   loadsPackage,
+  missingLatexPackages,
   scanImportCompatibility,
   stripLineComments,
 } from "./import-compat";
@@ -112,5 +116,94 @@ describe("scanImportCompatibility", () => {
     ).toBe(true);
     expect(loadsPackage(String.raw`\usepackage{amsmath,minted}`, "minted")).toBe(true);
     expect(loadsPackage(String.raw`\usepackage{amsmath}`, "minted")).toBe(false);
+  });
+});
+
+describe("classifyCompileFailure", () => {
+  it("recognizes a minted shell-escape refusal", () => {
+    const log =
+      "Package minted Error: You must invoke LaTeX with the -shell-escape flag.";
+    expect(classifyCompileFailure(log).map((f) => f.id)).toContain("minted");
+  });
+
+  it("does not double-report shell-escape when minted already matched", () => {
+    const log =
+      "Package minted Error: You must invoke LaTeX with the -shell-escape flag.";
+    const ids = classifyCompileFailure(log).map((f) => f.id);
+    expect(ids).not.toContain("shell-escape");
+  });
+
+  it("recognizes a missing glossary/index artifact", () => {
+    const log = "No file _oleafly_entry.gls.\nOutput written on x.pdf";
+    expect(classifyCompileFailure(log).map((f) => f.id)).toContain(
+      "glossaries-index",
+    );
+  });
+
+  it("recognizes the unresolved-Biber marker appended by the compile layer", () => {
+    const log = "[Oleafly] Bibliography needs Biber (biblatex), but a usable .bbl was not produced.";
+    expect(classifyCompileFailure(log).map((f) => f.id)).toContain(
+      "biblatex-biber",
+    );
+  });
+
+  it("recognizes pdfTeX primitives failing under XeTeX (Springer sn-jnl shape)", () => {
+    const log = [
+      "! Undefined control sequence.",
+      String.raw`\burl@condpdflink ...f@box \dimen@ii \dp \pdf@box`,
+    ].join("\n");
+    expect(classifyCompileFailure(log).map((f) => f.id)).toContain("pdftex-only");
+  });
+
+  it("stays silent on ordinary user errors", () => {
+    const log = [
+      "! Undefined control sequence.",
+      String.raw`l.42 \foo`,
+      "! Missing $ inserted.",
+    ].join("\n");
+    expect(classifyCompileFailure(log)).toEqual([]);
+  });
+});
+
+describe("taxonomy catalog", () => {
+  it("marks latexmk-fixable findings and exposes entries by id", () => {
+    expect(latexmkFixesFinding("minted")).toBe(true);
+    expect(latexmkFixesFinding("fontspec")).toBe(false);
+    expect(latexmkFixesFinding("not-a-real-id")).toBe(false);
+    const finding = importCompatFinding("class-compat");
+    expect(finding.level).toBe("warning");
+    expect(finding.title.length).toBeGreaterThan(0);
+  });
+});
+
+describe("missingLatexPackages", () => {
+  it("extracts package stems from missing .sty and .cls errors", () => {
+    const log = [
+      "! LaTeX Error: File `siunitx.sty' not found.",
+      "! LaTeX Error: File `sn-jnl.cls' not found.",
+      "! I can't find file `algorithmic.sty'.",
+    ].join("\n");
+    expect(missingLatexPackages(log).sort()).toEqual([
+      "algorithmic",
+      "siunitx",
+      "sn-jnl",
+    ]);
+  });
+
+  it("ignores missing files that are not packages or classes", () => {
+    const log = [
+      "! LaTeX Error: File `figure1.pdf' not found.",
+      "! I can't find file `chapters/intro.tex'.",
+    ].join("\n");
+    expect(missingLatexPackages(log)).toEqual([]);
+  });
+
+  it("deduplicates repeated misses and rejects unsafe names", () => {
+    const log = [
+      "! LaTeX Error: File `siunitx.sty' not found.",
+      "! LaTeX Error: File `siunitx.sty' not found.",
+      "! LaTeX Error: File `bad name$.sty' not found.",
+    ].join("\n");
+    expect(missingLatexPackages(log)).toEqual(["siunitx"]);
   });
 });

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -325,6 +325,47 @@ export function classifyCompileFailure(logRaw: string): ImportCompatFinding[] {
 }
 
 /**
+ * Package/class files a failed compile could not find, as installable tlmgr
+ * package names (best effort: the file stem is the package name for the vast
+ * majority of CTAN packages). Matches the pdfLaTeX/XeLaTeX error shapes:
+ *
+ *   ! LaTeX Error: File `foo.sty' not found.
+ *   ! I can't find file `bar.cls'.
+ *
+ * Linear indexOf scans only. Capped and deduplicated.
+ */
+export function missingLatexPackages(logRaw: string): string[] {
+  const log =
+    logRaw.length > MAX_CLASSIFY_CHARS ? logRaw.slice(0, MAX_CLASSIFY_CHARS) : logRaw;
+  const found = new Set<string>();
+  const markers = ["LaTeX Error: File `", "I can't find file `"];
+  for (const marker of markers) {
+    let from = 0;
+    while (from < log.length && found.size < 8) {
+      const idx = log.indexOf(marker, from);
+      if (idx === -1) break;
+      const start = idx + marker.length;
+      const quote = log.indexOf("'", start);
+      if (quote === -1 || quote - start > 128) {
+        from = start;
+        continue;
+      }
+      const file = log.slice(start, quote).trim();
+      const dot = file.lastIndexOf(".");
+      const ext = dot === -1 ? "" : file.slice(dot + 1).toLowerCase();
+      if (ext === "sty" || ext === "cls") {
+        const stem = file.slice(0, dot).split("/").pop() ?? "";
+        // tlmgr package names are a safe charset; anything else is not
+        // installable by name and would just fail the install call.
+        if (stem && /^[a-zA-Z0-9.-]+$/.test(stem)) found.add(stem);
+      }
+      from = quote + 1;
+    }
+  }
+  return [...found];
+}
+
+/**
  * TeX reports a missing include as `No file <name><ext>` (with a trailing
  * period). Line-scan for that shape so ordinary mentions of the extension in
  * prose do not match.

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -70,7 +70,7 @@ export const IMPORT_COMPAT_CATALOG = {
     level: "info",
     title: "pdfTeX-oriented packages",
     detail:
-      "Oleafly’s default engine is Tectonic (XeTeX-class), and this project relies on pdfTeX-only packages or primitives. The latexmk engine compiles with real pdfLaTeX — the same way Overleaf does.",
+      "Oleafly’s default engine is Tectonic (XeTeX-class), and this project relies on pdfTeX-only packages or primitives. The latexmk engine compiles with real pdfLaTeX, the same way Overleaf does.",
     latexmkFixes: true,
   },
 } as const satisfies Record<

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -70,7 +70,7 @@ export const IMPORT_COMPAT_CATALOG = {
     level: "info",
     title: "pdfTeX-oriented packages",
     detail:
-      "Oleafly’s default engine is Tectonic (XeTeX-class). Some pdfTeX-only packages or primitives may need small source adjustments.",
+      "Oleafly’s default engine is Tectonic (XeTeX-class), and this project relies on pdfTeX-only packages or primitives. The latexmk engine compiles with real pdfLaTeX — the same way Overleaf does.",
     latexmkFixes: true,
   },
 } as const satisfies Record<
@@ -295,6 +295,18 @@ export function classifyCompileFailure(logRaw: string): ImportCompatFinding[] {
     log.includes("cannot be found") && log.includes("font")
   ) {
     findings.push(findingFor("fontspec"));
+  }
+
+  // Journal classes (e.g. Springer's sn-jnl) hit pdfTeX-only internals under
+  // XeTeX: "Undefined control sequence" pointing at \pdf@... primitives.
+  // Real pdfLaTeX via latexmk is the fix, exactly like Overleaf.
+  if (
+    log.includes("Undefined control sequence") &&
+    ["\\pdf@", "\\pdfoutput", "\\pdfliteral", "\\pdftexversion", "\\pdfpageattr"].some(
+      (primitive) => log.includes(primitive),
+    )
+  ) {
+    findings.push(findingFor("pdftex-only"));
   }
 
   return findings;

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -15,6 +15,83 @@ export type ImportCompatFinding = {
   detail: string;
 };
 
+/**
+ * Single source of truth for the Tectonic-gap taxonomy. The import scan, the
+ * compile-failure classifier, the engine-picker modal, and the Settings info
+ * popovers all derive their copy from here so they can never disagree.
+ *
+ * `latexmkFixes`: whether switching the project to the latexmk engine (system
+ * TeX) resolves this class of finding.
+ */
+export const IMPORT_COMPAT_CATALOG = {
+  "biblatex-biber": {
+    level: "warning",
+    title: "Bibliography uses biblatex / Biber",
+    detail:
+      "This project needs Biber to build the reference list. Oleafly ships a pinned tectonic-biber matched to its Tectonic engine. If citations stay as “?” after compile, check the log for a Biber note.",
+    latexmkFixes: true,
+  },
+  minted: {
+    level: "blocker",
+    title: "minted needs shell-escape and Pygments",
+    detail:
+      "Code listings via minted require \\write18 and a system pygmentize. Oleafly does not enable shell-escape by default; expect failures until that toolchain is available.",
+    latexmkFixes: true,
+  },
+  "glossaries-index": {
+    level: "blocker",
+    title: "Glossary / index external tool",
+    detail:
+      "glossaries or makeindex need an external index run (makeindex/xindy), which is not yet orchestrated by Oleafly.",
+    latexmkFixes: true,
+  },
+  pythontex: {
+    level: "blocker",
+    title: "pythontex",
+    detail:
+      "pythontex needs a Python helper pass outside the core Tectonic compile loop.",
+    latexmkFixes: true,
+  },
+  "shell-escape": {
+    level: "warning",
+    title: "Shell-escape commands",
+    detail:
+      "The source uses \\write18 / shell escapes. These are disabled by default for safety and often fail when host tools are missing.",
+    latexmkFixes: true,
+  },
+  fontspec: {
+    level: "info",
+    title: "Custom fonts (fontspec)",
+    detail:
+      "fontspec needs the named fonts installed on this machine. Overleaf often ships fonts that are not present locally.",
+    latexmkFixes: false,
+  },
+  "pdftex-only": {
+    level: "info",
+    title: "pdfTeX-oriented packages",
+    detail:
+      "Oleafly’s default engine is Tectonic (XeTeX-class). Some pdfTeX-only packages or primitives may need small source adjustments.",
+    latexmkFixes: true,
+  },
+} as const satisfies Record<
+  string,
+  { level: ImportCompatLevel; title: string; detail: string; latexmkFixes: boolean }
+>;
+
+export type ImportCompatFindingId = keyof typeof IMPORT_COMPAT_CATALOG;
+
+function findingFor(id: ImportCompatFindingId): ImportCompatFinding {
+  const entry = IMPORT_COMPAT_CATALOG[id];
+  return { id, level: entry.level, title: entry.title, detail: entry.detail };
+}
+
+/** True when switching to the latexmk engine resolves this finding. */
+export function latexmkFixesFinding(id: string): boolean {
+  return id in IMPORT_COMPAT_CATALOG
+    ? IMPORT_COMPAT_CATALOG[id as ImportCompatFindingId].latexmkFixes
+    : false;
+}
+
 /** Cap combined TeX size so import scan stays cheap and predictable. */
 const MAX_SCAN_CHARS = 512 * 1024;
 
@@ -116,23 +193,11 @@ export function scanImportCompatibility(sources: {
     latexmkrc.toLowerCase().includes("biber");
 
   if (usesBiblatex) {
-    findings.push({
-      id: "biblatex-biber",
-      level: "warning",
-      title: "Bibliography uses biblatex / Biber",
-      detail:
-        "This project needs Biber to build the reference list. Oleafly ships a pinned tectonic-biber matched to its Tectonic engine. If citations stay as “?” after compile, check the log for a Biber note.",
-    });
+    findings.push(findingFor("biblatex-biber"));
   }
 
   if (loadsPackage(tex, "minted") || includesLiteral(tex, "\\begin{minted}")) {
-    findings.push({
-      id: "minted",
-      level: "blocker",
-      title: "minted needs shell-escape and Pygments",
-      detail:
-        "Code listings via minted require \\write18 and a system pygmentize. Oleafly does not enable shell-escape by default; expect failures until that toolchain is available.",
-    });
+    findings.push(findingFor("minted"));
   }
 
   if (
@@ -142,23 +207,11 @@ export function scanImportCompatibility(sources: {
     includesLiteral(tex, "\\makeglossaries") ||
     includesLiteral(tex, "\\printglossar")
   ) {
-    findings.push({
-      id: "glossaries-index",
-      level: "blocker",
-      title: "Glossary / index external tool",
-      detail:
-        "glossaries or makeindex need an external index run (makeindex/xindy), which is not yet orchestrated by Oleafly.",
-    });
+    findings.push(findingFor("glossaries-index"));
   }
 
   if (loadsPackage(tex, "pythontex") || includesLiteral(tex, "\\begin{pycode}")) {
-    findings.push({
-      id: "pythontex",
-      level: "blocker",
-      title: "pythontex",
-      detail:
-        "pythontex needs a Python helper pass outside the core Tectonic compile loop.",
-    });
+    findings.push(findingFor("pythontex"));
   }
 
   if (
@@ -166,23 +219,11 @@ export function scanImportCompatibility(sources: {
     includesLiteral(tex, "\\ShellEscape") ||
     includesLiteral(tex, "\\input{|")
   ) {
-    findings.push({
-      id: "shell-escape",
-      level: "warning",
-      title: "Shell-escape commands",
-      detail:
-        "The source uses \\write18 / shell escapes. These are disabled by default for safety and often fail when host tools are missing.",
-    });
+    findings.push(findingFor("shell-escape"));
   }
 
   if (loadsPackage(tex, "fontspec") || includesLiteral(tex, "\\setmainfont{")) {
-    findings.push({
-      id: "fontspec",
-      level: "info",
-      title: "Custom fonts (fontspec)",
-      detail:
-        "fontspec needs the named fonts installed on this machine. Overleaf often ships fonts that are not present locally.",
-    });
+    findings.push(findingFor("fontspec"));
   }
 
   if (
@@ -191,14 +232,90 @@ export function scanImportCompatibility(sources: {
     includesLiteral(tex, "\\pdfoutput") ||
     includesLiteral(tex, "\\pdfliteral")
   ) {
-    findings.push({
-      id: "pdftex-only",
-      level: "info",
-      title: "pdfTeX-oriented packages",
-      detail:
-        "Oleafly’s default engine is Tectonic (XeTeX-class). Some pdfTeX-only packages or primitives may need small source adjustments.",
-    });
+    findings.push(findingFor("pdftex-only"));
   }
 
   return findings;
+}
+
+/** Cap classified log size the same way the scan caps source size. */
+const MAX_CLASSIFY_CHARS = 1024 * 1024;
+
+/**
+ * Match a failed Tectonic compile log against known Tectonic-gap signatures.
+ * Returns the same taxonomy entries as `scanImportCompatibility`, so the
+ * compile-failure modal and the import toast tell one consistent story.
+ * Plain `includes` scans only — logs are attacker-influenced text.
+ */
+export function classifyCompileFailure(logRaw: string): ImportCompatFinding[] {
+  const log =
+    logRaw.length > MAX_CLASSIFY_CHARS ? logRaw.slice(0, MAX_CLASSIFY_CHARS) : logRaw;
+  const findings: ImportCompatFinding[] = [];
+
+  if (
+    log.includes("Package minted Error") ||
+    log.includes("minted Error") ||
+    log.includes("pygmentize")
+  ) {
+    findings.push(findingFor("minted"));
+  }
+
+  if (
+    log.includes("-shell-escape") ||
+    log.includes("shell escape is disabled") ||
+    log.includes("Shell escape disabled") ||
+    log.includes("\\write18 disabled") ||
+    log.includes("runsystem(")
+  ) {
+    if (!findings.some((f) => f.id === "minted")) {
+      findings.push(findingFor("shell-escape"));
+    }
+  }
+
+  if (
+    log.includes("Package glossaries") ||
+    hasMissingFileWithExtension(log, [".gls.", ".glo.", ".ind.", ".idx.", ".acr."]) ||
+    log.includes("makeglossaries")
+  ) {
+    findings.push(findingFor("glossaries-index"));
+  }
+
+  if (log.includes("pythontex") || log.includes("PythonTeX")) {
+    findings.push(findingFor("pythontex"));
+  }
+
+  // Appended by the Rust compile layer only when the pinned Biber pass could
+  // not produce a usable .bbl — the case a full latexmk toolchain resolves.
+  if (log.includes("[Oleafly] Bibliography needs Biber")) {
+    findings.push(findingFor("biblatex-biber"));
+  }
+
+  if (
+    log.includes("Package fontspec Error") ||
+    log.includes("cannot be found") && log.includes("font")
+  ) {
+    findings.push(findingFor("fontspec"));
+  }
+
+  return findings;
+}
+
+/**
+ * TeX reports a missing include as `No file <name><ext>` (with a trailing
+ * period). Line-scan for that shape so ordinary mentions of the extension in
+ * prose do not match.
+ */
+function hasMissingFileWithExtension(log: string, endings: string[]): boolean {
+  let from = 0;
+  while (from < log.length) {
+    const idx = log.indexOf("No file ", from);
+    if (idx === -1) return false;
+    const eol = log.indexOf("\n", idx);
+    const line = log.slice(idx, eol === -1 ? log.length : eol).trimEnd();
+    if (endings.some((ending) => line.endsWith(ending) || line.endsWith(ending.slice(0, -1)))) {
+      return true;
+    }
+    from = idx + 8;
+  }
+  return false;
 }

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -35,7 +35,7 @@ export const IMPORT_COMPAT_CATALOG = {
     level: "blocker",
     title: "minted needs shell-escape and Pygments",
     detail:
-      "Code listings via minted require \\write18 and a system pygmentize. Oleafly does not enable shell-escape by default; expect failures until that toolchain is available.",
+      "Code listings via minted require \\write18 and a system pygmentize. Oleafly does not enable shell-escape by default. Expect failures until that toolchain is available.",
     latexmkFixes: true,
   },
   "glossaries-index": {
@@ -73,6 +73,13 @@ export const IMPORT_COMPAT_CATALOG = {
       "Oleafly’s default engine is Tectonic (XeTeX-class), and this project relies on pdfTeX-only packages or primitives. The latexmk engine compiles with real pdfLaTeX, the same way Overleaf does.",
     latexmkFixes: true,
   },
+  "class-compat": {
+    level: "warning",
+    title: "Publisher class hits engine limits",
+    detail:
+      "The compile errors come from a class or style file, not from your document. Publisher classes often depend on tools or pdfTeX behavior the bundled Tectonic engine does not provide. The latexmk engine compiles with a full TeX distribution, the same way Overleaf does.",
+    latexmkFixes: true,
+  },
 } as const satisfies Record<
   string,
   { level: ImportCompatLevel; title: string; detail: string; latexmkFixes: boolean }
@@ -83,6 +90,11 @@ export type ImportCompatFindingId = keyof typeof IMPORT_COMPAT_CATALOG;
 function findingFor(id: ImportCompatFindingId): ImportCompatFinding {
   const entry = IMPORT_COMPAT_CATALOG[id];
   return { id, level: entry.level, title: entry.title, detail: entry.detail };
+}
+
+/** Public lookup for one taxonomy entry (used by catch-all failure checks). */
+export function importCompatFinding(id: ImportCompatFindingId): ImportCompatFinding {
+  return findingFor(id);
 }
 
 /** True when switching to the latexmk engine resolves this finding. */

--- a/packages/templates/src/NewProjectDialog.tsx
+++ b/packages/templates/src/NewProjectDialog.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Download,
   FileText,
+  FolderInput,
   Hash,
   Search,
   Sparkles,
@@ -196,6 +197,7 @@ export function NewProjectDialog({
   onClose,
   onCreate,
   onGenerateWithAi,
+  onImportProject,
   onOpenTemplateDownloads,
   host,
   kit,
@@ -210,6 +212,8 @@ export function NewProjectDialog({
   onClose: () => void;
   onCreate: (name: string, templateId: string, color: string) => void | Promise<void>;
   onGenerateWithAi?: () => void;
+  /** Import an existing project (Overleaf ZIP / folder) instead of a template. */
+  onImportProject?: () => void;
   onOpenTemplateDownloads?: () => void;
   host: TemplatesHost;
   kit: TemplatesKit;
@@ -449,6 +453,17 @@ export function NewProjectDialog({
             {step === 1 ? "Choose a template" : "Name your project"}
           </h2>
           <div className="flex items-center gap-2">
+            {step === 1 && onImportProject && (
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid="import-from-overleaf"
+                data-tour-hide
+                onClick={onImportProject}
+              >
+                <FolderInput className="size-3.5" /> Import from Overleaf
+              </Button>
+            )}
             {step === 1 && onGenerateWithAi && (
               <Button
                 variant="ghostPrimary"

--- a/packages/templates/src/types.ts
+++ b/packages/templates/src/types.ts
@@ -8,7 +8,7 @@ export interface TemplateInfo {
   description: string;
   category: string;
   engine: string;
-  document_engine: "latex" | "typst" | "markdown" | "unknown";
+  document_engine: "latex" | "latexmk" | "typst" | "markdown" | "unknown";
   ats_profile: "friendly" | "design-forward" | null;
   default_color: string | null;
   license: { spdx?: string | null; author?: string | null } | null;

--- a/scripts/check-performance-budget.mjs
+++ b/scripts/check-performance-budget.mjs
@@ -51,7 +51,10 @@ const limits = {
   // tools gating) and the omnibar command wiring.
   // +50 KB for document-citation (paragraph scan, debate ranker, Review
   // panel, Google Scholar parser): combined graph measures 9.25 MB.
-  totalJavaScript: 9_260_000,
+  // +40 KB for the Overleaf import and latexmk engine surfaces (engine
+  // picker modal, TinyTeX install guards, import taxonomy and classifier,
+  // Library import entry points): combined graph measures 9.27 MB.
+  totalJavaScript: 9_300_000,
   largestCss: 400_000,
   harperWasm: 19_000_000,
   // The real worker and the independently loaded recovery module are each

--- a/src-tauri/src/biber_toolchain.rs
+++ b/src-tauri/src/biber_toolchain.rs
@@ -182,33 +182,9 @@ fn host_triple_guess() -> Option<&'static str> {
 }
 
 fn tex_bin_search_dirs() -> Vec<PathBuf> {
-    let mut dirs = vec![
-        PathBuf::from("/Library/TeX/texbin"),
-        PathBuf::from("/usr/local/bin"),
-        PathBuf::from("/opt/homebrew/bin"),
-    ];
-    if let Ok(home) = std::env::var("HOME") {
-        let home = PathBuf::from(home);
-        dirs.push(home.join(".oleafly/tinytex/bin"));
-        dirs.push(home.join(".TinyTeX/bin"));
-        // TinyTeX nests bin/<platform>/
-        if let Ok(entries) = std::fs::read_dir(home.join(".oleafly/tinytex")) {
-            for entry in entries.flatten() {
-                let bin = entry.path().join("bin");
-                if bin.is_dir() {
-                    dirs.push(bin.clone());
-                    if let Ok(platforms) = std::fs::read_dir(&bin) {
-                        for platform in platforms.flatten() {
-                            if platform.path().is_dir() {
-                                dirs.push(platform.path());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    dirs
+    // Shared discovery (MacTeX, TeX Live by year, MiKTeX, TinyTeX variants) so
+    // PATH injection and the latexmk engine agree on where TeX tools live.
+    crate::tex_distro::tex_bin_dirs()
 }
 
 fn push_unique(dirs: &mut Vec<PathBuf>, dir: PathBuf) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -309,6 +309,23 @@ pub async fn compile_project(
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
                 + 1,
         );
+        // Provenance record (engine + distribution + lockfile hash) for
+        // "my coauthor's PDF looks different" debugging. Best-effort, off
+        // the command path.
+        let record_project = project_id.clone();
+        let record_engine = meta.engine.clone();
+        let record_output = result.output_id.clone();
+        let record_revision = result.output_revision.unwrap_or(0);
+        let record_time = result.compile_time_ms;
+        tauri::async_runtime::spawn_blocking(move || {
+            crate::project::write_build_metadata(
+                &record_project,
+                record_revision,
+                &record_engine,
+                record_output.as_deref(),
+                record_time,
+            );
+        });
     }
     #[cfg(debug_assertions)]
     eprintln!(

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -2656,4 +2656,98 @@ mod tests {
             "pdf-v1:4:6fab6075b28eda84"
         );
     }
+
+    #[test]
+    fn latexmk_engine_resolves_with_latex_capabilities() {
+        let engine = engine_for("latexmk", "main.tex").unwrap();
+        assert_eq!(engine.id(), DocumentEngineId::Latexmk);
+        let capabilities = engine.capabilities();
+        assert!(capabilities.produces_pdf);
+        assert!(capabilities.supports_synctex);
+        assert!(capabilities.supports_isolated_compile);
+        assert_eq!(capabilities.formatting_profile, FormattingProfile::Latex);
+        assert_eq!(
+            capabilities.compiler_prerequisite,
+            Some(CompilerPrerequisite::SystemTex)
+        );
+        let descriptor = descriptor_for("latexmk", "main.tex").unwrap();
+        assert_eq!(descriptor.label, "LaTeX (latexmk)");
+        // The frontend keys LaTeX behavior off source_format, not the id.
+        assert_eq!(descriptor.source_format, "latex");
+    }
+
+    #[test]
+    fn latexmk_flavor_honors_magic_program_comment() {
+        assert_eq!(
+            detect_latexmk_flavor("% !TeX program = xelatex\n\\documentclass{article}"),
+            LatexmkFlavor::Xelatex
+        );
+        assert_eq!(
+            detect_latexmk_flavor("%!TEX program = lualatex\n"),
+            LatexmkFlavor::Lualatex
+        );
+        assert_eq!(
+            detect_latexmk_flavor("% !TeX program = pdflatex\n\\usepackage{fontspec}"),
+            LatexmkFlavor::Pdflatex
+        );
+    }
+
+    #[test]
+    fn latexmk_flavor_upgrades_for_unicode_font_packages() {
+        assert_eq!(
+            detect_latexmk_flavor("\\usepackage{fontspec}"),
+            LatexmkFlavor::Xelatex
+        );
+        assert_eq!(
+            detect_latexmk_flavor("\\setmainfont{Georgia}"),
+            LatexmkFlavor::Xelatex
+        );
+        // Overleaf's default: plain projects compile with pdfLaTeX.
+        assert_eq!(
+            detect_latexmk_flavor("\\documentclass{article}"),
+            LatexmkFlavor::Pdflatex
+        );
+    }
+
+    #[test]
+    fn latexmk_shell_escape_is_scoped_to_documents_that_need_it() {
+        assert!(latexmk_needs_shell_escape("\\usepackage{minted}"));
+        assert!(latexmk_needs_shell_escape("\\write18{echo hi}"));
+        assert!(latexmk_needs_shell_escape("\\usepackage{pythontex}"));
+        assert!(!latexmk_needs_shell_escape("\\documentclass{article}"));
+    }
+
+    #[test]
+    fn latexmk_args_carry_engine_outdir_jobname_and_error_mode() {
+        let args = latexmk_args(
+            "/build",
+            "/proj/main.tex",
+            crate::paths::ENTRY_STEM,
+            LatexmkFlavor::Pdflatex,
+            true,
+            CompileOptions::default(),
+        );
+        assert_eq!(args[0], "-pdf");
+        assert!(args.contains(&"-outdir=/build".to_string()));
+        assert!(args.contains(&format!("-jobname={}", crate::paths::ENTRY_STEM)));
+        assert!(args.contains(&"-shell-escape".to_string()));
+        assert!(args.contains(&"-f".to_string()));
+        assert_eq!(args.last().unwrap(), "/proj/main.tex");
+
+        let halt = latexmk_args(
+            "/build",
+            "main.tex",
+            "_figure",
+            LatexmkFlavor::Xelatex,
+            false,
+            CompileOptions {
+                halt_on_error: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(halt[0], "-xelatex");
+        assert!(halt.contains(&"-halt-on-error".to_string()));
+        assert!(!halt.contains(&"-f".to_string()));
+        assert!(!halt.contains(&"-shell-escape".to_string()));
+    }
 }

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -7,6 +7,7 @@ use crate::proc::{isolate_process_tree, terminate_process_tree, NoConsole};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DocumentEngineId {
     Latex,
+    Latexmk,
     Typst,
     Markdown,
 }
@@ -15,6 +16,7 @@ impl DocumentEngineId {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Latex => "latex",
+            Self::Latexmk => "latexmk",
             Self::Typst => "typst",
             Self::Markdown => "markdown",
         }
@@ -78,6 +80,9 @@ pub enum TemplateKind {
 #[serde(rename_all = "snake_case")]
 pub enum CompilerPrerequisite {
     Pandoc,
+    /// A system TeX distribution (MacTeX, TeX Live, MiKTeX, or TinyTeX) that
+    /// provides `latexmk`. Used by engines Oleafly does not bundle.
+    SystemTex,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -171,6 +176,9 @@ pub trait DocumentEngine: Sync {
 
 struct LatexEngine;
 static LATEX_ENGINE: LatexEngine = LatexEngine;
+
+struct LatexmkEngine;
+static LATEXMK_ENGINE: LatexmkEngine = LatexmkEngine;
 
 struct TypstEngine;
 static TYPST_ENGINE: TypstEngine = TypstEngine;
@@ -268,6 +276,227 @@ impl DocumentEngine for LatexEngine {
             executable: EngineExecutable::BundledSidecar("tectonic"),
             args: tectonic_args(&out, &search_path, &entry, options),
             input,
+            artifacts,
+            working_dir: project_dir.to_owned(),
+        })
+    }
+
+    fn parse_errors(&self, log: &str) -> Vec<CompileError> {
+        parse_tex_log_errors(log)
+    }
+}
+
+/// Which TeX engine latexmk should drive. Chosen from the source itself so an
+/// Overleaf import compiles out of the box: a `% !TeX program = ...` magic
+/// comment wins, fontspec-style packages force a Unicode engine, and everything
+/// else gets pdfLaTeX (Overleaf's own default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LatexmkFlavor {
+    Pdflatex,
+    Xelatex,
+    Lualatex,
+}
+
+impl LatexmkFlavor {
+    const fn as_arg(self) -> &'static str {
+        match self {
+            Self::Pdflatex => "-pdf",
+            Self::Xelatex => "-xelatex",
+            Self::Lualatex => "-lualatex",
+        }
+    }
+}
+
+fn detect_tex_program_magic(source: &str) -> Option<LatexmkFlavor> {
+    // TeXShop/latexmk convention: `% !TeX program = xelatex` near the top.
+    for line in source.lines().take(100) {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix('%') else {
+            continue;
+        };
+        let lower = rest.trim().trim_start_matches('!').to_ascii_lowercase();
+        let Some(value) = lower
+            .strip_prefix("tex program")
+            .map(str::trim_start)
+            .and_then(|v| v.strip_prefix('='))
+        else {
+            continue;
+        };
+        return match value.trim() {
+            "xelatex" => Some(LatexmkFlavor::Xelatex),
+            "lualatex" => Some(LatexmkFlavor::Lualatex),
+            "pdflatex" | "latex" => Some(LatexmkFlavor::Pdflatex),
+            _ => None,
+        };
+    }
+    None
+}
+
+fn detect_latexmk_flavor(source: &str) -> LatexmkFlavor {
+    if let Some(flavor) = detect_tex_program_magic(source) {
+        return flavor;
+    }
+    // These packages hard-fail under pdfLaTeX; XeLaTeX also matches how the
+    // bundled Tectonic (XeTeX-class) rendered the project before a switch.
+    if source.contains("fontspec")
+        || source.contains("polyglossia")
+        || source.contains("unicode-math")
+        || source.contains("\\setmainfont")
+    {
+        return LatexmkFlavor::Xelatex;
+    }
+    LatexmkFlavor::Pdflatex
+}
+
+/// Enable `-shell-escape` only when the source actually uses features that
+/// need it (Overleaf enables it unconditionally, but Overleaf compiles inside
+/// a container; on a user's machine it is arbitrary command execution, so it
+/// stays scoped to documents that require it). Plain substring checks: a
+/// commented-out `minted` merely enables the flag, it never breaks a compile.
+fn latexmk_needs_shell_escape(source: &str) -> bool {
+    [
+        "minted",
+        "pythontex",
+        "\\write18",
+        "\\ShellEscape",
+        "\\input{|",
+        "{svg}",
+    ]
+    .iter()
+    .any(|needle| source.contains(needle))
+}
+
+/// Read the head of a source file for flavor/shell-escape sniffing. Bounded so
+/// a giant generated file cannot balloon compile preparation.
+fn read_source_head(path: &Path) -> String {
+    use std::io::Read;
+    const MAX_SNIFF_BYTES: u64 = 512 * 1024;
+    let Ok(file) = std::fs::File::open(path) else {
+        return String::new();
+    };
+    let mut bytes = Vec::new();
+    let _ = file.take(MAX_SNIFF_BYTES).read_to_end(&mut bytes);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn latexmk_args(
+    out_dir: &str,
+    entry: &str,
+    stem: &str,
+    flavor: LatexmkFlavor,
+    shell_escape: bool,
+    options: CompileOptions,
+) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        flavor.as_arg().into(),
+        "-interaction=nonstopmode".into(),
+        "-synctex=1".into(),
+        format!("-outdir={out_dir}"),
+        format!("-jobname={stem}"),
+    ];
+    if shell_escape {
+        args.push("-shell-escape".into());
+    }
+    if options.halt_on_error {
+        args.push("-halt-on-error".into());
+    } else {
+        // Push on to a best-effort PDF after TeX errors (Tectonic
+        // continue-on-errors parity).
+        args.push("-f".into());
+    }
+    // `options.fast` is intentionally ignored: deciding how many passes to run
+    // is latexmk's whole job, and `-outdir` reuse already makes warm runs fast.
+    args.push(entry.into());
+    args
+}
+
+impl DocumentEngine for LatexmkEngine {
+    fn id(&self) -> DocumentEngineId {
+        DocumentEngineId::Latexmk
+    }
+
+    fn capabilities(&self) -> EngineCapabilities {
+        EngineCapabilities {
+            produces_pdf: true,
+            supports_synctex: true,
+            // latexmk itself never touches the network; "offline" is simply
+            // its normal mode, so the flag is accepted and has no effect.
+            supports_offline: true,
+            supports_isolated_compile: true,
+            formatting_profile: FormattingProfile::Latex,
+            source_preflight_profile: SourcePreflightProfile::Latex,
+            features: &[EngineFeature::Citations, EngineFeature::DocumentIndex],
+            conversion_exports: &[
+                ConversionExport::Docx,
+                ConversionExport::Html,
+                ConversionExport::Md,
+                ConversionExport::Txt,
+                ConversionExport::Pptx,
+                ConversionExport::Epub,
+            ],
+            template_kinds: &[TemplateKind::Document, TemplateKind::Image],
+            compiler_prerequisite: Some(CompilerPrerequisite::SystemTex),
+        }
+    }
+
+    fn accepts_metadata_name(&self, name: &str) -> bool {
+        name.trim().eq_ignore_ascii_case("latexmk")
+    }
+
+    fn accepts_main_document(&self, main_document: &str) -> bool {
+        LATEX_ENGINE.accepts_main_document(main_document)
+    }
+
+    fn source_extensions(&self) -> &'static [&'static str] {
+        LATEX_ENGINE.source_extensions()
+    }
+
+    fn artifacts(&self, out_dir: &Path, target: CompileTarget<'_>) -> EngineArtifacts {
+        LATEX_ENGINE.artifacts(out_dir, target)
+    }
+
+    fn compile_spec(
+        &self,
+        out_dir: &Path,
+        project_dir: &Path,
+        target: CompileTarget<'_>,
+        options: CompileOptions,
+    ) -> Result<EngineCompileSpec, String> {
+        let latexmk = crate::tex_distro::find_tex_tool("latexmk").ok_or_else(|| {
+            "latexmk was not found on this machine. The latexmk engine needs a TeX \
+             distribution (MacTeX, TeX Live, MiKTeX, or TinyTeX). Install one, or switch \
+             this project back to the built-in Tectonic engine."
+                .to_string()
+        })?;
+        // No generated wrapper: latexmk drives the real main document directly so
+        // Biber, makeindex, and multi-pass logic all see the project's own jobs.
+        // `-jobname` keeps every artifact on the same paths Tectonic uses.
+        let (input_path, stem) = match target {
+            CompileTarget::Main { main_document } => {
+                validate_latex_main_document(main_document)?;
+                (project_dir.join(main_document), crate::paths::ENTRY_STEM)
+            }
+            CompileTarget::Isolated {
+                source_path,
+                output_stem,
+            } => (source_path.to_owned(), output_stem),
+        };
+        let source_head = read_source_head(&input_path);
+        let flavor = detect_latexmk_flavor(&source_head);
+        let shell_escape = latexmk_needs_shell_escape(&source_head);
+        let artifacts = self.artifacts(out_dir, target);
+        let args = latexmk_args(
+            &out_dir.to_string_lossy(),
+            &input_path.to_string_lossy(),
+            stem,
+            flavor,
+            shell_escape,
+            options,
+        );
+        Ok(EngineCompileSpec {
+            executable: EngineExecutable::ExternalPath(latexmk),
+            args,
+            input: EngineInput::Direct(input_path),
             artifacts,
             working_dir: project_dir.to_owned(),
         })
@@ -467,7 +696,10 @@ pub fn engine_for(
     metadata_name: &str,
     main_document: &str,
 ) -> Result<&'static dyn DocumentEngine, String> {
-    let engine: &'static dyn DocumentEngine = if LATEX_ENGINE.accepts_metadata_name(metadata_name) {
+    let engine: &'static dyn DocumentEngine = if LATEXMK_ENGINE.accepts_metadata_name(metadata_name)
+    {
+        &LATEXMK_ENGINE
+    } else if LATEX_ENGINE.accepts_metadata_name(metadata_name) {
         &LATEX_ENGINE
     } else if TYPST_ENGINE.accepts_metadata_name(metadata_name) {
         &TYPST_ENGINE
@@ -636,11 +868,15 @@ pub fn descriptor_for(
         id: engine.id().as_str().to_owned(),
         label: match engine.id() {
             DocumentEngineId::Latex => "LaTeX",
+            DocumentEngineId::Latexmk => "LaTeX (latexmk)",
             DocumentEngineId::Typst => "Typst",
             DocumentEngineId::Markdown => "Markdown / Pandoc",
         }
         .to_owned(),
-        source_format: engine.id().as_str().to_owned(),
+        source_format: match engine.id() {
+            DocumentEngineId::Latexmk => "latex".to_owned(),
+            id => id.as_str().to_owned(),
+        },
         main_document: main_document.to_owned(),
         source_extensions: engine
             .source_extensions()
@@ -740,6 +976,7 @@ pub async fn prepare_compile_spec(
     tokio::task::spawn_blocking(move || {
         let engine: &'static dyn DocumentEngine = match engine_id {
             DocumentEngineId::Latex => &LATEX_ENGINE,
+            DocumentEngineId::Latexmk => &LATEXMK_ENGINE,
             DocumentEngineId::Typst => &TYPST_ENGINE,
             DocumentEngineId::Markdown => &MARKDOWN_ENGINE,
         };

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -27,6 +27,9 @@ pub struct EngineInfo {
     pub lualatex: Option<String>,
     pub tlmgr: Option<String>,
     pub version: Option<String>,
+    /// A usable `latexmk` from any detected distribution. Present even when
+    /// `kind` is "none" (a distro can lack lualatex yet still drive latexmk).
+    pub latexmk: Option<String>,
 }
 
 impl EngineInfo {
@@ -36,8 +39,14 @@ impl EngineInfo {
             lualatex: None,
             tlmgr: None,
             version: None,
+            latexmk: find_latexmk(),
         }
     }
+}
+
+/// A `latexmk` from any detected TeX distribution (stat-only probe).
+fn find_latexmk() -> Option<String> {
+    crate::tex_distro::find_tex_tool("latexmk").map(|p| p.to_string_lossy().into_owned())
 }
 
 fn exe(name: &str) -> String {
@@ -107,6 +116,9 @@ fn find_engine() -> EngineInfo {
                 version: engine_version(&lua.to_string_lossy()),
                 lualatex: Some(lua.to_string_lossy().to_string()),
                 tlmgr: tlmgr.map(|t| t.to_string_lossy().to_string()),
+                latexmk: find_in_texdir(&dir, "latexmk")
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .or_else(find_latexmk),
             };
         }
     }
@@ -123,20 +135,13 @@ fn find_engine() -> EngineInfo {
             version: engine_version("lualatex"),
             lualatex: Some("lualatex".to_string()),
             tlmgr,
+            latexmk: find_latexmk(),
         };
     }
 
-    // 3. Common system TeX Live / MacTeX / TinyTeX-in-home locations.
-    let mut roots: Vec<PathBuf> = vec![
-        PathBuf::from("/Library/TeX/texbin"), // macOS MacTeX symlink dir (holds binaries directly)
-        PathBuf::from("/usr/local/bin"),
-        PathBuf::from("/opt/homebrew/bin"),
-    ];
-    if let Ok(home) = std::env::var("HOME") {
-        roots.push(PathBuf::from(&home).join(".TinyTeX"));
-    }
-    // texbin-style dirs hold the binaries directly (no bin/<platform> nesting).
-    for dir in &roots {
+    // 3. Shared discovery: MacTeX, TeX Live (by year), MiKTeX, TinyTeX-in-home.
+    // These dirs hold binaries directly (bin/<platform> nesting already resolved).
+    for dir in crate::tex_distro::tex_bin_dirs() {
         let direct = dir.join(exe("lualatex"));
         if direct.exists() && runs(&direct.to_string_lossy()) {
             let tlmgr = dir.join(exe("tlmgr"));
@@ -145,15 +150,7 @@ fn find_engine() -> EngineInfo {
                 version: engine_version(&direct.to_string_lossy()),
                 lualatex: Some(direct.to_string_lossy().to_string()),
                 tlmgr: tlmgr.exists().then(|| tlmgr.to_string_lossy().to_string()),
-            };
-        }
-        if let Some(lua) = find_in_texdir(dir, "lualatex") {
-            let tlmgr = find_in_texdir(dir, "tlmgr");
-            return EngineInfo {
-                kind: "system".into(),
-                version: engine_version(&lua.to_string_lossy()),
-                lualatex: Some(lua.to_string_lossy().to_string()),
-                tlmgr: tlmgr.map(|t| t.to_string_lossy().to_string()),
+                latexmk: find_latexmk(),
             };
         }
     }

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -186,11 +186,134 @@ pub async fn has_tagging_engine() -> bool {
         .unwrap_or(false)
 }
 
+// --- TinyTeX install machinery -----------------------------------------------
+//
+// The install is long (100 MB+ download, large extraction) and must survive
+// user impatience: progress is phased, the partial download resumes across
+// failures and app launches, and quitting mid-install is intercepted so the
+// user decides deliberately.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static INSTALL_ACTIVE: AtomicBool = AtomicBool::new(false);
+static QUIT_CONFIRMED: AtomicBool = AtomicBool::new(false);
+
+/// True while a TinyTeX download/extract is running (drives quit interception).
+pub fn install_in_progress() -> bool {
+    INSTALL_ACTIVE.load(Ordering::SeqCst)
+}
+
+/// True once the user explicitly confirmed quitting mid-install.
+pub fn quit_confirmed() -> bool {
+    QUIT_CONFIRMED.load(Ordering::SeqCst)
+}
+
+/// The user confirmed the "quit during install?" dialog: let the close through.
+#[tauri::command]
+pub fn confirm_quit_during_install(app: tauri::AppHandle) {
+    QUIT_CONFIRMED.store(true, Ordering::SeqCst);
+    app.exit(0);
+}
+
+/// Releases the install flag on every exit path, including errors and panics.
+struct InstallGuard;
+
+impl InstallGuard {
+    fn acquire() -> Result<Self, String> {
+        INSTALL_ACTIVE
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| "A TinyTeX install is already in progress.".to_string())?;
+        Ok(InstallGuard)
+    }
+}
+
+impl Drop for InstallGuard {
+    fn drop(&mut self) {
+        INSTALL_ACTIVE.store(false, Ordering::SeqCst);
+    }
+}
+
+/// One progress event for the whole install. `phase` is "download",
+/// "extract", or "packages"; totals are only meaningful for the download.
 #[derive(Clone, serde::Serialize)]
 struct EngineProgress {
+    phase: &'static str,
     received: u64,
     total: Option<u64>,
 }
+
+/// Bytes of free disk space at `path`'s filesystem, when the OS can tell us.
+fn free_disk_space(path: &Path) -> Option<u64> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).ok()?;
+        let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+        if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
+            return None;
+        }
+        // f_bavail: blocks available to unprivileged users.
+        Some(stat.f_bavail as u64 * stat.f_frsize as u64)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide.push(0);
+        let mut available: u64 = 0;
+        let ok = unsafe {
+            windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW(
+                wide.as_ptr(),
+                &mut available,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        (ok != 0).then_some(available)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+/// Core download is ~100 MB and unpacks to roughly 500 MB; journal templates
+/// pull more via tlmgr afterwards. Refuse to start below this floor so an
+/// install never strands the user with a full disk.
+const MIN_FREE_BYTES: u64 = 1_500_000_000;
+
+fn gigabytes(bytes: u64) -> f64 {
+    bytes as f64 / 1_000_000_000.0
+}
+
+/// State the frontend needs to offer "Resume download" after a failure or a
+/// force-quit: how much of the archive is already on disk.
+#[derive(Clone, serde::Serialize)]
+pub struct TinytexInstallState {
+    pub installing: bool,
+    pub partial_download_bytes: u64,
+}
+
+#[tauri::command]
+pub async fn tinytex_install_state() -> TinytexInstallState {
+    let partial = tauri::async_runtime::spawn_blocking(|| {
+        tinytex_root()
+            .ok()
+            .map(|root| root.join(DOWNLOAD_TMP))
+            .and_then(|tmp| std::fs::metadata(tmp).ok())
+            .map(|meta| meta.len())
+            .unwrap_or(0)
+    })
+    .await
+    .unwrap_or(0);
+    TinytexInstallState {
+        installing: install_in_progress(),
+        partial_download_bytes: partial,
+    }
+}
+
+const DOWNLOAD_TMP: &str = "tinytex-download.tmp";
 
 fn tinytex_asset() -> Result<(String, bool), String> {
     let base =
@@ -262,8 +385,12 @@ fn extract_all(archive: &Path, is_targz: bool, dest_dir: &Path) -> Result<(), St
     Ok(())
 }
 
-/// Download and install TinyTeX on demand under `~/.oleafly/tinytex`. Emits
-/// `tinytex-download-progress` events; returns the resulting engine info.
+/// Download and install TinyTeX on demand under `~/.oleafly/tinytex`.
+///
+/// Emits phased `tinytex-install-progress` events (download / extract /
+/// packages). The download resumes from a previous partial file (HTTP Range),
+/// including across app launches after a force-quit. On failure the partial
+/// file is kept so Retry continues instead of starting over.
 #[tauri::command]
 pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String> {
     use futures_util::StreamExt;
@@ -275,27 +402,69 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
         return Ok(existing);
     }
 
+    let _install = InstallGuard::acquire()?;
+
     let (url, is_targz) = tinytex_asset()?;
     let root = tinytex_root()?;
     std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
-    let tmp = root.join("tinytex-download.tmp");
+    let tmp = root.join(DOWNLOAD_TMP);
 
-    let resp = reqwest::get(&url)
+    // Fail before downloading a byte if the disk cannot hold the install.
+    if let Some(free) = free_disk_space(&root) {
+        if free < MIN_FREE_BYTES {
+            return Err(format!(
+                "Not enough free disk space to install TinyTeX. It needs about {:.1} GB \
+                 (download plus extraction, with room for LaTeX packages); this disk has \
+                 {:.1} GB free. Free up space, then try again.",
+                gigabytes(MIN_FREE_BYTES),
+                gigabytes(free)
+            ));
+        }
+    }
+
+    // Resume from a previous partial download when the server honors Range;
+    // a 200 (full body) response restarts cleanly from zero.
+    let already = std::fs::metadata(&tmp).map(|m| m.len()).unwrap_or(0);
+    let client = reqwest::Client::new();
+    let mut request = client.get(&url);
+    if already > 0 {
+        request = request.header(reqwest::header::RANGE, format!("bytes={already}-"));
+    }
+    let resp = request
+        .send()
         .await
         .map_err(|e| format!("download failed: {e}"))?
         .error_for_status()
         .map_err(|e| format!("download failed: {e}"))?;
-    let total = resp.content_length();
-    let mut file = std::fs::File::create(&tmp).map_err(|e| e.to_string())?;
+    let resuming = resp.status() == reqwest::StatusCode::PARTIAL_CONTENT && already > 0;
+    let total = if resuming {
+        resp.content_length().map(|remaining| remaining + already)
+    } else {
+        resp.content_length()
+    };
+    let mut file = if resuming {
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&tmp)
+            .map_err(|e| e.to_string())?
+    } else {
+        std::fs::File::create(&tmp).map_err(|e| e.to_string())?
+    };
+    let mut received: u64 = if resuming { already } else { 0 };
     let mut stream = resp.bytes_stream();
-    let mut received: u64 = 0;
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("download interrupted: {e}"))?;
+        let chunk = chunk.map_err(|e| {
+            format!("download interrupted: {e}. Your progress is saved — retry to resume.")
+        })?;
         received += chunk.len() as u64;
         file.write_all(&chunk).map_err(|e| e.to_string())?;
         let _ = app.emit(
-            "tinytex-download-progress",
-            EngineProgress { received, total },
+            "tinytex-install-progress",
+            EngineProgress {
+                phase: "download",
+                received,
+                total,
+            },
         );
     }
     file.flush().map_err(|e| e.to_string())?;
@@ -303,6 +472,14 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
 
     // The archive is ~100MB; extract off the async runtime so it doesn't block
     // the webview UI while unpacking.
+    let _ = app.emit(
+        "tinytex-install-progress",
+        EngineProgress {
+            phase: "extract",
+            received: 0,
+            total: None,
+        },
+    );
     let tmp_extract = tmp.clone();
     let root_extract = root.clone();
     let extracted = tauri::async_runtime::spawn_blocking(move || {
@@ -310,8 +487,13 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
     })
     .await
     .map_err(|e| e.to_string())?;
-    let _ = std::fs::remove_file(&tmp);
+    if extracted.is_err() {
+        // A truncated or corrupt archive cannot be resumed into a good one:
+        // clear it so the next attempt downloads fresh.
+        let _ = std::fs::remove_file(&tmp);
+    }
     extracted?;
+    let _ = std::fs::remove_file(&tmp);
 
     let info = find_engine();
     if info.lualatex.is_none() {
@@ -319,6 +501,27 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
             "TinyTeX installed but no lualatex was found in it. Install a toolchain manually."
                 .to_string(),
         );
+    }
+
+    // TinyTeX's default bundle ships latexmk, but be defensive: if it is
+    // missing, pull it via tlmgr so the latexmk engine works out of the box.
+    if info.latexmk.is_none() {
+        let _ = app.emit(
+            "tinytex-install-progress",
+            EngineProgress {
+                phase: "packages",
+                received: 0,
+                total: None,
+            },
+        );
+        let installed =
+            tauri::async_runtime::spawn_blocking(|| tlmgr_run("install", vec!["latexmk".into()]))
+                .await;
+        if let Ok(Err(error)) = installed {
+            // Not fatal for the tagged-export flow; surface in the log only.
+            eprintln!("tlmgr install latexmk failed: {error}");
+        }
+        return Ok(find_engine());
     }
     Ok(info)
 }

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -454,7 +454,7 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
     let mut stream = resp.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| {
-            format!("download interrupted: {e}. Your progress is saved — retry to resume.")
+            format!("download interrupted: {e}. Your progress is saved; retry to resume.")
         })?;
         received += chunk.len() as u64;
         file.write_all(&chunk).map_err(|e| e.to_string())?;

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -573,6 +573,42 @@ fn tlmgr_installed_blocking() -> Result<Vec<String>, String> {
         .collect())
 }
 
+/// Installed package -> revision, for the reproducibility pin in project.json.
+/// `cat-version` is the CTAN version where known; the TeX Live revision fills
+/// in when it is not. Empty map when no tlmgr exists (e.g. MiKTeX).
+pub fn tlmgr_installed_versions() -> Result<std::collections::BTreeMap<String, String>, String> {
+    let tlmgr = tlmgr_path()?;
+    let out = Command::new(&tlmgr)
+        .no_console()
+        .args([
+            "info",
+            "--only-installed",
+            "--data",
+            "name,revision,cat-version",
+        ])
+        .output()
+        .map_err(|e| format!("failed to run tlmgr: {e}"))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+    let mut versions = std::collections::BTreeMap::new();
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let mut fields = line.trim().splitn(3, ',');
+        let Some(name) = fields.next().map(str::trim).filter(|n| !n.is_empty()) else {
+            continue;
+        };
+        let revision = fields.next().map(str::trim).unwrap_or("");
+        let cat_version = fields.next().map(str::trim).unwrap_or("");
+        let version = if cat_version.is_empty() {
+            format!("r{revision}")
+        } else {
+            cat_version.to_string()
+        };
+        versions.insert(name.to_string(), version);
+    }
+    Ok(versions)
+}
+
 /// Install TeX packages by name via tlmgr. Returns the combined output log.
 #[tauri::command]
 pub async fn tlmgr_install(packages: Vec<String>) -> Result<String, String> {

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -414,7 +414,7 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
         if free < MIN_FREE_BYTES {
             return Err(format!(
                 "Not enough free disk space to install TinyTeX. It needs about {:.1} GB \
-                 (download plus extraction, with room for LaTeX packages); this disk has \
+                 (download plus extraction, with room for LaTeX packages). This disk has \
                  {:.1} GB free. Free up space, then try again.",
                 gigabytes(MIN_FREE_BYTES),
                 gigabytes(free)
@@ -454,7 +454,7 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
     let mut stream = resp.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| {
-            format!("download interrupted: {e}. Your progress is saved; retry to resume.")
+            format!("download interrupted: {e}. Your progress is saved. Retry to resume.")
         })?;
         received += chunk.len() as u64;
         file.write_all(&chunk).map_err(|e| e.to_string())?;
@@ -573,19 +573,16 @@ fn tlmgr_installed_blocking() -> Result<Vec<String>, String> {
         .collect())
 }
 
-/// Installed package -> revision, for the reproducibility pin in project.json.
-/// `cat-version` is the CTAN version where known; the TeX Live revision fills
-/// in when it is not. Empty map when no tlmgr exists (e.g. MiKTeX).
+/// Installed package -> version, for the reproducibility pin in project.json.
+/// `cat-version` is the CTAN version where the catalogue has one, "installed"
+/// otherwise. Note: `revision`/`lrev` are NOT valid `--data` fields on TeX
+/// Live 2025's tlmgr (the command exits with "unknown data field"). Empty map
+/// when no tlmgr exists (e.g. MiKTeX).
 pub fn tlmgr_installed_versions() -> Result<std::collections::BTreeMap<String, String>, String> {
     let tlmgr = tlmgr_path()?;
     let out = Command::new(&tlmgr)
         .no_console()
-        .args([
-            "info",
-            "--only-installed",
-            "--data",
-            "name,revision,cat-version",
-        ])
+        .args(["info", "--only-installed", "--data", "name,cat-version"])
         .output()
         .map_err(|e| format!("failed to run tlmgr: {e}"))?;
     if !out.status.success() {
@@ -593,18 +590,22 @@ pub fn tlmgr_installed_versions() -> Result<std::collections::BTreeMap<String, S
     }
     let mut versions = std::collections::BTreeMap::new();
     for line in String::from_utf8_lossy(&out.stdout).lines() {
-        let mut fields = line.trim().splitn(3, ',');
-        let Some(name) = fields.next().map(str::trim).filter(|n| !n.is_empty()) else {
+        let Some((name, version)) = line.trim().split_once(',') else {
             continue;
         };
-        let revision = fields.next().map(str::trim).unwrap_or("");
-        let cat_version = fields.next().map(str::trim).unwrap_or("");
-        let version = if cat_version.is_empty() {
-            format!("r{revision}")
-        } else {
-            cat_version.to_string()
-        };
-        versions.insert(name.to_string(), version);
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        let version = version.trim();
+        versions.insert(
+            name.to_string(),
+            if version.is_empty() {
+                "installed".to_string()
+            } else {
+                version.to_string()
+            },
+        );
     }
     Ok(versions)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,18 @@ pub fn run() {
     builder
         .manage(AppState::default())
         .manage(mcp::server::McpState::default())
+        // Closing the app mid-TinyTeX-install must be a deliberate choice: block
+        // the close, let the frontend show a confirm dialog, and only pass a
+        // close through after `confirm_quit_during_install`.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                if latex_engine::install_in_progress() && !latex_engine::quit_confirmed() {
+                    api.prevent_close();
+                    use tauri::Emitter;
+                    let _ = window.emit("tinytex-quit-blocked", ());
+                }
+            }
+        })
         .setup(|app| {
             if std::env::var("OLEAFLY_E2E_WINDOW").is_err() {
                 use tauri::Manager;
@@ -168,6 +180,8 @@ pub fn run() {
             project::has_pandoc,
             project::download_pandoc,
             latex_engine::latex_engine_info,
+            latex_engine::tinytex_install_state,
+            latex_engine::confirm_quit_during_install,
             tex_distro::tex_distributions,
             latex_engine::has_tagging_engine,
             latex_engine::install_tinytex,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,7 @@ pub fn run() {
             project::set_project_engine,
             project::record_project_tex_spec,
             project::project_tex_status,
+            project::import_overleaf_project,
             project::set_project_color,
             project::rename_project,
             project::open_devtools,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ mod state;
 mod synctex;
 mod template_packs;
 mod templates;
+mod tex_distro;
 
 use state::AppState;
 
@@ -167,6 +168,7 @@ pub fn run() {
             project::has_pandoc,
             project::download_pandoc,
             latex_engine::latex_engine_info,
+            tex_distro::tex_distributions,
             latex_engine::has_tagging_engine,
             latex_engine::install_tinytex,
             latex_engine::delete_tinytex,
@@ -182,6 +184,7 @@ pub fn run() {
             connectors::get_connector_key,
             connectors::set_connector_key,
             project::set_main_doc,
+            project::set_project_engine,
             project::set_project_color,
             project::rename_project,
             project::open_devtools,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -199,6 +199,8 @@ pub fn run() {
             connectors::set_connector_key,
             project::set_main_doc,
             project::set_project_engine,
+            project::record_project_tex_spec,
+            project::project_tex_status,
             project::set_project_color,
             project::rename_project,
             project::open_devtools,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -57,7 +57,15 @@ pub fn on_event<R: Runtime>(app: &AppHandle<R>, id: &str) {
             app.request_restart();
         }
         "quit_app" => {
-            app.exit(0);
+            // Cmd+Q during a TinyTeX install goes through the same confirm
+            // flow as a window close: the frontend shows the dialog and calls
+            // `confirm_quit_during_install` if the user really means it.
+            if crate::latex_engine::install_in_progress() && !crate::latex_engine::quit_confirmed()
+            {
+                let _ = app.emit("tinytex-quit-blocked", ());
+            } else {
+                app.exit(0);
+            }
         }
         _ => {}
     }

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -106,6 +106,13 @@ pub fn figure_build_dir(project_id: &str) -> Result<PathBuf, String> {
     secure_build_subdirectory(project_id, "figbuild")
 }
 
+/// Build metadata records: `<project>/.oleafly/builds/`. One small JSON per
+/// successful compile (engine + distribution + lockfile hash) so "my
+/// coauthor's PDF looks different" is diagnosable.
+pub fn builds_metadata_dir(project_id: &str) -> Result<PathBuf, String> {
+    secure_build_subdirectory(project_id, "builds")
+}
+
 fn secure_build_subdirectory(project_id: &str, name: &str) -> Result<PathBuf, String> {
     let project = project_dir(project_id)?;
     secure_build_subdirectory_in(&project, name)

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1407,6 +1407,333 @@ fn create_typst_project_in(root: &Path, name: String) -> Result<String, String> 
     Ok(id)
 }
 
+// --- Overleaf / external project import --------------------------------------
+
+const IMPORT_MAX_ENTRIES: usize = 5000;
+const IMPORT_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
+const IMPORT_MAX_DEPTH: usize = 16;
+
+/// Junk and app-internal entries that never belong in an imported project.
+fn import_skip(rel: &str) -> bool {
+    rel.split('/').any(|segment| {
+        matches!(
+            segment,
+            "__MACOSX" | ".DS_Store" | ".git" | ".oleafly" | "Thumbs.db"
+        )
+    })
+}
+
+/// Import an Overleaf export (ZIP) or a plain folder as a new project.
+/// The main document is inferred when the archive has no project.json:
+/// a `% !TeX root` magic comment wins, then `\documentclass` +
+/// `\begin{document}` + a root-level `main.tex`-style name score best, and a
+/// lone `.tex` file is simply it.
+#[tauri::command]
+pub async fn import_overleaf_project(name: Option<String>, path: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || import_overleaf_project_blocking(name, &path))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn import_overleaf_project_blocking(name: Option<String>, path: &str) -> Result<String, String> {
+    let source = PathBuf::from(path);
+    if !source.exists() {
+        return Err(format!("import source not found: {path}"));
+    }
+    let root = paths::projects_root()?;
+    let id = unique_random_slug(&root)?;
+    let dir = root.join(&id);
+    let fallback_name = source
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .filter(|stem| !stem.trim().is_empty())
+        .unwrap_or_else(|| "Imported project".to_string());
+    let project_name = name
+        .filter(|candidate| !candidate.trim().is_empty())
+        .unwrap_or(fallback_name);
+    create_project_transaction(&dir, || {
+        if source.is_dir() {
+            copy_tree_for_import(&source, &dir, 0, &mut 0, &mut 0)?;
+        } else {
+            extract_zip_for_import(&source, &dir)?;
+        }
+        flatten_single_root_folder(&dir)?;
+        // An Oleafly-exported archive round-trips: keep its project.json when
+        // it still points at a real file. Overleaf archives have none.
+        let existing = read_import_meta(&dir);
+        let meta = match existing {
+            Some(mut meta) if dir.join(&meta.main_doc).is_file() => {
+                meta.name = project_name.clone();
+                meta
+            }
+            _ => {
+                let main_doc = infer_main_document(&dir)?;
+                let engine = engine_for_main_document(&default_engine(), &main_doc)
+                    .unwrap_or_else(|_| default_engine());
+                ProjectMeta {
+                    name: project_name.clone(),
+                    main_doc,
+                    engine,
+                    ..Default::default()
+                }
+            }
+        };
+        write_meta_at(&dir.join("project.json"), &meta)
+    })?;
+    Ok(id)
+}
+
+fn read_import_meta(dir: &Path) -> Option<ProjectMeta> {
+    let raw = std::fs::read_to_string(dir.join("project.json")).ok()?;
+    serde_json::from_str::<ProjectMeta>(&raw).ok()
+}
+
+fn extract_zip_for_import(archive: &Path, dest: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(archive).map_err(|e| format!("failed to open archive: {e}"))?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| format!("not a readable ZIP: {e}"))?;
+    if zip.len() > IMPORT_MAX_ENTRIES {
+        return Err(format!(
+            "archive has too many entries ({} > {IMPORT_MAX_ENTRIES})",
+            zip.len()
+        ));
+    }
+    let mut total: u64 = 0;
+    for index in 0..zip.len() {
+        let mut entry = zip.by_index(index).map_err(|e| e.to_string())?;
+        let Some(rel) = entry.enclosed_name() else {
+            continue; // unsafe path (absolute / traversal): skip
+        };
+        let rel_text = rel.to_string_lossy().replace('\\', "/");
+        if import_skip(&rel_text) || rel.components().count() > IMPORT_MAX_DEPTH {
+            continue;
+        }
+        let out = dest.join(&rel);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out).map_err(|e| e.to_string())?;
+            continue;
+        }
+        total = total.saturating_add(entry.size());
+        if total > IMPORT_MAX_TOTAL_BYTES {
+            return Err("archive is larger than the 2 GB import limit".to_string());
+        }
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let mut output = std::fs::File::create(&out).map_err(|e| e.to_string())?;
+        std::io::copy(&mut entry, &mut output).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn copy_tree_for_import(
+    source: &Path,
+    dest: &Path,
+    depth: usize,
+    entries: &mut usize,
+    total: &mut u64,
+) -> Result<(), String> {
+    if depth > IMPORT_MAX_DEPTH {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dest).map_err(|e| e.to_string())?;
+    for entry in std::fs::read_dir(source).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let file_type = entry.file_type().map_err(|e| e.to_string())?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let name_text = file_name.to_string_lossy();
+        if import_skip(&name_text) {
+            continue;
+        }
+        *entries += 1;
+        if *entries > IMPORT_MAX_ENTRIES {
+            return Err(format!(
+                "folder has too many files (> {IMPORT_MAX_ENTRIES})"
+            ));
+        }
+        let target = dest.join(&file_name);
+        if file_type.is_dir() {
+            copy_tree_for_import(&entry.path(), &target, depth + 1, entries, total)?;
+        } else if file_type.is_file() {
+            let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            *total = total.saturating_add(size);
+            if *total > IMPORT_MAX_TOTAL_BYTES {
+                return Err("folder is larger than the 2 GB import limit".to_string());
+            }
+            std::fs::copy(entry.path(), &target).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+/// Zipping a folder usually wraps everything in one top-level directory.
+/// Unwrap it so the project root holds the actual files.
+fn flatten_single_root_folder(dir: &Path) -> Result<(), String> {
+    let entries: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .collect();
+    if entries.len() != 1 {
+        return Ok(());
+    }
+    let only = &entries[0];
+    if !only.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        return Ok(());
+    }
+    let wrapper = only.path();
+    for child in std::fs::read_dir(&wrapper)
+        .map_err(|e| e.to_string())?
+        .flatten()
+    {
+        let target = dir.join(child.file_name());
+        std::fs::rename(child.path(), target).map_err(|e| e.to_string())?;
+    }
+    std::fs::remove_dir(&wrapper).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Pick the compile entry point for an imported project. See
+/// `import_overleaf_project` for the strategy.
+fn infer_main_document(dir: &Path) -> Result<String, String> {
+    let mut tex_files: Vec<String> = Vec::new();
+    collect_tex_files(dir, dir, 0, &mut tex_files);
+    if tex_files.is_empty() {
+        return Err(
+            "No .tex file was found in the import, so there is nothing to compile. \
+             Pick an Overleaf ZIP export or a folder containing a LaTeX project."
+                .to_string(),
+        );
+    }
+    tex_files.sort();
+    if tex_files.len() == 1 {
+        return Ok(tex_files.remove(0));
+    }
+    let mut heads: Vec<(String, String)> = tex_files
+        .iter()
+        .map(|rel| (rel.clone(), read_head_for_import(&dir.join(rel))))
+        .collect();
+    // A `% !TeX root = ...` magic comment anywhere wins when its target exists.
+    for (rel, head) in &heads {
+        if let Some(target) = tex_root_magic_target(head) {
+            let base = Path::new(rel).parent().unwrap_or(Path::new(""));
+            let joined = normalize_relative(&base.join(&target));
+            if let Some(joined) = joined {
+                if tex_files.iter().any(|candidate| candidate == &joined) {
+                    return Ok(joined);
+                }
+            }
+        }
+    }
+    heads.sort_by_key(|(rel, head)| {
+        let mut score: i32 = 0;
+        if head.contains("\\documentclass") {
+            score += 4;
+        }
+        if head.contains("\\begin{document}") {
+            score += 2;
+        }
+        if !rel.contains('/') {
+            score += 2;
+        }
+        let filename = rel.rsplit('/').next().unwrap_or(rel).to_ascii_lowercase();
+        if filename == "main.tex" {
+            score += 3;
+        } else if filename.starts_with("main") || filename == "root.tex" {
+            score += 1;
+        }
+        // Sort ascending: best score first via negation, then shallow, then name.
+        (-score, rel.matches('/').count(), rel.clone())
+    });
+    Ok(heads.remove(0).0)
+}
+
+fn collect_tex_files(root: &Path, dir: &Path, depth: usize, output: &mut Vec<String>) {
+    if depth > IMPORT_MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
+            if entry.file_name() != ".oleafly" {
+                collect_tex_files(root, &path, depth + 1, output);
+            }
+        } else if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("tex"))
+        {
+            if let Ok(rel) = path.strip_prefix(root) {
+                output.push(
+                    rel.components()
+                        .map(|c| c.as_os_str().to_string_lossy())
+                        .collect::<Vec<_>>()
+                        .join("/"),
+                );
+            }
+        }
+    }
+}
+
+fn read_head_for_import(path: &Path) -> String {
+    use std::io::Read;
+    const MAX_HEAD: u64 = 64 * 1024;
+    let Ok(file) = std::fs::File::open(path) else {
+        return String::new();
+    };
+    let mut bytes = Vec::new();
+    let _ = file.take(MAX_HEAD).read_to_end(&mut bytes);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// `% !TeX root = ../main.tex` (TeXShop/latexmk convention, case-insensitive).
+fn tex_root_magic_target(head: &str) -> Option<String> {
+    for line in head.lines().take(50) {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix('%') else {
+            continue;
+        };
+        let lower = rest.trim().trim_start_matches('!').to_ascii_lowercase();
+        if !lower.starts_with("tex root") {
+            continue;
+        }
+        let original = rest.trim().trim_start_matches('!');
+        let value = original
+            .split_once('=')
+            .map(|(_, rest)| rest.trim())
+            .filter(|v| !v.is_empty())?;
+        return Some(value.to_string());
+    }
+    None
+}
+
+/// Resolve `.`/`..` inside a joined relative path; None when it escapes root.
+fn normalize_relative(path: &Path) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => {
+                parts.push(part.to_string_lossy().into_owned());
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                parts.pop()?;
+            }
+            _ => return None,
+        }
+    }
+    Some(parts.join("/"))
+}
+
 fn create_project_transaction<F>(dir: &Path, initialize: F) -> Result<(), String>
 where
     F: FnOnce() -> Result<(), String>,

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1468,8 +1468,20 @@ fn import_overleaf_project_blocking(name: Option<String>, path: &str) -> Result<
             }
             _ => {
                 let main_doc = infer_main_document(&dir)?;
-                let engine = engine_for_main_document(&default_engine(), &main_doc)
+                let mut engine = engine_for_main_document(&default_engine(), &main_doc)
                     .unwrap_or_else(|_| default_engine());
+                // Overleaf parity out of the box: imported LaTeX projects use
+                // the full latexmk toolchain when a system TeX is available.
+                // Journal classes routinely rely on tools and pdfTeX
+                // primitives the bundled Tectonic (XeTeX-class) cannot
+                // provide, and Overleaf compiles them with pdfLaTeX. Without
+                // a system TeX the project stays on Tectonic and the scan /
+                // compile-failure flows offer the switch.
+                if engine == default_engine()
+                    && crate::tex_distro::find_tex_tool("latexmk").is_some()
+                {
+                    engine = "latexmk".to_string();
+                }
                 ProjectMeta {
                     name: project_name.clone(),
                     main_doc,

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -47,6 +47,27 @@ const DEFAULT_MAIN_DIAGRAM: &str = "\\documentclass[tikz,border=4pt]{standalone}
 \\end{tikzpicture}\n\
 \\end{document}\n";
 
+/// Reproducibility pin for latexmk projects: which TeX distribution and which
+/// package versions produced this project's output. Lives in project.json so
+/// it travels with git and every coauthor sees the same spec (the app-internal
+/// `.oleafly/` directory is deliberately gitignored, so it cannot live there).
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct TexSpec {
+    /// Distribution kind ("oleafly-tinytex", "mactex", "texlive", "miktex", ...).
+    #[serde(default)]
+    pub distribution: String,
+    /// Human label, e.g. "TeX Live 2025".
+    #[serde(default)]
+    pub distribution_label: String,
+    /// tlmgr package -> version (CTAN version or TeX Live revision). The
+    /// npm-lockfile role: coauthors are prompted to install what is missing.
+    #[serde(default)]
+    pub packages: std::collections::BTreeMap<String, String>,
+    /// Unix epoch seconds when the spec was captured.
+    #[serde(default)]
+    pub recorded_at: f64,
+}
+
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct ProjectMeta {
     #[serde(default)]
@@ -55,6 +76,9 @@ pub struct ProjectMeta {
     pub main_doc: String,
     #[serde(default = "default_engine")]
     pub engine: String,
+    /// Present on latexmk projects once an engine spec has been recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tex: Option<TexSpec>,
     /// Book-cover color (hex). Empty means "unset" so the UI falls back to its
     /// default. Stored on disk so a project's color survives across machines.
     #[serde(default)]
@@ -151,6 +175,7 @@ pub fn read_meta(project_id: &str) -> Result<ProjectMeta, String> {
             exports: Vec::new(),
             hidden: false,
             forked_from: None,
+            tex: None,
         });
     }
     let s = std::fs::read_to_string(&p).map_err(|e| format!("failed to read project.json: {e}"))?;
@@ -882,6 +907,162 @@ pub async fn set_project_engine(
     Ok(meta)
 }
 
+fn epoch_seconds() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn collect_tex_spec() -> Option<TexSpec> {
+    let active = crate::tex_distro::list_distributions()
+        .into_iter()
+        .find(|d| d.latexmk.is_some())?;
+    // No tlmgr (e.g. MiKTeX, which installs packages on the fly) still yields
+    // a distribution pin; the package map just stays empty.
+    let packages = crate::latex_engine::tlmgr_installed_versions().unwrap_or_default();
+    Some(TexSpec {
+        distribution: active.kind,
+        distribution_label: active.label,
+        packages,
+        recorded_at: epoch_seconds(),
+    })
+}
+
+/// Capture the local TeX distribution + tlmgr package versions into the
+/// project's reproducibility pin. Called after a project switches to latexmk.
+/// The slow part (tlmgr info, seconds) runs before the lock is taken.
+#[tauri::command]
+pub async fn record_project_tex_spec(
+    state: tauri::State<'_, crate::state::AppState>,
+    project_id: String,
+) -> Result<Option<TexSpec>, String> {
+    let spec = tauri::async_runtime::spawn_blocking(collect_tex_spec)
+        .await
+        .map_err(|e| e.to_string())?;
+    let Some(spec) = spec else { return Ok(None) };
+    let _guard = state.compile_lock.lock().await;
+    let mut meta = read_meta(&project_id)?;
+    if meta.engine != "latexmk" {
+        return Ok(None);
+    }
+    meta.tex = Some(spec.clone());
+    write_meta(&project_id, &meta)?;
+    Ok(Some(spec))
+}
+
+/// How this machine compares against the project's reproducibility pin.
+#[derive(Serialize)]
+pub struct TexStatus {
+    pub pinned_label: String,
+    pub local_label: Option<String>,
+    pub distribution_differs: bool,
+    pub missing_packages: Vec<String>,
+    /// Whether "install the missing packages" is actionable here (tlmgr found).
+    pub can_install_missing: bool,
+}
+
+/// Compare the local TeX setup against the project pin (latexmk projects with
+/// a recorded spec only). Coauthors get prompted from this on project open.
+#[tauri::command]
+pub async fn project_tex_status(project_id: String) -> Result<Option<TexStatus>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let meta = read_meta(&project_id)?;
+        if meta.engine != "latexmk" {
+            return Ok(None);
+        }
+        let Some(spec) = meta.tex else {
+            return Ok(None);
+        };
+        let active = crate::tex_distro::list_distributions()
+            .into_iter()
+            .find(|d| d.latexmk.is_some());
+        let local_label = active.as_ref().map(|d| d.label.clone());
+        let can_install = active.as_ref().is_some_and(|d| d.tlmgr.is_some());
+        let missing_packages = if can_install && !spec.packages.is_empty() {
+            let installed = crate::latex_engine::tlmgr_installed_versions()
+                .map(|versions| {
+                    versions
+                        .into_keys()
+                        .collect::<std::collections::BTreeSet<_>>()
+                })
+                .unwrap_or_default();
+            spec.packages
+                .keys()
+                .filter(|name| !installed.contains(*name))
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let distribution_differs = local_label.as_deref() != Some(spec.distribution_label.as_str());
+        Ok(Some(TexStatus {
+            pinned_label: spec.distribution_label,
+            local_label,
+            distribution_differs,
+            missing_packages,
+            can_install_missing: can_install,
+        }))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Record a successful compile's provenance under `.oleafly/builds/`.
+/// Best-effort: failures here must never fail the compile itself.
+pub(crate) fn write_build_metadata(
+    project_id: &str,
+    revision: u64,
+    engine: &str,
+    output_id: Option<&str>,
+    compile_time_ms: u64,
+) {
+    use sha2::Digest;
+    let Ok(dir) = paths::builds_metadata_dir(project_id) else {
+        return;
+    };
+    let tex = read_meta(project_id).ok().and_then(|meta| meta.tex);
+    let lockfile_hash = tex.as_ref().map(|spec| {
+        let serialized = serde_json::to_vec(&spec.packages).unwrap_or_default();
+        format!("sha256:{:x}", sha2::Sha256::digest(&serialized))
+    });
+    let record = serde_json::json!({
+        "revision": revision,
+        "engine": engine,
+        "distribution": tex.as_ref().map(|spec| spec.distribution_label.clone()),
+        "lockfile_hash": lockfile_hash,
+        "output_id": output_id,
+        "compile_time_ms": compile_time_ms,
+        "completed_at": epoch_seconds(),
+    });
+    let path = dir.join(format!("build-{revision:010}.json"));
+    if let Ok(bytes) = serde_json::to_vec_pretty(&record) {
+        let _ = std::fs::write(path, bytes);
+    }
+    prune_build_metadata(&dir, 20);
+}
+
+/// Keep only the newest `keep` build records (names sort chronologically
+/// because the revision is zero-padded).
+fn prune_build_metadata(dir: &Path, keep: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| name.starts_with("build-") && name.ends_with(".json"))
+        .collect();
+    if names.len() <= keep {
+        return;
+    }
+    names.sort();
+    let excess = names.len() - keep;
+    for name in names.into_iter().take(excess) {
+        let _ = std::fs::remove_file(dir.join(name));
+    }
+}
+
 fn engine_for_main_document(current_engine: &str, main_doc: &str) -> Result<String, String> {
     let current_is_typst = matches!(
         current_engine.trim().to_ascii_lowercase().as_str(),
@@ -927,6 +1108,7 @@ fn create_markdown_project_in(root: &Path, name: String) -> Result<String, Strin
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )
     })?;
@@ -1100,6 +1282,7 @@ pub fn create_project(name: String) -> Result<String, String> {
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )
     })?;
@@ -1179,6 +1362,7 @@ pub fn create_project_from_pdf_conversion(
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )?;
         rename_exclusive(&staging, &destination)
@@ -1216,6 +1400,7 @@ fn create_typst_project_in(root: &Path, name: String) -> Result<String, String> 
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )
     })?;
@@ -1269,6 +1454,7 @@ fn create_image_project_in(
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )
     })?;
@@ -1314,6 +1500,7 @@ pub fn create_diagram_project(name: String, source: String) -> Result<String, St
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )
     })?;
@@ -1337,6 +1524,7 @@ pub fn get_or_create_scratch_project() -> Result<String, String> {
                 exports: Vec::new(),
                 hidden: true,
                 forked_from: None,
+                tex: None,
             },
         )?;
     }
@@ -1765,6 +1953,7 @@ pub async fn create_project_from_docx(name: String, data_base64: String) -> Resu
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )?;
         rename_exclusive(&staging, &destination)
@@ -2064,6 +2253,7 @@ pub fn create_project_from_template(
                 exports: Vec::new(),
                 hidden: false,
                 forked_from: None,
+                tex: None,
             },
         )
     })?;
@@ -3188,6 +3378,7 @@ mod tests {
             exports: Vec::new(),
             hidden: false,
             forked_from: None,
+            tex: None,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let decoded: ProjectMeta = serde_json::from_str(&json).unwrap();
@@ -3405,6 +3596,7 @@ mod tests {
             exports: Vec::new(),
             hidden: false,
             forked_from: None,
+            tex: None,
         };
 
         let valid = projects.join("valid-project");
@@ -3451,6 +3643,7 @@ mod tests {
                         exports: Vec::new(),
                         hidden: false,
                         forked_from: None,
+                        tex: None,
                     },
                 )
                 .unwrap();

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -858,6 +858,30 @@ fn set_main_doc_unlocked(project_id: String, main_doc: String) -> Result<Project
     Ok(meta)
 }
 
+/// Pin a project's compile engine in `project.json` (e.g. "xetex" for the
+/// bundled Tectonic, "latexmk" for a system TeX toolchain). Shares the compile
+/// lock with `set_main_doc` so an engine switch never lands between a compile's
+/// final identity check and its revision allocation.
+#[tauri::command]
+pub async fn set_project_engine(
+    state: tauri::State<'_, crate::state::AppState>,
+    project_id: String,
+    engine: String,
+) -> Result<ProjectMeta, String> {
+    let _guard = state.compile_lock.lock().await;
+    let engine = engine.trim().to_string();
+    if engine.is_empty() {
+        return Err("engine name cannot be empty".into());
+    }
+    let mut meta = read_meta(&project_id)?;
+    // Reject engines that cannot compile the current main document before
+    // persisting anything.
+    crate::document_engine::engine_for(&engine, &meta.main_doc)?;
+    meta.engine = engine;
+    write_meta(&project_id, &meta)?;
+    Ok(meta)
+}
+
 fn engine_for_main_document(current_engine: &str, main_doc: &str) -> Result<String, String> {
     let current_is_typst = matches!(
         current_engine.trim().to_ascii_lowercase().as_str(),

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -3134,12 +3134,13 @@ mod tests {
         copy_path_in_project, create_diagram_project, create_image_project_in,
         create_markdown_project_in, create_project_from_pdf_conversion, create_project_transaction,
         create_typst_project, create_typst_project_in, download_project_zip, duplicate_project,
-        engine_for_main_document, extract_pandoc, get_or_create_scratch_project,
-        import_paths_transactional, import_paths_transactional_with, list_projects,
-        pandoc_asset_for, pandoc_version_supported, read_meta, rel_slash, rename_exclusive,
-        rename_path_in_project, search_docs, set_main_doc_synchronized, validate_conversion_export,
+        engine_for_main_document, extract_pandoc, flatten_single_root_folder,
+        get_or_create_scratch_project, import_paths_transactional, import_paths_transactional_with,
+        import_skip, infer_main_document, list_projects, normalize_relative, pandoc_asset_for,
+        pandoc_version_supported, read_meta, rel_slash, rename_exclusive, rename_path_in_project,
+        search_docs, set_main_doc_synchronized, tex_root_magic_target, validate_conversion_export,
         write_meta_at, FileConflictStrategy, PdfConversionFigure, ProjectMeta, RenameFileResult,
-        SCRATCH_PROJECT_ID,
+        TexSpec, SCRATCH_PROJECT_ID,
     };
     use std::io::Write;
     use std::path::Path;
@@ -4107,5 +4108,161 @@ mod tests {
         assert_eq!(meta.forked_from.as_deref(), Some("Original Paper"));
         std::env::remove_var("OLEAFLY_DATA_DIR");
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn import_skip_filters_junk_and_internal_directories() {
+        assert!(import_skip("__MACOSX/main.tex"));
+        assert!(import_skip("figures/.DS_Store"));
+        assert!(import_skip(".git/config"));
+        assert!(import_skip(".oleafly/build/x.pdf"));
+        assert!(!import_skip("chapters/intro.tex"));
+        assert!(!import_skip("main.tex"));
+    }
+
+    #[test]
+    fn tex_root_magic_comment_parses_case_and_spacing_variants() {
+        assert_eq!(
+            tex_root_magic_target("% !TeX root = ../thesis.tex\n").as_deref(),
+            Some("../thesis.tex")
+        );
+        assert_eq!(
+            tex_root_magic_target("%!TEX root=main.tex\n").as_deref(),
+            Some("main.tex")
+        );
+        assert_eq!(tex_root_magic_target("% just a comment\n"), None);
+    }
+
+    #[test]
+    fn normalize_relative_resolves_dots_and_rejects_escapes() {
+        assert_eq!(
+            normalize_relative(Path::new("chapters/../thesis.tex")).as_deref(),
+            Some("thesis.tex")
+        );
+        assert_eq!(
+            normalize_relative(Path::new("a/./b.tex")).as_deref(),
+            Some("a/b.tex")
+        );
+        assert_eq!(normalize_relative(Path::new("../outside.tex")), None);
+    }
+
+    #[test]
+    fn infer_main_document_prefers_documentclass_and_root_level_main() {
+        let dir = test_dir("infer-main-scoring");
+        std::fs::create_dir_all(dir.join("chapters")).unwrap();
+        std::fs::write(
+            dir.join("main.tex"),
+            "\\documentclass{article}\n\\begin{document}Hi\\end{document}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("chapters/ch1.tex"), "\\section{One}\n").unwrap();
+        std::fs::write(dir.join("notes.tex"), "no preamble here\n").unwrap();
+        assert_eq!(infer_main_document(&dir).unwrap(), "main.tex");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn infer_main_document_follows_a_magic_root_comment() {
+        let dir = test_dir("infer-main-magic-root");
+        std::fs::create_dir_all(dir.join("chapters")).unwrap();
+        std::fs::write(
+            dir.join("thesis.tex"),
+            "\\documentclass{report}\n\\begin{document}\\end{document}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("chapters/ch1.tex"),
+            "% !TeX root = ../thesis.tex\n\\chapter{One}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("preamble.tex"), "\\usepackage{amsmath}\n").unwrap();
+        assert_eq!(infer_main_document(&dir).unwrap(), "thesis.tex");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn infer_main_document_uses_a_lone_tex_file_as_is() {
+        let dir = test_dir("infer-main-lone");
+        std::fs::write(dir.join("paper.tex"), "\\documentclass{article}\n").unwrap();
+        std::fs::write(dir.join("refs.bib"), "@book{k, title={T}}\n").unwrap();
+        assert_eq!(infer_main_document(&dir).unwrap(), "paper.tex");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn infer_main_document_errors_without_any_tex_file() {
+        let dir = test_dir("infer-main-none");
+        std::fs::write(dir.join("readme.md"), "hello\n").unwrap();
+        assert!(infer_main_document(&dir).is_err());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn flatten_single_root_folder_unwraps_a_zip_wrapper() {
+        let dir = test_dir("flatten-wrapper");
+        std::fs::create_dir_all(dir.join("wrapped/chapters")).unwrap();
+        std::fs::write(dir.join("wrapped/main.tex"), "x").unwrap();
+        std::fs::write(dir.join("wrapped/chapters/ch1.tex"), "y").unwrap();
+        flatten_single_root_folder(&dir).unwrap();
+        assert!(dir.join("main.tex").is_file());
+        assert!(dir.join("chapters/ch1.tex").is_file());
+        assert!(!dir.join("wrapped").exists());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn flatten_single_root_folder_leaves_flat_projects_alone() {
+        let dir = test_dir("flatten-flat");
+        std::fs::write(dir.join("main.tex"), "x").unwrap();
+        std::fs::write(dir.join("refs.bib"), "y").unwrap();
+        flatten_single_root_folder(&dir).unwrap();
+        assert!(dir.join("main.tex").is_file());
+        assert!(dir.join("refs.bib").is_file());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn tex_spec_round_trips_through_project_json() {
+        let dir = test_dir("tex-spec-roundtrip");
+        let path = dir.join("project.json");
+        let mut packages = std::collections::BTreeMap::new();
+        packages.insert("siunitx".to_string(), "3.3.20".to_string());
+        write_meta_at(
+            &path,
+            &ProjectMeta {
+                name: "Pinned".into(),
+                main_doc: "main.tex".into(),
+                engine: "latexmk".into(),
+                tex: Some(TexSpec {
+                    distribution: "texlive".into(),
+                    distribution_label: "TeX Live 2025".into(),
+                    packages,
+                    recorded_at: 1.0,
+                }),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let parsed: ProjectMeta = serde_json::from_str(&raw).unwrap();
+        let spec = parsed.tex.unwrap();
+        assert_eq!(spec.distribution_label, "TeX Live 2025");
+        assert_eq!(
+            spec.packages.get("siunitx").map(String::as_str),
+            Some("3.3.20")
+        );
+        // Projects without a pin keep project.json free of the field entirely.
+        write_meta_at(
+            &path,
+            &ProjectMeta {
+                name: "Plain".into(),
+                main_doc: "main.tex".into(),
+                engine: "xetex".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(!std::fs::read_to_string(&path).unwrap().contains("\"tex\""));
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src-tauri/src/tex_distro.rs
+++ b/src-tauri/src/tex_distro.rs
@@ -1,0 +1,332 @@
+//! System TeX distribution discovery.
+//!
+//! One shared enumeration of TeX binary directories (managed TinyTeX, MacTeX,
+//! TeX Live, MiKTeX, user TinyTeX) feeds three consumers: the PATH injected
+//! into compile children (`biber_toolchain`), the latexmk engine's tool
+//! lookup (`document_engine`), and the tagged-export engine probe
+//! (`latex_engine`). GUI apps launch with a minimal PATH, so relying on the
+//! inherited environment alone misses most real installs.
+
+use std::path::{Path, PathBuf};
+
+/// Append the platform executable suffix.
+pub fn exe(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+/// TeX binary directories to probe, best-first: Oleafly's managed TinyTeX
+/// (pinned, tlmgr-writable), then versioned system installs (MacTeX, TeX Live
+/// by year, MiKTeX), then generic locations. Only existing directories are
+/// returned.
+pub fn tex_bin_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let home = crate::paths::home_dir().ok();
+
+    // Oleafly's own TinyTeX (managed install; may nest TinyTeX/bin/<platform>).
+    if let Ok(root) = crate::paths::oleafly_root() {
+        push_texdir_bins(&mut dirs, &root.join("tinytex"));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        push_existing(&mut dirs, PathBuf::from("/Library/TeX/texbin"));
+        push_texlive_year_bins(&mut dirs, Path::new("/usr/local/texlive"));
+        push_existing(&mut dirs, PathBuf::from("/usr/local/bin"));
+        push_existing(&mut dirs, PathBuf::from("/opt/homebrew/bin"));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        push_texlive_year_bins(&mut dirs, Path::new("/usr/local/texlive"));
+        push_texlive_year_bins(&mut dirs, Path::new("/opt/texlive"));
+        push_existing(&mut dirs, PathBuf::from("/usr/local/bin"));
+        push_existing(&mut dirs, PathBuf::from("/usr/bin"));
+    }
+
+    #[cfg(windows)]
+    {
+        // TeX Live: C:\texlive\<year>\bin\windows (2023+) or bin\win32.
+        push_texlive_year_bins(&mut dirs, Path::new("C:\\texlive"));
+        // MiKTeX: per-user install first (the installer default), then machine-wide.
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            push_existing(
+                &mut dirs,
+                PathBuf::from(&local).join("Programs\\MiKTeX\\miktex\\bin\\x64"),
+            );
+        }
+        push_existing(
+            &mut dirs,
+            PathBuf::from("C:\\Program Files\\MiKTeX\\miktex\\bin\\x64"),
+        );
+        push_existing(
+            &mut dirs,
+            PathBuf::from("C:\\Program Files\\MiKTeX 2.9\\miktex\\bin\\x64"),
+        );
+    }
+
+    // A user-installed TinyTeX in the home directory (any platform).
+    if let Some(home) = &home {
+        push_texdir_bins(&mut dirs, &home.join(".TinyTeX"));
+    }
+
+    dirs
+}
+
+/// Locate a TeX tool (latexmk, lualatex, tlmgr, ...) by probing `tex_bin_dirs`
+/// and then the inherited PATH. Pure stat-based: never executes anything, so it
+/// is cheap enough to call from every compile-spec preparation.
+pub fn find_tex_tool(name: &str) -> Option<PathBuf> {
+    let file = exe(name);
+    for dir in tex_bin_dirs() {
+        let candidate = dir.join(&file);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    // Fall back to the inherited PATH (covers package-manager installs in
+    // unusual prefixes when the app is launched from a shell).
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(&file))
+        .find(|candidate| candidate.is_file())
+}
+
+/// One detected TeX distribution, for the Settings "Manage TeX distributions"
+/// panel and the engine-picker modal.
+#[derive(Clone, serde::Serialize)]
+pub struct TexDistribution {
+    /// "oleafly-tinytex" | "mactex" | "texlive" | "miktex" | "tinytex" | "other"
+    pub kind: String,
+    pub label: String,
+    pub bin_dir: String,
+    pub latexmk: Option<String>,
+    pub tlmgr: Option<String>,
+}
+
+/// Detected TeX distributions for the Settings panel and the engine-picker
+/// modal. Stat-only (no process spawns), but still off the main thread since
+/// it walks several directories.
+#[tauri::command]
+pub async fn tex_distributions() -> Vec<TexDistribution> {
+    tauri::async_runtime::spawn_blocking(list_distributions)
+        .await
+        .unwrap_or_default()
+}
+
+/// Enumerate distinct TeX distributions by classifying each discovered bin dir.
+/// Only the first bin dir of each root is reported so one install does not show
+/// up once per nested platform directory.
+pub fn list_distributions() -> Vec<TexDistribution> {
+    let mut seen_roots: Vec<PathBuf> = Vec::new();
+    let mut result = Vec::new();
+    for dir in tex_bin_dirs() {
+        let (kind, root) = classify_bin_dir(&dir);
+        if seen_roots.iter().any(|r| r == &root) {
+            continue;
+        }
+        // Generic locations (/usr/local/bin, homebrew) only count as a TeX
+        // distribution when a TeX tool is actually present there.
+        let latexmk = dir.join(exe("latexmk"));
+        let tlmgr = dir.join(exe("tlmgr"));
+        let has_tex = latexmk.is_file()
+            || tlmgr.is_file()
+            || dir.join(exe("pdflatex")).is_file()
+            || dir.join(exe("xelatex")).is_file()
+            || dir.join(exe("lualatex")).is_file();
+        if !has_tex {
+            continue;
+        }
+        seen_roots.push(root.clone());
+        result.push(TexDistribution {
+            label: label_for(&kind, &root),
+            kind,
+            bin_dir: dir.to_string_lossy().into_owned(),
+            latexmk: latexmk
+                .is_file()
+                .then(|| latexmk.to_string_lossy().into_owned()),
+            tlmgr: tlmgr
+                .is_file()
+                .then(|| tlmgr.to_string_lossy().into_owned()),
+        });
+    }
+    result
+}
+
+fn classify_bin_dir(dir: &Path) -> (String, PathBuf) {
+    let text = dir.to_string_lossy().replace('\\', "/");
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("/.oleafly/tinytex") || lower.contains("oleafly") && lower.contains("tinytex")
+    {
+        let root = crate::paths::oleafly_root()
+            .map(|r| r.join("tinytex"))
+            .unwrap_or_else(|_| dir.to_owned());
+        return ("oleafly-tinytex".into(), root);
+    }
+    if lower.contains("/.tinytex") {
+        let root = crate::paths::home_dir()
+            .map(|h| h.join(".TinyTeX"))
+            .unwrap_or_else(|_| dir.to_owned());
+        return ("tinytex".into(), root);
+    }
+    if lower.starts_with("/library/tex") {
+        return ("mactex".into(), PathBuf::from("/Library/TeX/texbin"));
+    }
+    if lower.contains("miktex") {
+        return ("miktex".into(), dir.to_owned());
+    }
+    if lower.contains("texlive") {
+        // Root at the year directory: /usr/local/texlive/2025 or C:\texlive\2025.
+        let mut root = dir.to_owned();
+        while let Some(parent) = root.parent() {
+            let name = root
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if name.len() == 4 && name.chars().all(|c| c.is_ascii_digit()) {
+                break;
+            }
+            root = parent.to_owned();
+            if root.parent().is_none() {
+                break;
+            }
+        }
+        return ("texlive".into(), root);
+    }
+    ("other".into(), dir.to_owned())
+}
+
+fn label_for(kind: &str, root: &Path) -> String {
+    match kind {
+        "oleafly-tinytex" => "TinyTeX (managed by Oleafly)".into(),
+        "tinytex" => "TinyTeX".into(),
+        "mactex" => "MacTeX / TeX Live".into(),
+        "miktex" => "MiKTeX".into(),
+        "texlive" => {
+            let year = root
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if year.chars().all(|c| c.is_ascii_digit()) && !year.is_empty() {
+                format!("TeX Live {year}")
+            } else {
+                "TeX Live".into()
+            }
+        }
+        _ => format!("TeX tools in {}", root.display()),
+    }
+}
+
+fn push_existing(dirs: &mut Vec<PathBuf>, dir: PathBuf) {
+    if dir.is_dir() && !dirs.iter().any(|existing| existing == &dir) {
+        dirs.push(dir);
+    }
+}
+
+/// TeX-dir layout: `<root>/bin/<platform>/` (TeX Live, TinyTeX), possibly with
+/// one extra nesting level from archive extraction (`<root>/TinyTeX/bin/...`).
+fn push_texdir_bins(dirs: &mut Vec<PathBuf>, root: &Path) {
+    if !root.is_dir() {
+        return;
+    }
+    let mut candidates = vec![root.to_owned()];
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir() {
+                candidates.push(entry.path());
+            }
+        }
+    }
+    for candidate in candidates {
+        let bin = candidate.join("bin");
+        if !bin.is_dir() {
+            continue;
+        }
+        if let Ok(platforms) = std::fs::read_dir(&bin) {
+            for platform in platforms.flatten() {
+                if platform.path().is_dir() {
+                    push_existing(dirs, platform.path());
+                }
+            }
+        }
+    }
+}
+
+/// TeX Live installs under `<root>/<year>/bin/<platform>/`; probe years
+/// newest-first so a machine with several TeX Live releases prefers the latest.
+fn push_texlive_year_bins(dirs: &mut Vec<PathBuf>, root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    let mut years: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.len() == 4 && name.chars().all(|c| c.is_ascii_digit()))
+        })
+        .collect();
+    years.sort();
+    years.reverse();
+    for year in years {
+        let bin = year.join("bin");
+        if let Ok(platforms) = std::fs::read_dir(&bin) {
+            for platform in platforms.flatten() {
+                if platform.path().is_dir() {
+                    push_existing(dirs, platform.path());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exe_appends_suffix_only_on_windows() {
+        if cfg!(windows) {
+            assert_eq!(exe("latexmk"), "latexmk.exe");
+        } else {
+            assert_eq!(exe("latexmk"), "latexmk");
+        }
+    }
+
+    #[test]
+    fn texlive_year_bins_prefer_newest() {
+        let root = std::env::temp_dir().join(format!("oleafly-texdist-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for year in ["2023", "2025"] {
+            std::fs::create_dir_all(root.join(year).join("bin/x86_64-test")).unwrap();
+        }
+        std::fs::create_dir_all(root.join("texmf")).unwrap();
+        let mut dirs = Vec::new();
+        push_texlive_year_bins(&mut dirs, &root);
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs[0].to_string_lossy().contains("2025"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn classify_recognizes_texlive_year_root() {
+        let (kind, root) =
+            classify_bin_dir(Path::new("/usr/local/texlive/2025/bin/universal-darwin"));
+        assert_eq!(kind, "texlive");
+        assert!(root.to_string_lossy().ends_with("2025"));
+    }
+
+    #[test]
+    fn tex_bin_dirs_never_duplicates() {
+        let dirs = tex_bin_dirs();
+        for (index, dir) in dirs.iter().enumerate() {
+            assert!(!dirs[index + 1..].contains(dir), "duplicate {dir:?}");
+        }
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { cn } from "@/lib/utils";
 import { ExternalToolApprovals } from "@/components/ai/ExternalToolApprovals";
 import { AboutModal } from "@/components/layout/AboutModal";
+import { EnginePickerModal } from "@/components/layout/EnginePickerModal";
 import { COMPILE_SUCCEEDED_EVENT } from "@/lib/compile-checkpoint";
 import { applyRemoteCompileSuccess } from "@/lib/compile-sync";
 
@@ -634,6 +635,7 @@ function AppContent() {
           {toolsOpen && <LatexToolsView />}
         </Suspense>
         <ExternalToolApprovals />
+        <EnginePickerModal />
         <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
         {chatFloating && (
           <Suspense fallback={null}>
@@ -746,6 +748,7 @@ function AppContent() {
         <SearchOmnibar />
         <GlobalNewProject />
         <ExternalToolApprovals />
+        <EnginePickerModal />
         <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
         {chatFloating && (
           <Suspense fallback={null}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ import { cn } from "@/lib/utils";
 import { ExternalToolApprovals } from "@/components/ai/ExternalToolApprovals";
 import { AboutModal } from "@/components/layout/AboutModal";
 import { EnginePickerModal } from "@/components/layout/EnginePickerModal";
+import { TinytexGuards } from "@/components/layout/TinytexGuards";
 import { COMPILE_SUCCEEDED_EVENT } from "@/lib/compile-checkpoint";
 import { applyRemoteCompileSuccess } from "@/lib/compile-sync";
 
@@ -636,6 +637,7 @@ function AppContent() {
         </Suspense>
         <ExternalToolApprovals />
         <EnginePickerModal />
+        <TinytexGuards />
         <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
         {chatFloating && (
           <Suspense fallback={null}>
@@ -749,6 +751,7 @@ function AppContent() {
         <GlobalNewProject />
         <ExternalToolApprovals />
         <EnginePickerModal />
+        <TinytexGuards />
         <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
         {chatFloating && (
           <Suspense fallback={null}>

--- a/src/components/editor/LanguageServiceKeeper.tsx
+++ b/src/components/editor/LanguageServiceKeeper.tsx
@@ -40,7 +40,9 @@ function currentProjectSnapshot(): LanguageServiceProjectSnapshot {
   const index = useIndexStore.getState();
   return {
     projectId: files.projectId,
-    engineId: files.engine.id,
+    // Language tooling follows the source format, not the compiler: a latexmk
+    // project ("latexmk" id, "latex" source_format) still wants texlab.
+    engineId: files.engine.source_format,
     engineLoaded: files.engineLoaded,
     // The effective main document: an active-file `% !TEX root` override wins
     // over the stored main doc. The snapshot comparison sees it as a plain

--- a/src/components/editor/ProjectCitationPicker.tsx
+++ b/src/components/editor/ProjectCitationPicker.tsx
@@ -185,7 +185,7 @@ export function ProjectCitationPicker({
           role="status"
           className="border-b border-amber-500/20 bg-amber-500/8 px-2.5 py-1.5 text-[10px] text-amber-800 dark:text-amber-200"
         >
-          Partial catalog — malformed or unreadable bibliography files may be
+          Partial catalog. Malformed or unreadable bibliography files may be
           omitted.
         </div>
       ) : null}

--- a/src/components/editor/cm/hover-intel.ts
+++ b/src/components/editor/cm/hover-intel.ts
@@ -272,7 +272,7 @@ const projectHover = hoverTooltip((view, position) => {
       if (extras?.aux) {
         const aux = dom.appendChild(document.createElement("div"));
         aux.className = "cm-code-hover-aux";
-        aux.textContent = `№ ${extras.aux.number} · p. ${extras.aux.page} — last compile`;
+        aux.textContent = `№ ${extras.aux.number} · p. ${extras.aux.page} (last compile)`;
       }
       if (extras?.assetPath) {
         const thumb = dom.appendChild(document.createElement("div"));

--- a/src/components/layout/CompileControls.tsx
+++ b/src/components/layout/CompileControls.tsx
@@ -69,7 +69,7 @@ function TexRootIndicator() {
   if (overriddenBy === null) return null;
   return (
     <Tooltip
-      label={`root: ${mainDoc} — set by % !TEX root in ${overriddenBy}`}
+      label={`root: ${mainDoc} (set by % !TEX root in ${overriddenBy})`}
     >
       <span
         data-testid="tex-root-indicator"

--- a/src/components/layout/CompileControls.tsx
+++ b/src/components/layout/CompileControls.tsx
@@ -91,6 +91,7 @@ function TexRootIndicator() {
 export function CompileControls() {
   const engine = useFilesStore((s) => s.engine);
   const engineLoaded = useFilesStore((s) => s.engineLoaded);
+  const setEngine = useFilesStore((s) => s.setEngine);
   const viewMode = useSettingsStore((s) => s.viewMode);
   const setViewMode = useSettingsStore((s) => s.setViewMode);
   const recompile = useCompileStore((s) => s.recompile);
@@ -219,6 +220,29 @@ export function CompileControls() {
             Don’t check syntax
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
+
+        {engine.source_format === "latex" && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Engine (this project)</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={engine.id === "latexmk" ? "latexmk" : "tectonic"}
+              onValueChange={(value) => {
+                const isLatexmk = engine.id === "latexmk";
+                if (value === "latexmk" && !isLatexmk) void setEngine("latexmk");
+                // "xetex" is the stored default for the bundled Tectonic engine.
+                if (value === "tectonic" && isLatexmk) void setEngine("xetex");
+              }}
+            >
+              <DropdownMenuRadioItem value="tectonic">
+                Tectonic <span className="ml-1 text-muted-foreground">[built in]</span>
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="latexmk">
+                latexmk <span className="ml-1 text-muted-foreground">[system TeX]</span>
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </>
+        )}
 
         <DropdownMenuSeparator />
         <DropdownMenuLabel>Compile error handling</DropdownMenuLabel>

--- a/src/components/layout/EnginePickerModal.tsx
+++ b/src/components/layout/EnginePickerModal.tsx
@@ -205,7 +205,7 @@ export function EnginePickerModal() {
               </div>
               <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
                 Installs a minimal TeX Live into your home folder, no admin rights
-                needed. The core download is about 100 MB; journal templates can
+                needed. The core download is about 100 MB. Journal templates can
                 pull more packages later, up to roughly 1 GB in total.
               </p>
               <div className="mt-2">
@@ -234,7 +234,7 @@ export function EnginePickerModal() {
             </div>
             <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
               {fixable.length > 0
-                ? `Zero setup, works offline. ${fixable.map((f) => f.title).join("; ")} ${fixable.length === 1 ? "is" : "are"} expected to keep failing.`
+                ? `Zero setup, works offline. ${fixable.map((f) => f.title).join(", ")} ${fixable.length === 1 ? "is" : "are"} expected to keep failing.`
                 : "Zero setup, works offline. Fine for plain LaTeX and most common packages."}
             </p>
             <div className="mt-2">

--- a/src/components/layout/EnginePickerModal.tsx
+++ b/src/components/layout/EnginePickerModal.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useId, useState } from "react";
+import { Check, Cpu, Download, Loader2, Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useModalAccessibility } from "@/components/ui/use-modal-accessibility";
+import {
+  dismissEngineHint,
+  useEnginePickerStore,
+} from "@/store/engine-picker";
+import { useEngineStore } from "@/store/engine";
+import { useFilesStore } from "@/store/files";
+import { latexmkFixesFinding, type ImportCompatFinding } from "@oleafly/latex";
+import { notifyError, toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+
+const LEVEL_DOT: Record<ImportCompatFinding["level"], string> = {
+  blocker: "bg-red-500",
+  warning: "bg-amber-500",
+  info: "bg-muted-foreground/50",
+};
+
+/**
+ * The three-way engine choice for projects that need tools beyond Tectonic
+ * (minted, glossaries/makeindex, pythontex, shell-escape-heavy templates).
+ * Opened from the import-scan toast, from a compile failure that matches a
+ * known Tectonic gap, and from the compile options menu.
+ */
+export function EnginePickerModal() {
+  const open = useEnginePickerStore((s) => s.open);
+  const source = useEnginePickerStore((s) => s.source);
+  const findings = useEnginePickerStore((s) => s.findings);
+  const close = useEnginePickerStore((s) => s.close);
+
+  const projectId = useFilesStore((s) => s.projectId);
+  const engineId = useFilesStore((s) => s.engine.id);
+  const setEngine = useFilesStore((s) => s.setEngine);
+
+  const info = useEngineStore((s) => s.info);
+  const installing = useEngineStore((s) => s.installing);
+  const progress = useEngineStore((s) => s.progress);
+  const ensureLoaded = useEngineStore((s) => s.ensureLoaded);
+  const install = useEngineStore((s) => s.install);
+
+  const [switching, setSwitching] = useState(false);
+  const titleId = useId();
+  const { dialogRef, onBackdropMouseDown } = useModalAccessibility<HTMLDivElement>(
+    open,
+    close,
+  );
+
+  useEffect(() => {
+    if (open) void ensureLoaded();
+  }, [open, ensureLoaded]);
+
+  if (!open) return null;
+
+  const hasSystemTex = !!info?.latexmk;
+  const alreadyLatexmk = engineId === "latexmk";
+  const fixable = findings.filter((finding) => latexmkFixesFinding(finding.id));
+
+  const pinLatexmk = async (afterInstall: boolean) => {
+    setSwitching(true);
+    try {
+      await setEngine("latexmk");
+      toast.success(
+        afterInstall
+          ? "TinyTeX installed. This project now compiles with latexmk."
+          : "This project now compiles with latexmk.",
+      );
+      close();
+      if (source === "compile-failure") {
+        const compile = await import("@/store/compile");
+        void compile.useCompileStore.getState().recompile();
+      }
+    } catch (error) {
+      notifyError("switch compile engine", error);
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  const installThenPin = async () => {
+    await install();
+    // install() surfaces its own failure toast; only pin when latexmk exists.
+    if (useEngineStore.getState().info?.latexmk) {
+      await pinLatexmk(true);
+    }
+  };
+
+  const keepTectonic = () => {
+    if (projectId) dismissEngineHint(projectId, findings);
+    close();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <button
+        type="button"
+        aria-label="Close"
+        className="absolute inset-0"
+        onMouseDown={onBackdropMouseDown}
+      />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className="relative flex w-full max-w-lg flex-col gap-4 rounded-xl border bg-background p-5 shadow-2xl"
+      >
+        <div>
+          <h2 id={titleId} className="text-sm font-semibold">
+            {source === "compile-failure"
+              ? "This compile needs more than the built-in engine"
+              : "This project needs more than the built-in engine"}
+          </h2>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {source === "compile-failure"
+              ? "The failure matches a known gap in the bundled Tectonic engine. Pick how this project should compile — the choice is saved in the project, so collaborators get the same setup."
+              : "The import scan found features the bundled Tectonic engine does not orchestrate. Pick how this project should compile — the choice is saved in the project, so collaborators get the same setup."}
+          </p>
+        </div>
+
+        {findings.length > 0 && (
+          <ul className="flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">
+            {findings.map((finding) => (
+              <li key={finding.id} className="flex items-start gap-2 text-xs">
+                <span
+                  className={cn(
+                    "mt-1 size-1.5 shrink-0 rounded-full",
+                    LEVEL_DOT[finding.level],
+                  )}
+                />
+                <div className="min-w-0">
+                  <span className="font-medium">{finding.title}</span>
+                  <p className="text-[11px] leading-relaxed text-muted-foreground">
+                    {finding.detail}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-col gap-2">
+          {/* Option 1: system TeX via latexmk */}
+          <div
+            className={cn(
+              "rounded-lg border p-3",
+              hasSystemTex && "border-primary/60",
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Cpu className="size-4 shrink-0 text-muted-foreground" />
+              <span className="text-sm font-medium">Use my system LaTeX (latexmk)</span>
+              {hasSystemTex && (
+                <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                  Recommended
+                </span>
+              )}
+            </div>
+            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+              {hasSystemTex
+                ? "A TeX distribution was found on this machine. latexmk orchestrates every pass — Biber, makeindex, shell-escape — exactly like Overleaf."
+                : "No TeX distribution (MacTeX, TeX Live, MiKTeX, TinyTeX) was found on this machine."}
+            </p>
+            {info?.latexmk && (
+              <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground/70">
+                {info.latexmk}
+              </p>
+            )}
+            <div className="mt-2">
+              <Button
+                size="sm"
+                disabled={!hasSystemTex || switching || alreadyLatexmk}
+                onClick={() => void pinLatexmk(false)}
+                data-modal-initial-focus={hasSystemTex || undefined}
+              >
+                {switching ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : alreadyLatexmk ? (
+                  <Check className="size-3.5" />
+                ) : null}
+                {alreadyLatexmk ? "Already selected" : "Use system LaTeX"}
+              </Button>
+            </div>
+          </div>
+
+          {/* Option 2: on-demand TinyTeX (hidden when a system TeX already covers it) */}
+          {!hasSystemTex && (
+            <div className="rounded-lg border p-3">
+              <div className="flex items-center gap-2">
+                <Download className="size-4 shrink-0 text-muted-foreground" />
+                <span className="text-sm font-medium">Download TinyTeX</span>
+              </div>
+              <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                Installs a minimal TeX Live into your home folder — no admin rights.
+                The core download is about 100 MB; journal templates can pull more
+                packages later, up to roughly 1 GB in total.
+              </p>
+              <div className="mt-2">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={installing || switching}
+                  onClick={() => void installThenPin()}
+                >
+                  {installing ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                  {installing
+                    ? progress != null
+                      ? `Downloading… ${progress}%`
+                      : "Downloading…"
+                    : "Download and use TinyTeX"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Option 3: stay on Tectonic */}
+          <div className="rounded-lg border p-3">
+            <div className="flex items-center gap-2">
+              <Zap className="size-4 shrink-0 text-muted-foreground" />
+              <span className="text-sm font-medium">Keep using Tectonic</span>
+            </div>
+            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+              {fixable.length > 0
+                ? `Zero setup, works offline. ${fixable.map((f) => f.title).join("; ")} ${fixable.length === 1 ? "is" : "are"} expected to keep failing.`
+                : "Zero setup, works offline. Fine for plain LaTeX and most common packages."}
+            </p>
+            <div className="mt-2">
+              <Button size="sm" variant="ghost" onClick={keepTectonic}>
+                Keep Tectonic
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/EnginePickerModal.tsx
+++ b/src/components/layout/EnginePickerModal.tsx
@@ -126,8 +126,8 @@ export function EnginePickerModal() {
           </h2>
           <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
             {source === "compile-failure"
-              ? "The failure matches a known gap in the bundled Tectonic engine. Pick how this project should compile — the choice is saved in the project, so collaborators get the same setup."
-              : "The import scan found features the bundled Tectonic engine does not orchestrate. Pick how this project should compile — the choice is saved in the project, so collaborators get the same setup."}
+              ? "The failure matches a known gap in the bundled Tectonic engine. Pick how this project should compile. The choice is saved in the project, so collaborators get the same setup."
+              : "The import scan found features the bundled Tectonic engine does not orchestrate. Pick how this project should compile. The choice is saved in the project, so collaborators get the same setup."}
           </p>
         </div>
 
@@ -171,7 +171,7 @@ export function EnginePickerModal() {
             </div>
             <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
               {hasSystemTex
-                ? "A TeX distribution was found on this machine. latexmk orchestrates every pass — Biber, makeindex, shell-escape — exactly like Overleaf."
+                ? "A TeX distribution was found on this machine. latexmk orchestrates every pass (Biber, makeindex, shell-escape), exactly like Overleaf."
                 : "No TeX distribution (MacTeX, TeX Live, MiKTeX, TinyTeX) was found on this machine."}
             </p>
             {info?.latexmk && (
@@ -204,9 +204,9 @@ export function EnginePickerModal() {
                 <span className="text-sm font-medium">Download TinyTeX</span>
               </div>
               <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-                Installs a minimal TeX Live into your home folder — no admin rights.
-                The core download is about 100 MB; journal templates can pull more
-                packages later, up to roughly 1 GB in total.
+                Installs a minimal TeX Live into your home folder, no admin rights
+                needed. The core download is about 100 MB; journal templates can
+                pull more packages later, up to roughly 1 GB in total.
               </p>
               <div className="mt-2">
                 <Button

--- a/src/components/layout/EnginePickerModal.tsx
+++ b/src/components/layout/EnginePickerModal.tsx
@@ -116,6 +116,7 @@ export function EnginePickerModal() {
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
+        data-testid="engine-picker-modal"
         className="relative flex w-full max-w-lg flex-col gap-4 rounded-xl border bg-background p-5 shadow-2xl"
       >
         <div>
@@ -182,6 +183,7 @@ export function EnginePickerModal() {
             <div className="mt-2">
               <Button
                 size="sm"
+                data-testid="engine-picker-use-system"
                 disabled={!hasSystemTex || switching || alreadyLatexmk}
                 onClick={() => void pinLatexmk(false)}
                 data-modal-initial-focus={hasSystemTex || undefined}
@@ -238,7 +240,12 @@ export function EnginePickerModal() {
                 : "Zero setup, works offline. Fine for plain LaTeX and most common packages."}
             </p>
             <div className="mt-2">
-              <Button size="sm" variant="ghost" onClick={() => void keepTectonic()}>
+              <Button
+                size="sm"
+                variant="ghost"
+                data-testid="engine-picker-keep-tectonic"
+                onClick={() => void keepTectonic()}
+              >
                 {alreadyLatexmk ? "Switch back to Tectonic" : "Keep Tectonic"}
               </Button>
             </div>

--- a/src/components/layout/EnginePickerModal.tsx
+++ b/src/components/layout/EnginePickerModal.tsx
@@ -6,7 +6,7 @@ import {
   dismissEngineHint,
   useEnginePickerStore,
 } from "@/store/engine-picker";
-import { useEngineStore } from "@/store/engine";
+import { installPhaseLabel, useEngineStore } from "@/store/engine";
 import { useFilesStore } from "@/store/files";
 import { latexmkFixesFinding, type ImportCompatFinding } from "@oleafly/latex";
 import { notifyError, toast } from "@/lib/toast";
@@ -36,7 +36,9 @@ export function EnginePickerModal() {
 
   const info = useEngineStore((s) => s.info);
   const installing = useEngineStore((s) => s.installing);
+  const installPhase = useEngineStore((s) => s.installPhase);
   const progress = useEngineStore((s) => s.progress);
+  const partialDownloadBytes = useEngineStore((s) => s.partialDownloadBytes);
   const ensureLoaded = useEngineStore((s) => s.ensureLoaded);
   const install = useEngineStore((s) => s.install);
 
@@ -86,8 +88,17 @@ export function EnginePickerModal() {
     }
   };
 
-  const keepTectonic = () => {
+  const keepTectonic = async () => {
     if (projectId) dismissEngineHint(projectId, findings);
+    // For a latexmk project this is a real switch back, not just a dismissal
+    // ("xetex" is the stored name of the bundled Tectonic engine).
+    if (alreadyLatexmk) {
+      try {
+        await setEngine("xetex");
+      } catch (error) {
+        notifyError("switch compile engine", error);
+      }
+    }
     close();
   };
 
@@ -206,10 +217,10 @@ export function EnginePickerModal() {
                 >
                   {installing ? <Loader2 className="size-3.5 animate-spin" /> : null}
                   {installing
-                    ? progress != null
-                      ? `Downloading… ${progress}%`
-                      : "Downloading…"
-                    : "Download and use TinyTeX"}
+                    ? installPhaseLabel(installPhase, progress)
+                    : partialDownloadBytes > 0
+                      ? `Resume download (${Math.round(partialDownloadBytes / 1_000_000)} MB done)`
+                      : "Download and use TinyTeX"}
                 </Button>
               </div>
             </div>
@@ -227,8 +238,8 @@ export function EnginePickerModal() {
                 : "Zero setup, works offline. Fine for plain LaTeX and most common packages."}
             </p>
             <div className="mt-2">
-              <Button size="sm" variant="ghost" onClick={keepTectonic}>
-                Keep Tectonic
+              <Button size="sm" variant="ghost" onClick={() => void keepTectonic()}>
+                {alreadyLatexmk ? "Switch back to Tectonic" : "Keep Tectonic"}
               </Button>
             </div>
           </div>

--- a/src/components/layout/Outline.tsx
+++ b/src/components/layout/Outline.tsx
@@ -115,7 +115,7 @@ function StatusStrip({ state }: { state: ProjectIntelligenceState }) {
         role="status"
         className="border-b border-amber-500/20 bg-amber-500/8 px-2.5 py-1.5 text-[10px] leading-relaxed text-amber-800 dark:text-amber-200"
       >
-        Updating — previous-revision structure is hidden until current source
+        Updating. Previous-revision structure is hidden until current source
         ranges are ready.
       </div>
     );
@@ -126,7 +126,7 @@ function StatusStrip({ state }: { state: ProjectIntelligenceState }) {
         role="status"
         className="border-b border-amber-500/20 bg-amber-500/8 px-2.5 py-1.5 text-[10px] leading-relaxed text-amber-800 dark:text-amber-200"
       >
-        Partial map — unreadable or malformed files remain visible where
+        Partial map. Unreadable or malformed files remain visible where
         possible.
       </div>
     );

--- a/src/components/layout/ReferencesPanel.tsx
+++ b/src/components/layout/ReferencesPanel.tsx
@@ -167,7 +167,7 @@ function AnalysisNotice({ state }: { state: ProjectIntelligenceState }) {
         role="status"
         className="border-b border-amber-500/20 bg-amber-500/8 px-2.5 py-1.5 text-[10px] leading-relaxed text-amber-800 dark:text-amber-200"
       >
-        Updating — previous-revision citations, symbols, and ranges are hidden.
+        Updating. Previous-revision citations, symbols, and ranges are hidden.
       </div>
     );
   }
@@ -177,7 +177,7 @@ function AnalysisNotice({ state }: { state: ProjectIntelligenceState }) {
         role="status"
         className="border-b border-amber-500/20 bg-amber-500/8 px-2.5 py-1.5 text-[10px] leading-relaxed text-amber-800 dark:text-amber-200"
       >
-        Partial results — malformed or unreadable files may omit some
+        Partial results. Malformed or unreadable files may omit some
         occurrences.
       </div>
     );

--- a/src/components/layout/TinytexGuards.tsx
+++ b/src/components/layout/TinytexGuards.tsx
@@ -50,7 +50,7 @@ export function TinytexGuards() {
       <ConfirmationDialog
         open={quitAsked && installing}
         title="TinyTeX is still installing"
-        description={`${phaseLabel} right now. If you quit, the install pauses; the downloaded part is kept and resumes the next time you open Oleafly.`}
+        description={`${phaseLabel} right now. If you quit, the install pauses. The downloaded part is kept and resumes the next time you open Oleafly.`}
         confirmLabel="Quit anyway"
         destructive
         onConfirm={() => {

--- a/src/components/layout/TinytexGuards.tsx
+++ b/src/components/layout/TinytexGuards.tsx
@@ -50,7 +50,7 @@ export function TinytexGuards() {
       <ConfirmationDialog
         open={quitAsked && installing}
         title="TinyTeX is still installing"
-        description={`${phaseLabel} right now. If you quit, the install pauses — the downloaded part is kept and resumes the next time you open Oleafly.`}
+        description={`${phaseLabel} right now. If you quit, the install pauses; the downloaded part is kept and resumes the next time you open Oleafly.`}
         confirmLabel="Quit anyway"
         destructive
         onConfirm={() => {

--- a/src/components/layout/TinytexGuards.tsx
+++ b/src/components/layout/TinytexGuards.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { isTauri } from "@tauri-apps/api/core";
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
+import { installPhaseLabel, useEngineStore } from "@/store/engine";
+import { confirmQuitDuringInstall } from "@/lib/tauri";
+import { notifyError } from "@/lib/toast";
+
+/**
+ * Two guards around a running TinyTeX install:
+ *
+ * - Quit interception: the Rust side blocks window close / Cmd+Q while an
+ *   install runs and emits `tinytex-quit-blocked`; the user confirms before
+ *   the app really exits. The partial download survives and resumes.
+ * - Recompile notice: compiling while the install runs queues the compile and
+ *   tells the user it will start as soon as the engine is ready.
+ */
+export function TinytexGuards() {
+  const [quitAsked, setQuitAsked] = useState(false);
+  const installing = useEngineStore((s) => s.installing);
+  const installPhase = useEngineStore((s) => s.installPhase);
+  const progress = useEngineStore((s) => s.progress);
+  const waitNoticeOpen = useEngineStore((s) => s.installWaitNoticeOpen);
+  const closeWaitNotice = useEngineStore((s) => s.closeInstallWaitNotice);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void listen("tinytex-quit-blocked", () => setQuitAsked(true)).then((stop) => {
+      if (disposed) stop();
+      else unlisten = stop;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+
+  // The install finished (or failed) while the dialog was up: quitting is no
+  // longer destructive, so stop asking.
+  useEffect(() => {
+    if (!installing) setQuitAsked(false);
+  }, [installing]);
+
+  const phaseLabel = installPhaseLabel(installPhase, progress).replace(/…$/, "");
+
+  return (
+    <>
+      <ConfirmationDialog
+        open={quitAsked && installing}
+        title="TinyTeX is still installing"
+        description={`${phaseLabel} right now. If you quit, the install pauses — the downloaded part is kept and resumes the next time you open Oleafly.`}
+        confirmLabel="Quit anyway"
+        destructive
+        onConfirm={() => {
+          void confirmQuitDuringInstall().catch((error) =>
+            notifyError("quit during install", error),
+          );
+        }}
+        onCancel={() => setQuitAsked(false)}
+      />
+      <ConfirmationDialog
+        open={waitNoticeOpen && installing}
+        title="TinyTeX is still downloading"
+        description={`${installPhaseLabel(installPhase, progress)} Your compile is queued and starts automatically as soon as the engine is ready.`}
+        confirmLabel="OK"
+        onConfirm={closeWaitNotice}
+        onCancel={closeWaitNotice}
+      />
+    </>
+  );
+}

--- a/src/components/layout/project-intelligence-view.ts
+++ b/src/components/layout/project-intelligence-view.ts
@@ -330,7 +330,7 @@ function bibliographyMetadata(entry: BibliographyEntry): {
   const author = fields.get("author");
   const title = fields.get("title");
   const year = fields.get("year");
-  const description = [title, author].filter(Boolean).join(" — ");
+  const description = [title, author].filter(Boolean).join(", ");
   return {
     description: description || `${entry.type} entry in ${entry.file}`,
     badge: year || entry.type,

--- a/src/components/library/Library.tsx
+++ b/src/components/library/Library.tsx
@@ -236,8 +236,9 @@ export function Library() {
     if (typeof selection !== "string") return;
     setImporting(true);
     try {
+      // Success feedback (including which engine was chosen) comes from the
+      // store's single import toast.
       await importProject(selection);
-      toast.success("Project imported.");
     } catch (error) {
       notifyError("import project", error);
     } finally {

--- a/src/components/library/Library.tsx
+++ b/src/components/library/Library.tsx
@@ -5,9 +5,11 @@ import {
   Check,
   Clock3,
   FileText,
+  FolderInput,
   GitFork,
   History,
   Info,
+  Loader2,
   Palette,
   Plus,
   SearchX,
@@ -15,6 +17,13 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { pickOpenPath } from "@/lib/native-file-dialog";
 import { Button } from "@/components/ui/button";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import { Input } from "@/components/ui/input";
@@ -209,6 +218,32 @@ export function Library() {
   const page = useHomeViewStore((s) => s.page);
   const projects = useFilesStore((s) => s.projects);
   const projectsLoaded = useFilesStore((s) => s.projectsLoaded);
+  const importProject = useFilesStore((s) => s.importProject);
+  const [importing, setImporting] = useState(false);
+
+  // Overleaf ZIP export or plain folder → new project. The backend infers the
+  // main document (magic comment > \documentclass scoring > lone .tex).
+  const runImport = async (kind: "zip" | "folder") => {
+    const selection = await pickOpenPath(
+      kind === "zip"
+        ? {
+            multiple: false,
+            filters: [{ name: "ZIP archive", extensions: ["zip"] }],
+            title: "Import Overleaf project (ZIP)",
+          }
+        : { multiple: false, directory: true, title: "Import project folder" },
+    );
+    if (typeof selection !== "string") return;
+    setImporting(true);
+    try {
+      await importProject(selection);
+      toast.success("Project imported.");
+    } catch (error) {
+      notifyError("import project", error);
+    } finally {
+      setImporting(false);
+    }
+  };
   const refreshProjects = useFilesStore((s) => s.refreshProjects);
   const openProject = useFilesStore((s) => s.openProject);
   const favs = useFavoritesStore((s) => s.favs);
@@ -420,6 +455,32 @@ export function Library() {
 
         </div>
         <div data-tauri-drag-region className="flex items-center justify-end gap-1.5">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                data-testid="import-project-button"
+                variant="ghost"
+                size="sm"
+                disabled={importing}
+                className="gap-1.5 text-muted-foreground hover:text-foreground"
+              >
+                {importing ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <FolderInput className="size-4" />
+                )}
+                <span className="text-xs">{importing ? "Importing…" : "Import"}</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => void runImport("zip")}>
+                Overleaf ZIP…
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => void runImport("folder")}>
+                Project folder…
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {projects.length > 0 && (
             <>
               <Tooltip label="Advanced project filters">
@@ -617,14 +678,23 @@ export function Library() {
                 </EmptyDescription>
               </EmptyHeader>
               <EmptyContent className="max-w-2xl">
-                <Button
-                  data-testid="create-first-project"
-                  data-tour="new-project"
-                  className="bg-primary text-white hover:bg-primary"
-                  onClick={() => setNewProjectOpen(true)}
-                >
-                  <Plus className="size-4" /> Create your first project
-                </Button>
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                  <Button
+                    data-testid="create-first-project"
+                    data-tour="new-project"
+                    className="bg-primary text-white hover:bg-primary"
+                    onClick={() => setNewProjectOpen(true)}
+                  >
+                    <Plus className="size-4" /> Create your first project
+                  </Button>
+                  <Button
+                    variant="outline"
+                    disabled={importing}
+                    onClick={() => void runImport("zip")}
+                  >
+                    <FolderInput className="size-4" /> Import from Overleaf
+                  </Button>
+                </div>
               </EmptyContent>
             </Empty>
             ) : (

--- a/src/components/library/NewProjectDialog.tsx
+++ b/src/components/library/NewProjectDialog.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip } from "@/components/ui/tooltip";
 import { pickOpenPath } from "@/lib/native-file-dialog";
-import { notifyError, toast } from "@/lib/toast";
+import { notifyError } from "@/lib/toast";
 import { useFilesStore } from "@/store/files";
 import { useSettingsStore } from "@/store/settings";
 import {
@@ -118,8 +118,8 @@ export function NewProjectDialog(props: {
     if (typeof selection !== "string") return;
     props.onClose();
     try {
+      // Success feedback comes from the store's single import toast.
       await useFilesStore.getState().importProject(selection);
-      toast.success("Project imported.");
     } catch (error) {
       notifyError("import project", error);
     }

--- a/src/components/library/NewProjectDialog.tsx
+++ b/src/components/library/NewProjectDialog.tsx
@@ -11,6 +11,9 @@ import { TemplateGenerateModal } from "@/components/library/TemplateGenerateModa
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip } from "@/components/ui/tooltip";
+import { pickOpenPath } from "@/lib/native-file-dialog";
+import { notifyError, toast } from "@/lib/toast";
+import { useFilesStore } from "@/store/files";
 import { useSettingsStore } from "@/store/settings";
 import {
   Select,
@@ -104,11 +107,29 @@ export function NewProjectDialog(props: {
     setSettingsOpen(true);
     props.onClose();
   };
+  // Import an Overleaf ZIP export instead of starting from a template. The
+  // dialog closes first so the imported project's editor is what appears.
+  const importFromOverleaf = async () => {
+    const selection = await pickOpenPath({
+      multiple: false,
+      filters: [{ name: "ZIP archive", extensions: ["zip"] }],
+      title: "Import Overleaf project (ZIP)",
+    });
+    if (typeof selection !== "string") return;
+    props.onClose();
+    try {
+      await useFilesStore.getState().importProject(selection);
+      toast.success("Project imported.");
+    } catch (error) {
+      notifyError("import project", error);
+    }
+  };
   return (
     <>
       <NewProjectDialogCore
         {...props}
         onGenerateWithAi={canGenerate ? () => setGenerateOpen(true) : undefined}
+        onImportProject={() => void importFromOverleaf()}
         onOpenTemplateDownloads={openTemplateDownloads}
         host={HOST}
         kit={KIT}

--- a/src/components/settings/EngineSection.tsx
+++ b/src/components/settings/EngineSection.tsx
@@ -106,7 +106,7 @@ export function EngineSection() {
         <Tooltip
           wide
           side="right"
-          label="Everything the latexmk engine can use on this machine. TinyTeX installs into your home folder with no admin rights; system installs (MacTeX, TeX Live, MiKTeX) are detected automatically."
+          label="Everything the latexmk engine can use on this machine. TinyTeX installs into your home folder with no admin rights. System installs (MacTeX, TeX Live, MiKTeX) are detected automatically."
         >
           <Info className="size-3.5 cursor-help text-muted-foreground/60 hover:text-muted-foreground" />
         </Tooltip>
@@ -151,9 +151,9 @@ export function EngineSection() {
               <span className="text-sm">TinyTeX</span>
             </div>
             <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-              A minimal TeX Live in your home folder. Core download is about 100 MB; journal
-              templates can add packages later (up to ~1 GB total). Installing ahead of time makes
-              imported Overleaf projects compile immediately.
+              A minimal TeX Live in your home folder. The core download is about 100 MB.
+              Journal templates can add packages later, up to about 1 GB in total.
+              Installing ahead of time makes imported Overleaf projects compile immediately.
             </p>
             <div className="mt-2">
               <button

--- a/src/components/settings/EngineSection.tsx
+++ b/src/components/settings/EngineSection.tsx
@@ -1,10 +1,29 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, Check, Cpu, Download, Info, Loader2, Trash2, X } from "lucide-react";
 import { useEngineStore } from "@/store/engine";
+import { useSettingsStore, type DefaultLatexEngine } from "@/store/settings";
 import { LATEX_PACKAGES, type TaggingStatus } from "@/lib/latex-packages";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+
+const ENGINE_CHOICES: Array<{
+  id: DefaultLatexEngine;
+  name: string;
+  detail: string;
+}> = [
+  {
+    id: "tectonic",
+    name: "Tectonic (built in)",
+    detail: "Ships with Oleafly. Fast, offline, zero setup. Covers plain LaTeX and most common packages.",
+  },
+  {
+    id: "latexmk",
+    name: "latexmk (system TeX)",
+    detail:
+      "Uses a TeX distribution on this machine (MacTeX, TeX Live, MiKTeX, or TinyTeX). Required for minted code highlighting, glossaries/makeindex, pythontex, and shell-escape-heavy journal templates.",
+  },
+];
 
 const TAG_BADGE: Record<TaggingStatus, { label: string; className: string } | null> = {
   ok: null,
@@ -15,6 +34,8 @@ const TAG_BADGE: Record<TaggingStatus, { label: string; className: string } | nu
 export function EngineSection() {
   const { info, installing, progress, installed, busyPkg, refresh, refreshPackages, install, remove, addPackage, removePackage } =
     useEngineStore();
+  const defaultLatexEngine = useSettingsStore((s) => s.defaultLatexEngine);
+  const setDefaultLatexEngine = useSettingsStore((s) => s.setDefaultLatexEngine);
   const [query, setQuery] = useState("");
 
   useEffect(() => {
@@ -30,6 +51,50 @@ export function EngineSection() {
 
   return (
     <div className="flex flex-col gap-5">
+      <div className="flex items-center gap-1.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Default compile engine</h3>
+        <Tooltip
+          wide
+          side="right"
+          label="Applies to new projects. Each project pins its own engine in project.json, so collaborators opening the same project compile it the same way regardless of this setting."
+        >
+          <Info className="size-3.5 cursor-help text-muted-foreground/60 hover:text-muted-foreground" />
+        </Tooltip>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {ENGINE_CHOICES.map((choice) => {
+          const selected = defaultLatexEngine === choice.id;
+          const missing = choice.id === "latexmk" && !info?.latexmk;
+          return (
+            <button
+              key={choice.id}
+              type="button"
+              onClick={() => setDefaultLatexEngine(choice.id)}
+              className={cn(
+                "rounded-lg border p-3 text-left transition-colors hover:bg-accent/50",
+                selected && "border-primary ring-1 ring-primary",
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <Cpu className="size-4 text-muted-foreground" />
+                <span className="text-sm">{choice.name}</span>
+                {selected && <Check className="size-3.5 text-primary" />}
+                {missing && (
+                  <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="size-2.5" /> no latexmk found
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 text-[11px] text-muted-foreground">{choice.detail}</p>
+              {choice.id === "latexmk" && info?.latexmk && (
+                <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground/70">{info.latexmk}</p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
       <div className="flex items-center gap-1.5">
         <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Tagged / accessible export</h3>
         <Tooltip

--- a/src/components/settings/EngineSection.tsx
+++ b/src/components/settings/EngineSection.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, Check, Cpu, Download, Info, Loader2, Trash2, X } from "lucide-react";
-import { useEngineStore } from "@/store/engine";
+import { AlertTriangle, Check, Cpu, Download, HardDrive, Info, Loader2, Trash2, X } from "lucide-react";
+import { installPhaseLabel, useEngineStore } from "@/store/engine";
 import { useSettingsStore, type DefaultLatexEngine } from "@/store/settings";
 import { LATEX_PACKAGES, type TaggingStatus } from "@/lib/latex-packages";
+import { texDistributions, type TexDistribution } from "@/lib/tauri";
+import { isTauri } from "@tauri-apps/api/core";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -36,11 +38,15 @@ export function EngineSection() {
     useEngineStore();
   const defaultLatexEngine = useSettingsStore((s) => s.defaultLatexEngine);
   const setDefaultLatexEngine = useSettingsStore((s) => s.setDefaultLatexEngine);
+  const installPhase = useEngineStore((s) => s.installPhase);
+  const partialDownloadBytes = useEngineStore((s) => s.partialDownloadBytes);
   const [query, setQuery] = useState("");
+  const [distros, setDistros] = useState<TexDistribution[]>([]);
 
   useEffect(() => {
     // refreshPackages() needs engine info from refresh() first, so run in sequence.
     void refresh().then(() => refreshPackages());
+    if (isTauri()) void texDistributions().then(setDistros).catch(() => {});
   }, [refresh, refreshPackages]);
 
   const kind = info?.kind ?? "none";
@@ -96,6 +102,79 @@ export function EngineSection() {
       </div>
 
       <div className="flex items-center gap-1.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Manage TeX distributions</h3>
+        <Tooltip
+          wide
+          side="right"
+          label="Everything the latexmk engine can use on this machine. TinyTeX installs into your home folder with no admin rights; system installs (MacTeX, TeX Live, MiKTeX) are detected automatically."
+        >
+          <Info className="size-3.5 cursor-help text-muted-foreground/60 hover:text-muted-foreground" />
+        </Tooltip>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {distros.length === 0 && (
+          <p className="text-xs text-muted-foreground">No TeX distribution detected on this machine.</p>
+        )}
+        {distros.map((distro) => (
+          <div key={distro.bin_dir} className="rounded-lg border p-3">
+            <div className="flex items-center gap-2">
+              <HardDrive className="size-4 shrink-0 text-muted-foreground" />
+              <span className="text-sm">{distro.label}</span>
+              {distro.latexmk && (
+                <span className="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-400">
+                  latexmk
+                </span>
+              )}
+              {distro.tlmgr && (
+                <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                  tlmgr
+                </span>
+              )}
+              {distro.kind === "oleafly-tinytex" && (
+                <button
+                  type="button"
+                  onClick={() => void remove()}
+                  className="ml-auto inline-flex items-center gap-1 rounded-md border border-input px-2 py-1 text-[11px] hover:bg-accent"
+                >
+                  <Trash2 className="size-3" /> Remove
+                </button>
+              )}
+            </div>
+            <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground/70">{distro.bin_dir}</p>
+          </div>
+        ))}
+        {!distros.some((d) => d.kind === "oleafly-tinytex") && (
+          <div className="rounded-lg border p-3">
+            <div className="flex items-center gap-2">
+              <Download className="size-4 shrink-0 text-muted-foreground" />
+              <span className="text-sm">TinyTeX</span>
+            </div>
+            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+              A minimal TeX Live in your home folder. Core download is about 100 MB; journal
+              templates can add packages later (up to ~1 GB total). Installing ahead of time makes
+              imported Overleaf projects compile immediately.
+            </p>
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => void install()}
+                disabled={installing}
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1.5 text-xs text-white hover:opacity-90 disabled:opacity-60"
+              >
+                {installing ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
+                {installing
+                  ? installPhaseLabel(installPhase, progress)
+                  : partialDownloadBytes > 0
+                    ? `Resume download (${Math.round(partialDownloadBytes / 1_000_000)} MB done)`
+                    : "Download TinyTeX (~100 MB)"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5">
         <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Tagged / accessible export</h3>
         <Tooltip
           wide
@@ -117,22 +196,12 @@ export function EngineSection() {
 
         <div className="mt-3 flex flex-wrap items-center gap-2">
           {kind === "none" && (
-            <button type="button"
-              onClick={() => void install()}
-              disabled={installing}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1.5 text-xs text-white hover:opacity-90 disabled:opacity-60"
-            >
-              {installing ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
-              {installing ? (progress != null ? `Installing… ${progress}%` : "Installing…") : "Install TinyTeX (~100 MB)"}
-            </button>
+            <span className="text-xs text-muted-foreground">
+              Install TinyTeX under “Manage TeX distributions” above to enable tagged export.
+            </span>
           )}
           {kind === "tinytex" && (
-            <button type="button"
-              onClick={() => void remove()}
-              className="inline-flex items-center gap-1.5 rounded-md border border-input px-2.5 py-1.5 text-xs hover:bg-accent"
-            >
-              <Trash2 className="size-3.5" /> Delete TinyTeX to free space
-            </button>
+            <span className="text-xs text-muted-foreground">Provided by TinyTeX (managed above).</span>
           )}
           {kind === "system" && (
             <span className="text-xs text-muted-foreground">Detected on your system. Nothing to install.</span>

--- a/src/lib/project-intelligence/latex-ast.test.ts
+++ b/src/lib/project-intelligence/latex-ast.test.ts
@@ -67,7 +67,7 @@ describe("astAugmentLatexFile", () => {
     const definition = result?.definitions[0];
     expect(definition?.kind).toBe("glossary");
     expect(definition?.name).toBe("ast");
-    expect(definition?.detail).toBe("AST — Abstract Syntax Tree");
+    expect(definition?.detail).toBe("AST, Abstract Syntax Tree");
   });
 
   it("skips a leading optional argument on \\newacronym", () => {
@@ -76,7 +76,7 @@ describe("astAugmentLatexFile", () => {
     );
     const definition = result?.definitions[0];
     expect(definition?.name).toBe("k");
-    expect(definition?.detail).toBe("S — L");
+    expect(definition?.detail).toBe("S, L");
   });
 
   it("returns null when the source has no glossary macros", () => {

--- a/src/lib/project-intelligence/latex-ast.ts
+++ b/src/lib/project-intelligence/latex-ast.ts
@@ -152,7 +152,7 @@ function glossaryDefinition(
     macro.content === "newabbreviation";
   let detail = "glossary entry";
   if (isAcronym && groups.length >= 3) {
-    detail = `${trimmedRaw(api, groups[1].content)} — ${trimmedRaw(api, groups[2].content)}`;
+    detail = `${trimmedRaw(api, groups[1].content)}, ${trimmedRaw(api, groups[2].content)}`;
   } else if (!isAcronym && groups.length >= 2) {
     const nameField = /name\s*=\s*\{?([^,{}]+)/u.exec(
       trimmedRaw(api, groups[1].content),

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -40,7 +40,7 @@ export interface EngineCapabilities {
   features: EngineFeature[];
   conversion_exports: Array<"docx" | "html" | "md" | "txt" | "pptx" | "epub">;
   template_kinds: Array<"document" | "image">;
-  compiler_prerequisite: "pandoc" | null;
+  compiler_prerequisite: "pandoc" | "system_tex" | null;
 }
 export type EngineFeature = "citations" | "document_index";
 
@@ -53,7 +53,7 @@ export interface DocumentEngineDescriptor {
   capabilities: EngineCapabilities;
 }
 
-export type DocumentEngineId = "latex" | "typst" | "markdown" | "unknown";
+export type DocumentEngineId = "latex" | "latexmk" | "typst" | "markdown" | "unknown";
 
 export const getProjectEngine = (projectId: string) =>
   invoke<DocumentEngineDescriptor>("project_engine", { projectId });
@@ -224,6 +224,11 @@ export const readAppLog = (maxBytes: number) =>
 
 export const setMainDocCmd = (projectId: string, mainDoc: string) =>
   invoke<ProjectMeta>("set_main_doc", { projectId, mainDoc });
+
+// Pin a project's compile engine ("xetex" for bundled Tectonic, "latexmk" for
+// a system TeX toolchain) in its project.json.
+export const setProjectEngineCmd = (projectId: string, engine: string) =>
+  invoke<ProjectMeta>("set_project_engine", { projectId, engine });
 
 export const renameProjectCmd = (projectId: string, name: string) =>
   invoke<ProjectMeta>("rename_project", { projectId, name });
@@ -451,7 +456,18 @@ export interface EngineInfo {
   lualatex: string | null;
   tlmgr: string | null;
   version: string | null;
+  latexmk: string | null;
 }
+
+export interface TexDistribution {
+  kind: "oleafly-tinytex" | "mactex" | "texlive" | "miktex" | "tinytex" | "other";
+  label: string;
+  bin_dir: string;
+  latexmk: string | null;
+  tlmgr: string | null;
+}
+
+export const texDistributions = () => invoke<TexDistribution[]>("tex_distributions");
 
 export interface TaggedCompileResult {
   success: boolean;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -477,10 +477,21 @@ export interface TaggedCompileResult {
   log: string;
 }
 
+export interface TinytexInstallState {
+  installing: boolean;
+  partial_download_bytes: number;
+}
+
 export const latexEngineInfo = () => invoke<EngineInfo>("latex_engine_info");
 export const hasTaggingEngine = () => invoke<boolean>("has_tagging_engine");
-// Emits `tinytex-download-progress` events while downloading.
+// Emits phased `tinytex-install-progress` events (download/extract/packages);
+// a failed download keeps its partial file so a retry resumes.
 export const installTinytex = () => invoke<EngineInfo>("install_tinytex");
+export const tinytexInstallState = () =>
+  invoke<TinytexInstallState>("tinytex_install_state");
+// The user confirmed quitting mid-install; the app exits immediately.
+export const confirmQuitDuringInstall = () =>
+  invoke<void>("confirm_quit_during_install");
 export const deleteTinytex = () => invoke<void>("delete_tinytex");
 export const tlmgrInstalled = () => invoke<string[]>("tlmgr_installed");
 export const tlmgrInstall = (packages: string[]) => invoke<string>("tlmgr_install", { packages });

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -78,7 +78,33 @@ export interface ProjectMeta {
   engine: string;
   color?: string;
   kind?: string;
+  tex?: TexSpec | null;
 }
+
+// Reproducibility pin for latexmk projects (stored in project.json so it
+// travels with git and every coauthor sees the same spec).
+export interface TexSpec {
+  distribution: string;
+  distribution_label: string;
+  packages: Record<string, string>;
+  recorded_at: number;
+}
+
+export interface TexStatus {
+  pinned_label: string;
+  local_label: string | null;
+  distribution_differs: boolean;
+  missing_packages: string[];
+  can_install_missing: boolean;
+}
+
+// Capture the local distro + tlmgr package versions into the project pin.
+export const recordProjectTexSpec = (projectId: string) =>
+  invoke<TexSpec | null>("record_project_tex_spec", { projectId });
+
+// Compare this machine against the project pin (null when not applicable).
+export const projectTexStatus = (projectId: string) =>
+  invoke<TexStatus | null>("project_tex_status", { projectId });
 
 export interface ProjectInfo {
   id: string;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -102,6 +102,11 @@ export interface TexStatus {
 export const recordProjectTexSpec = (projectId: string) =>
   invoke<TexSpec | null>("record_project_tex_spec", { projectId });
 
+// Import an Overleaf ZIP export (or a plain folder) as a new project; the
+// main document is inferred when the archive carries no project.json.
+export const importOverleafProjectCmd = (path: string, name?: string) =>
+  invoke<string>("import_overleaf_project", { path, name: name ?? null });
+
 // Compare this machine against the project pin (null when not applicable).
 export const projectTexStatus = (projectId: string) =>
   invoke<TexStatus | null>("project_tex_status", { projectId });

--- a/src/store/compile.ts
+++ b/src/store/compile.ts
@@ -11,10 +11,14 @@ import {
 } from "@/lib/tauri";
 import { useFilesStore } from "@/store/files";
 import { engineHintDismissed, useEnginePickerStore } from "@/store/engine-picker";
-import { classifyCompileFailure, importCompatFinding } from "@oleafly/latex";
+import {
+  classifyCompileFailure,
+  importCompatFinding,
+  missingLatexPackages,
+} from "@oleafly/latex";
 import { useProjectAnalysisStore } from "@/store/project-analysis";
 import { useSettingsStore } from "@/store/settings";
-import { notifyError } from "@/lib/toast";
+import { notifyError, toast } from "@/lib/toast";
 import { compileOfflineForEngine } from "@/lib/document-engine";
 import { ensurePandoc } from "@/features/pandoc";
 import {
@@ -366,6 +370,64 @@ async function mainDocumentSyntaxErrors(
  * classes relying on toolchain behavior Tectonic does not provide), and it
  * never fires for ordinary typos, which TeX attributes to the user's .tex.
  */
+// Last missing-package suggestion per project, so auto-compile retries of the
+// same failure do not stack identical toasts. Session-scoped on purpose: a
+// fresh launch may as well offer the install again.
+const suggestedPackagesByProject = new Map<string, string>();
+
+/**
+ * A latexmk compile that failed on a missing .sty/.cls gets a one-click
+ * "install via tlmgr and recompile" toast. This closes the gap between a
+ * minimal TinyTeX and what a journal template actually loads.
+ */
+function maybeSuggestMissingPackages(log: string): void {
+  const files = useFilesStore.getState();
+  const projectId = files.projectId;
+  if (files.engine.id !== "latexmk" || !projectId) return;
+  const packages = missingLatexPackages(log);
+  if (packages.length === 0) return;
+  const signature = [...packages].sort().join(",");
+  if (suggestedPackagesByProject.get(projectId) === signature) return;
+  suggestedPackagesByProject.set(projectId, signature);
+  void (async () => {
+    const tauri = await import("@/lib/tauri");
+    const info = await tauri.latexEngineInfo().catch(() => null);
+    if (!info?.tlmgr) return; // MiKTeX installs on the fly; nothing to offer
+    const label = packages.length === 1 ? `Install ${packages[0]}` : `Install all ${packages.length}`;
+    const summary =
+      packages.length === 1
+        ? `The compile needs the LaTeX package "${packages[0]}", which is not installed.`
+        : `The compile needs ${packages.length} LaTeX packages that are not installed (${packages.join(", ")}).`;
+    toast.info(
+      summary,
+      {
+        label,
+        onClick: () => {
+          void (async () => {
+            toast.info(
+              packages.length === 1
+                ? `Installing ${packages[0]}. The compile restarts when it finishes.`
+                : `Installing ${packages.length} packages. The compile restarts when they finish.`,
+            );
+            try {
+              await tauri.tlmgrInstall(packages);
+              suggestedPackagesByProject.delete(projectId);
+              void useCompileStore.getState().recompile();
+            } catch (error) {
+              notifyError(
+                "install missing packages",
+                error,
+                "The packages could not be installed. See Settings, LaTeX Engine for details.",
+              );
+            }
+          })();
+        },
+      },
+      true,
+    );
+  })();
+}
+
 function maybePromptEngineGap(log: string, errors: CompileError[]): void {
   const files = useFilesStore.getState();
   if (files.engine.id !== "latex" || !files.projectId) return;
@@ -871,7 +933,10 @@ export const useCompileStore = create<CompileState>((set, get) => ({
       // (minted, missing index run, shell-escape refusal, unresolved Biber)
       // gets the engine-picker modal instead of leaving the user to decode
       // the log. latexmk projects already have the full toolchain.
-      if (!checkpoint) maybePromptEngineGap(result.log, result.errors);
+      if (!checkpoint) {
+        maybePromptEngineGap(result.log, result.errors);
+        maybeSuggestMissingPackages(result.log);
+      }
       // Tell detached windows (PDF preview, other OS windows) to reload.
       void import("@/lib/preview-window")
         .then((module) =>

--- a/src/store/compile.ts
+++ b/src/store/compile.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/tauri";
 import { useFilesStore } from "@/store/files";
 import { engineHintDismissed, useEnginePickerStore } from "@/store/engine-picker";
-import { classifyCompileFailure } from "@oleafly/latex";
+import { classifyCompileFailure, importCompatFinding } from "@oleafly/latex";
 import { useProjectAnalysisStore } from "@/store/project-analysis";
 import { useSettingsStore } from "@/store/settings";
 import { notifyError } from "@/lib/toast";
@@ -359,11 +359,24 @@ async function mainDocumentSyntaxErrors(
  * Open the engine-picker modal when a failed Tectonic compile matches a known
  * engine gap. Skipped for latexmk projects (they have the full toolchain) and
  * for finding sets the user already dismissed with "Keep Tectonic".
+ *
+ * Catch-all: when no specific signature matches but the errors originate in a
+ * class or style file rather than the user's own document, treat it as an
+ * engine gap too. That is the "it works on Overleaf" long tail (publisher
+ * classes relying on toolchain behavior Tectonic does not provide), and it
+ * never fires for ordinary typos, which TeX attributes to the user's .tex.
  */
-function maybePromptEngineGap(log: string): void {
+function maybePromptEngineGap(log: string, errors: CompileError[]): void {
   const files = useFilesStore.getState();
   if (files.engine.id !== "latex" || !files.projectId) return;
-  const findings = classifyCompileFailure(log);
+  let findings = classifyCompileFailure(log);
+  if (findings.length === 0) {
+    const classFileError = errors.some(
+      (error) =>
+        error.kind === "error" && /\.(cls|sty|bbx|cbx|def|ldf)$/i.test(error.file ?? ""),
+    );
+    if (classFileError) findings = [importCompatFinding("class-compat")];
+  }
   if (findings.length === 0) return;
   if (engineHintDismissed(files.projectId, findings)) return;
   useEnginePickerStore.getState().openPicker("compile-failure", findings);
@@ -858,7 +871,7 @@ export const useCompileStore = create<CompileState>((set, get) => ({
       // (minted, missing index run, shell-escape refusal, unresolved Biber)
       // gets the engine-picker modal instead of leaving the user to decode
       // the log. latexmk projects already have the full toolchain.
-      if (!checkpoint) maybePromptEngineGap(result.log);
+      if (!checkpoint) maybePromptEngineGap(result.log, result.errors);
       // Tell detached windows (PDF preview, other OS windows) to reload.
       void import("@/lib/preview-window")
         .then((module) =>

--- a/src/store/compile.ts
+++ b/src/store/compile.ts
@@ -10,6 +10,8 @@ import {
   type CompileResult,
 } from "@/lib/tauri";
 import { useFilesStore } from "@/store/files";
+import { engineHintDismissed, useEnginePickerStore } from "@/store/engine-picker";
+import { classifyCompileFailure } from "@oleafly/latex";
 import { useProjectAnalysisStore } from "@/store/project-analysis";
 import { useSettingsStore } from "@/store/settings";
 import { notifyError } from "@/lib/toast";
@@ -351,6 +353,20 @@ async function mainDocumentSyntaxErrors(
       kind: "error",
       explanation: null,
     }));
+}
+
+/**
+ * Open the engine-picker modal when a failed Tectonic compile matches a known
+ * engine gap. Skipped for latexmk projects (they have the full toolchain) and
+ * for finding sets the user already dismissed with "Keep Tectonic".
+ */
+function maybePromptEngineGap(log: string): void {
+  const files = useFilesStore.getState();
+  if (files.engine.id !== "latex" || !files.projectId) return;
+  const findings = classifyCompileFailure(log);
+  if (findings.length === 0) return;
+  if (engineHintDismissed(files.projectId, findings)) return;
+  useEnginePickerStore.getState().openPicker("compile-failure", findings);
 }
 
 export const useCompileStore = create<CompileState>((set, get) => ({
@@ -813,6 +829,11 @@ export const useCompileStore = create<CompileState>((set, get) => ({
         };
       });
       if (!applied) return result;
+      // A failed Tectonic compile whose log matches a known engine gap
+      // (minted, missing index run, shell-escape refusal, unresolved Biber)
+      // gets the engine-picker modal instead of leaving the user to decode
+      // the log. latexmk projects already have the full toolchain.
+      if (!checkpoint) maybePromptEngineGap(result.log);
       // Tell detached windows (PDF preview, other OS windows) to reload.
       void import("@/lib/preview-window")
         .then((module) =>

--- a/src/store/compile.ts
+++ b/src/store/compile.ts
@@ -539,6 +539,31 @@ export const useCompileStore = create<CompileState>((set, get) => ({
         return undefined;
       }
     }
+    if (files.engine.capabilities.compiler_prerequisite === "system_tex") {
+      // A TinyTeX install may be in flight: queue this compile behind it
+      // instead of failing with "latexmk not found". The engine store runs
+      // the queued compile the moment the install lands.
+      const engineModule = await import("@/store/engine");
+      const engineStore = engineModule.useEngineStore.getState();
+      if (engineStore.installing) {
+        engineStore.queueCompileAfterInstall();
+        set({
+          status: "unavailable",
+          phase: "idle",
+          failureReason:
+            "TinyTeX is still downloading. This compile starts automatically when it finishes.",
+          lastAttemptIdentity: capturedProjectId
+            ? identityForGeneration(capturedProjectId, mainDoc, intent)
+            : null,
+        });
+        abortIntent();
+        return undefined;
+      }
+      if (!matchesProjectAndMain() || checkpointAdvanced()) {
+        abortIntent();
+        return undefined;
+      }
+    }
     if (!matchesProjectAndMain() || checkpointAdvanced()) {
       abortIntent();
       return undefined;

--- a/src/store/engine-picker.ts
+++ b/src/store/engine-picker.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+import type { ImportCompatFinding } from "@oleafly/latex";
+
+export type EnginePickerSource = "project-open" | "compile-failure" | "manual";
+
+interface EnginePickerStore {
+  open: boolean;
+  source: EnginePickerSource;
+  findings: ImportCompatFinding[];
+  openPicker: (source: EnginePickerSource, findings: ImportCompatFinding[]) => void;
+  close: () => void;
+}
+
+export const useEnginePickerStore = create<EnginePickerStore>((set) => ({
+  open: false,
+  source: "manual",
+  findings: [],
+  openPicker: (source, findings) => set({ open: true, source, findings }),
+  close: () => set({ open: false }),
+}));
+
+// --- "Don't nag" memory -------------------------------------------------------
+//
+// The project-open hint is shown once per project per set of findings. Choosing
+// "Keep using Tectonic" (or dismissing the toast) records the finding signature;
+// the hint returns only when a NEW gap appears (e.g. the user adds minted).
+// Compile-failure prompts are not gated: a failing compile is worth interrupting.
+
+const dismissKey = (projectId: string) => `oleafly.engineHint.${projectId}`;
+
+export function engineHintDismissed(
+  projectId: string,
+  findings: ImportCompatFinding[],
+): boolean {
+  try {
+    const stored = localStorage.getItem(dismissKey(projectId));
+    if (stored === null) return false;
+    const seen = new Set(stored.split(","));
+    return findings.every((finding) => seen.has(finding.id));
+  } catch {
+    return false;
+  }
+}
+
+export function dismissEngineHint(
+  projectId: string,
+  findings: ImportCompatFinding[],
+): void {
+  try {
+    const previous = localStorage.getItem(dismissKey(projectId));
+    const merged = new Set(previous ? previous.split(",").filter(Boolean) : []);
+    for (const finding of findings) merged.add(finding.id);
+    localStorage.setItem(dismissKey(projectId), [...merged].sort().join(","));
+  } catch {
+    /* best-effort memory */
+  }
+}

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -5,6 +5,7 @@ import {
   latexEngineInfo,
   installTinytex,
   deleteTinytex,
+  tinytexInstallState,
   tlmgrInstalled,
   tlmgrInstall,
   tlmgrRemove,
@@ -13,10 +14,21 @@ import {
 import { toast } from "@/lib/toast";
 import { logError } from "@/lib/log";
 
+export type InstallPhase = "download" | "extract" | "packages";
+
 interface EngineStore {
   info: EngineInfo | null;
   installing: boolean;
+  /** Which install phase is running (null when idle). */
+  installPhase: InstallPhase | null;
+  /** Download percentage when the total size is known. */
   progress: number | null;
+  /** Bytes of a previous interrupted download waiting to be resumed. */
+  partialDownloadBytes: number;
+  /** A compile was requested mid-install; run it when the install lands. */
+  compileQueuedDuringInstall: boolean;
+  /** "TinyTeX is still downloading" notice (Recompile during install). */
+  installWaitNoticeOpen: boolean;
   installed: string[];
   busyPkg: string | null;
   loaded: boolean;
@@ -27,12 +39,18 @@ interface EngineStore {
   remove: () => Promise<void>;
   addPackage: (name: string) => Promise<void>;
   removePackage: (name: string) => Promise<void>;
+  queueCompileAfterInstall: () => void;
+  closeInstallWaitNotice: () => void;
 }
 
 export const useEngineStore = create<EngineStore>((set, get) => ({
   info: null,
   installing: false,
+  installPhase: null,
   progress: null,
+  partialDownloadBytes: 0,
+  compileQueuedDuringInstall: false,
+  installWaitNoticeOpen: false,
   installed: [],
   busyPkg: null,
   loaded: false,
@@ -43,7 +61,12 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
       // Only fetch engine info here. The package list (a slow `tlmgr info` call)
       // is loaded separately by the Settings panel, never on the Preflight path.
       const info = await latexEngineInfo();
-      set({ info, loaded: true });
+      const installState = await tinytexInstallState().catch(() => null);
+      set({
+        info,
+        loaded: true,
+        partialDownloadBytes: installState?.partial_download_bytes ?? 0,
+      });
     } catch (e) {
       void logError("engine info", e);
     }
@@ -65,28 +88,60 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
 
   install: async () => {
     if (!isTauri() || get().installing) return;
-    set({ installing: true, progress: 0 });
-    const unlisten = await listen<{ received: number; total: number | null }>(
-      "tinytex-download-progress",
-      (e) => {
-        const { received, total } = e.payload;
-        set({ progress: total ? Math.round((received / total) * 100) : null });
-      },
-    );
+    // A download must not race a running compile for disk/CPU: stop it first.
+    // The compile is re-queued and runs automatically once the install lands.
+    try {
+      const compile = await import("@/store/compile");
+      const compileStore = compile.useCompileStore.getState();
+      if (compileStore.status === "compiling") {
+        void compileStore.stopCompile();
+        get().queueCompileAfterInstall();
+      }
+    } catch {
+      /* compile store unavailable — nothing to pause */
+    }
+    set({ installing: true, installPhase: "download", progress: 0 });
+    const unlisten = await listen<{
+      phase: InstallPhase;
+      received: number;
+      total: number | null;
+    }>("tinytex-install-progress", (e) => {
+      const { phase, received, total } = e.payload;
+      set({
+        installPhase: phase,
+        progress:
+          phase === "download" && total
+            ? Math.round((received / total) * 100)
+            : null,
+      });
+    });
     try {
       const info = await installTinytex();
-      set({ info });
-      toast.success("Tagging engine installed (TinyTeX)");
+      set({ info, partialDownloadBytes: 0 });
+      toast.success("TinyTeX installed.");
       void get().refreshPackages();
+      if (get().compileQueuedDuringInstall) {
+        set({ compileQueuedDuringInstall: false, installWaitNoticeOpen: false });
+        const compile = await import("@/store/compile");
+        void compile.useCompileStore.getState().recompile();
+      }
     } catch (e) {
       void logError("install tinytex", e);
-      toast.error("Could not install the tagging engine. See the install guide.", {
-        label: "Guide",
-        onClick: () => void import("@tauri-apps/plugin-shell").then((m) => m.open("https://yihui.org/tinytex/")),
+      const detail = e instanceof Error ? e.message : String(e);
+      const state = await tinytexInstallState().catch(() => null);
+      set({ partialDownloadBytes: state?.partial_download_bytes ?? 0 });
+      // The backend message already says whether progress was kept; show it
+      // verbatim instead of a generic apology.
+      toast.error(detail || "Could not install TinyTeX.", {
+        label: "Install guide",
+        onClick: () =>
+          void import("@tauri-apps/plugin-shell").then((m) =>
+            m.open("https://yihui.org/tinytex/"),
+          ),
       });
     } finally {
       unlisten();
-      set({ installing: false, progress: null });
+      set({ installing: false, installPhase: null, progress: null });
     }
   },
 
@@ -95,7 +150,7 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
     try {
       await deleteTinytex();
       toast.success("Removed TinyTeX");
-      set({ installed: [] });
+      set({ installed: [], partialDownloadBytes: 0 });
       void get().refresh();
     } catch (e) {
       void logError("delete tinytex", e);
@@ -130,4 +185,27 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
       set({ busyPkg: null });
     }
   },
+
+  queueCompileAfterInstall: () => {
+    set({ compileQueuedDuringInstall: true, installWaitNoticeOpen: true });
+  },
+
+  closeInstallWaitNotice: () => set({ installWaitNoticeOpen: false }),
 }));
+
+/** Human label for the current install phase, shared by modal and Settings. */
+export function installPhaseLabel(
+  phase: InstallPhase | null,
+  progress: number | null,
+): string {
+  switch (phase) {
+    case "download":
+      return progress != null ? `Downloading… ${progress}%` : "Downloading…";
+    case "extract":
+      return "Unpacking…";
+    case "packages":
+      return "Adding packages…";
+    default:
+      return "Installing…";
+  }
+}

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -11,6 +11,7 @@ import {
   gitRestore,
   getProject,
   getProjectEngine,
+  importOverleafProjectCmd,
   importPathsIntoProject as apiImportPathsIntoProject,
   listFiles,
   listProjects,
@@ -142,6 +143,7 @@ interface FilesStore {
   openProject: (id: string) => Promise<void>;
   closeProject: () => Promise<void>;
   createProject: (name: string) => Promise<void>;
+  importProject: (path: string) => Promise<string>;
   createTypstProject: (name: string) => Promise<void>;
   createMarkdownProject: (name: string) => Promise<void>;
   renameProject: (name: string) => Promise<void>;
@@ -568,6 +570,14 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     const meta = await renameProjectCmd(projectId, name);
     set({ projectName: meta.name });
     await get().refreshProjects();
+  },
+
+  importProject: async (path) => {
+    const id = await importOverleafProjectCmd(path);
+    await applyDefaultLatexEngine(id);
+    await get().refreshProjects();
+    await get().openProject(id);
+    return id;
   },
 
   createFromTemplate: async (name, templateId, color) => {

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -575,6 +575,15 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
   importProject: async (path) => {
     const id = await importOverleafProjectCmd(path);
     await applyDefaultLatexEngine(id);
+    const meta = await getProject(id).catch(() => null);
+    if (meta?.engine === "latexmk") {
+      // The import picked the full toolchain (system TeX detected): say so
+      // once, and capture the reproducibility pin in the background.
+      void recordProjectTexSpec(id).catch(() => {});
+      toast.info(
+        "Imported. Compiling with latexmk and your system TeX — the setup Overleaf projects expect.",
+      );
+    }
     await get().refreshProjects();
     await get().openProject(id);
     return id;

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -31,6 +31,11 @@ import { notifyError, toast } from "@/lib/toast";
 import { scanImportCompatibility } from "@oleafly/latex";
 import { cancelProofreading } from "@/lib/proofreading/client";
 import { useDiffStore } from "@/store/diff";
+import {
+  dismissEngineHint,
+  engineHintDismissed,
+  useEnginePickerStore,
+} from "@/store/engine-picker";
 import { useSettingsStore } from "@/store/settings";
 import { nextTabSeq } from "@/store/tab-order";
 
@@ -357,40 +362,80 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
       }
       await get().openFile(meta.main_doc || "main.tex");
       // Overleaf-import compatibility: surface known tool gaps early (biblatex,
-      // minted, glossaries, …) so compile failures are less mysterious.
+      // minted, glossaries, …) so compile failures are less mysterious. Scans
+      // the whole tree (bounded), not just the main document — Overleaf projects
+      // routinely keep the preamble in a file the main doc \inputs.
+      // Fire-and-forget: the scan reads files over IPC and must never delay
+      // the project becoming interactive. `seq` guards every state touch.
       if (seq === openSeq) {
+        void (async () => {
         try {
           const mainPath = meta.main_doc || "main.tex";
-          const mainContent =
-            get().files[mainPath]?.content ??
-            (await readFileContent(id, mainPath).catch(() => ""));
-          let latexmkrc: string | null = null;
-          if (tree.some((f) => !f.is_dir && f.path === "latexmkrc")) {
-            latexmkrc = await readFileContent(id, "latexmkrc").catch(() => null);
+          const depth = (p: string) => p.split("/").length;
+          const texPaths = tree
+            .filter((f) => !f.is_dir && /\.(tex|ltx|latex)$/i.test(f.path))
+            .map((f) => f.path)
+            .sort((a, b) =>
+              a === mainPath ? -1 : b === mainPath ? 1 : depth(a) - depth(b),
+            )
+            .slice(0, 40); // scanner input is capped anyway; keep IPC bounded
+          const texFiles: Array<{ path: string; content: string }> = [];
+          for (const path of texPaths) {
+            const content =
+              get().files[path]?.content ??
+              (await readFileContent(id, path).catch(() => ""));
+            if (seq !== openSeq) return;
+            if (content) texFiles.push({ path, content });
           }
-          const findings = scanImportCompatibility({
-            texFiles: [{ path: mainPath, content: mainContent }],
-            latexmkrc,
-          });
-          const blockers = findings.filter((f) => f.level === "blocker");
-          const warnings = findings.filter((f) => f.level === "warning");
-          if (blockers.length > 0) {
-            const extra = blockers.length > 1 ? ` (+${blockers.length - 1} more)` : "";
-            toast.info(`${blockers[0].title}${extra}`);
-          } else if (warnings.length > 0) {
-            if (warnings.some((f) => f.id === "biblatex-biber") && warnings.length === 1) {
-              toast.info("This project uses biblatex/Biber for the bibliography.");
-            } else {
+          const rcName = ["latexmkrc", ".latexmkrc"].find((name) =>
+            tree.some((f) => !f.is_dir && f.path === name),
+          );
+          const latexmkrc = rcName
+            ? await readFileContent(id, rcName).catch(() => null)
+            : null;
+          if (seq !== openSeq) return;
+          const findings = scanImportCompatibility({ texFiles, latexmkrc });
+          // A latexmk project already has the full toolchain; nothing to say.
+          // A previously acknowledged set of findings stays quiet too — the
+          // hint returns only when a new gap appears.
+          if (
+            findings.length > 0 &&
+            get().engine.id !== "latexmk" &&
+            !engineHintDismissed(id, findings)
+          ) {
+            const blockers = findings.filter((f) => f.level === "blocker");
+            const warnings = findings.filter((f) => f.level === "warning");
+            if (blockers.length > 0) {
+              const extra = blockers.length > 1 ? ` (+${blockers.length - 1} more)` : "";
               toast.info(
-                `${warnings.length} import note${warnings.length === 1 ? "" : "s"}: ${warnings[0].title}${
-                  warnings.length > 1 ? ` (+${warnings.length - 1} more)` : ""
-                }`,
+                `${blockers[0].title}${extra}`,
+                {
+                  label: "Choose engine…",
+                  onClick: () =>
+                    useEnginePickerStore
+                      .getState()
+                      .openPicker("project-open", findings),
+                },
+                true,
               );
+            } else if (warnings.length > 0) {
+              if (warnings.some((f) => f.id === "biblatex-biber") && warnings.length === 1) {
+                toast.info("This project uses biblatex/Biber for the bibliography.");
+              } else {
+                toast.info(
+                  `${warnings.length} import note${warnings.length === 1 ? "" : "s"}: ${warnings[0].title}${
+                    warnings.length > 1 ? ` (+${warnings.length - 1} more)` : ""
+                  }`,
+                );
+              }
+              // Plain notes need no decision; showing them once is enough.
+              dismissEngineHint(id, warnings);
             }
           }
         } catch {
           /* scan is best-effort */
         }
+        })();
       }
     } catch (e) {
       // Surface the failure and fall back to the library rather than leaving the

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -575,14 +575,15 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
   importProject: async (path) => {
     const id = await importOverleafProjectCmd(path);
     await applyDefaultLatexEngine(id);
+    // One toast for the whole import (callers stay silent on success). When
+    // the import picked the full toolchain, fold that into the same message
+    // and capture the reproducibility pin in the background.
     const meta = await getProject(id).catch(() => null);
     if (meta?.engine === "latexmk") {
-      // The import picked the full toolchain (system TeX detected): say so
-      // once, and capture the reproducibility pin in the background.
       void recordProjectTexSpec(id).catch(() => {});
-      toast.info(
-        "Imported. Compiling with latexmk and your system TeX — the setup Overleaf projects expect.",
-      );
+      toast.success("Project imported — compiling with latexmk (system TeX detected).");
+    } else {
+      toast.success("Project imported.");
     }
     await get().refreshProjects();
     await get().openProject(id);

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -18,6 +18,7 @@ import {
   renameFile as apiRenameFile,
   renameProjectCmd,
   setMainDocCmd,
+  setProjectEngineCmd,
   writeFileContent,
   type FileConflictStrategy,
   type FileEntry,
@@ -30,7 +31,20 @@ import { notifyError, toast } from "@/lib/toast";
 import { scanImportCompatibility } from "@oleafly/latex";
 import { cancelProofreading } from "@/lib/proofreading/client";
 import { useDiffStore } from "@/store/diff";
+import { useSettingsStore } from "@/store/settings";
 import { nextTabSeq } from "@/store/tab-order";
+
+// Pin the user's global default engine onto a freshly created project. Only
+// LaTeX projects can take the latexmk pin; anything else (Typst templates,
+// Markdown) rejects it in validation and simply keeps its own engine.
+async function applyDefaultLatexEngine(projectId: string): Promise<void> {
+  if (useSettingsStore.getState().defaultLatexEngine !== "latexmk") return;
+  try {
+    await setProjectEngineCmd(projectId, "latexmk");
+  } catch {
+    /* non-LaTeX project or validation refusal — keep the project's engine */
+  }
+}
 
 interface FileState {
   content: string;
@@ -86,6 +100,7 @@ interface FilesStore {
   applyExternalDelete: (path: string) => void;
   applyExternalRename: (from: string, to: string) => void;
   setMainDoc: (path: string) => Promise<void>;
+  setEngine: (engine: string) => Promise<void>;
 }
 
 let autosaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -418,6 +433,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
 
   createProject: async (name) => {
     const id = await apiCreateProject(name);
+    await applyDefaultLatexEngine(id);
     await get().refreshProjects();
     await get().openProject(id);
   },
@@ -444,6 +460,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
 
   createFromTemplate: async (name, templateId, color) => {
     const id = await apiCreateFromTemplate(name, templateId, color);
+    await applyDefaultLatexEngine(id);
     await get().refreshProjects();
     await get().openProject(id);
     return id;
@@ -818,6 +835,34 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
       const message = "Document engine details could not be loaded. Engine-specific actions are disabled.";
       set({ engine: UNKNOWN_ENGINE, engineLoaded: false, engineError: message });
       notifyError("set main document", error, message);
+      throw error;
+    }
+  },
+
+  setEngine: async (engineName) => {
+    const { projectId } = get();
+    if (!projectId) return;
+    // Same race protections as setMainDoc: an engine switch invalidates the
+    // current compile output and must not let a late descriptor request from a
+    // previous selection win.
+    const seq = ++mainDocSeq;
+    const compileStore = import("@/store/compile");
+    set({ engine: UNKNOWN_ENGINE, engineLoaded: false, engineError: null });
+    try {
+      const meta = await setProjectEngineCmd(projectId, engineName);
+      if (seq !== mainDocSeq || get().projectId !== projectId) return;
+      const compile = await compileStore;
+      if (seq !== mainDocSeq || get().projectId !== projectId) return;
+      compile.useCompileStore.getState().reset();
+      set({ mainDoc: meta.main_doc });
+      const engine = await getProjectEngine(projectId);
+      if (seq !== mainDocSeq || get().projectId !== projectId) return;
+      set({ engine, engineLoaded: true, engineError: null });
+    } catch (error) {
+      if (seq !== mainDocSeq || get().projectId !== projectId) return;
+      const message = "Document engine details could not be loaded. Engine-specific actions are disabled.";
+      set({ engine: UNKNOWN_ENGINE, engineLoaded: false, engineError: message });
+      notifyError("set compile engine", error, message);
       throw error;
     }
   },

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -16,9 +16,12 @@ import {
   listProjects,
   readFileContent,
   renameFile as apiRenameFile,
+  projectTexStatus,
+  recordProjectTexSpec,
   renameProjectCmd,
   setMainDocCmd,
   setProjectEngineCmd,
+  tlmgrInstall,
   writeFileContent,
   type FileConflictStrategy,
   type FileEntry,
@@ -46,8 +49,65 @@ async function applyDefaultLatexEngine(projectId: string): Promise<void> {
   if (useSettingsStore.getState().defaultLatexEngine !== "latexmk") return;
   try {
     await setProjectEngineCmd(projectId, "latexmk");
+    void recordProjectTexSpec(projectId).catch(() => {});
   } catch {
     /* non-LaTeX project or validation refusal — keep the project's engine */
+  }
+}
+
+// Compare this machine against a latexmk project's TeX pin. Missing pinned
+// packages get an actionable toast; a differing distribution gets a one-time
+// heads-up. Both remember what was shown so reopening a project stays quiet.
+async function checkTexPinStatus(
+  projectId: string,
+  stillCurrent: () => boolean,
+): Promise<void> {
+  const status = await projectTexStatus(projectId).catch(() => null);
+  if (!status || !stillCurrent()) return;
+  const remember = (key: string, value: string): boolean => {
+    try {
+      if (localStorage.getItem(key) === value) return false;
+      localStorage.setItem(key, value);
+      return true;
+    } catch {
+      return true;
+    }
+  };
+  const missing = status.missing_packages;
+  if (missing.length > 0 && status.can_install_missing) {
+    const fresh = remember(`oleafly.texGap.${projectId}`, [...missing].sort().join(","));
+    if (!fresh) return;
+    toast.info(
+      `This project pins ${missing.length} LaTeX package${missing.length === 1 ? "" : "s"} that ${missing.length === 1 ? "is" : "are"} not installed here.`,
+      {
+        label: missing.length === 1 ? "Install it" : `Install all ${missing.length}`,
+        onClick: () => {
+          void (async () => {
+            toast.info(`Installing ${missing.length} pinned package${missing.length === 1 ? "" : "s"}…`);
+            try {
+              await tlmgrInstall(missing);
+              toast.success("Pinned LaTeX packages installed.");
+            } catch (error) {
+              notifyError(
+                "install pinned packages",
+                error,
+                "Some pinned packages could not be installed. See Settings → LaTeX Engine.",
+              );
+            }
+          })();
+        },
+      },
+      true,
+    );
+  } else if (status.distribution_differs && status.local_label) {
+    const fresh = remember(
+      `oleafly.texSkew.${projectId}`,
+      `${status.pinned_label}|${status.local_label}`,
+    );
+    if (!fresh) return;
+    toast.info(
+      `This project was pinned with ${status.pinned_label}; this machine compiles with ${status.local_label}. Output may differ slightly.`,
+    );
   }
 }
 
@@ -370,6 +430,13 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
       if (seq === openSeq) {
         void (async () => {
         try {
+          // latexmk projects already have the full toolchain; instead of the
+          // import scan, check this machine against the project's TeX pin so
+          // coauthors get the same packages (and know about distro skew).
+          if (get().engine.id === "latexmk") {
+            await checkTexPinStatus(id, () => seq === openSeq && get().projectId === id);
+            return;
+          }
           const mainPath = meta.main_doc || "main.tex";
           const depth = (p: string) => p.split("/").length;
           const texPaths = tree
@@ -895,6 +962,9 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     set({ engine: UNKNOWN_ENGINE, engineLoaded: false, engineError: null });
     try {
       const meta = await setProjectEngineCmd(projectId, engineName);
+      // Capture the reproducibility pin (distro + tlmgr packages) for the new
+      // latexmk project in the background; slow tlmgr calls stay off this path.
+      if (engineName === "latexmk") void recordProjectTexSpec(projectId).catch(() => {});
       if (seq !== mainDocSeq || get().projectId !== projectId) return;
       const compile = await compileStore;
       if (seq !== mainDocSeq || get().projectId !== projectId) return;

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -581,7 +581,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     const meta = await getProject(id).catch(() => null);
     if (meta?.engine === "latexmk") {
       void recordProjectTexSpec(id).catch(() => {});
-      toast.success("Project imported — compiling with latexmk (system TeX detected).");
+      toast.success("Project imported. Compiling with latexmk (system TeX detected).");
     } else {
       toast.success("Project imported.");
     }

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -277,7 +277,18 @@ interface SettingsState {
   setVisualEditor: (v: boolean) => void;
   latexTools: boolean;
   setLatexTools: (v: boolean) => void;
+  // Engine for NEW LaTeX projects: "tectonic" (bundled, zero-setup) or
+  // "latexmk" (system TeX; full Overleaf tool parity). Existing projects keep
+  // their own pin in project.json.
+  defaultLatexEngine: DefaultLatexEngine;
+  setDefaultLatexEngine: (v: DefaultLatexEngine) => void;
   resetToDefaults: () => void;
+}
+
+export type DefaultLatexEngine = "tectonic" | "latexmk";
+
+function readDefaultLatexEngine(raw: string): DefaultLatexEngine {
+  return raw === "latexmk" ? "latexmk" : "tectonic";
 }
 
 const PREF_DEFAULTS = {
@@ -302,6 +313,7 @@ const PREF_DEFAULTS = {
   bgPattern: "dots" as BackgroundPattern,
   visualEditor: false,
   latexTools: false,
+  defaultLatexEngine: "tectonic" as DefaultLatexEngine,
 } as const;
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
@@ -516,6 +528,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         break;
     }
   },
+  defaultLatexEngine: readDefaultLatexEngine(ls("oleafly.defaultLatexEngine", "tectonic")),
+  setDefaultLatexEngine: (v) => {
+    saveLs("oleafly.defaultLatexEngine", v);
+    set({ defaultLatexEngine: v });
+  },
   resetToDefaults: () => {
     // Drop the persisted copies so a restart doesn't resurrect old values.
     saveLs("oleafly.vim", PREF_DEFAULTS.vim ? "1" : "0");
@@ -537,6 +554,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     saveLs("oleafly.bgPattern", PREF_DEFAULTS.bgPattern);
     saveLs("oleafly.visualEditor", PREF_DEFAULTS.visualEditor ? "1" : "0");
     saveLs("oleafly.latexTools", PREF_DEFAULTS.latexTools ? "1" : "0");
+    saveLs("oleafly.defaultLatexEngine", PREF_DEFAULTS.defaultLatexEngine);
     set({ ...PREF_DEFAULTS });
     notifyProofreadingSettingsChanged("reset", get());
   },


### PR DESCRIPTION
Closes #42.

## What this delivers

Importing a project from Overleaf now works end to end: bring in the ZIP (or a plain folder), Oleafly picks the right main document, selects the right compile engine, and the project builds the same way it did on Overleaf. Two collaborators opening the same project get the same engine and the same package setup.

## Import from Overleaf

- New **Import** action in the Library header and in the template chooser (next to "Generate a template with AI"). Accepts an Overleaf ZIP export or a plain folder.
- The main document is inferred automatically. A `% !TeX root` magic comment wins, otherwise `\documentclass` / `\begin{document}` scoring picks the entry, and a lone `.tex` file is used as is. Oleafly-exported archives round-trip their own `project.json`.
- Extraction is hardened: path traversal rejected, entry/size/depth caps, junk filtered, a single wrapping folder unwrapped.

## latexmk engine (system TeX)

- A new engine wired through the existing `DocumentEngine` trait drives `latexmk` against the real main document, so Biber, makeindex/makeglossaries, pythontex, shell-escape, and multi-pass builds are orchestrated exactly the way Overleaf does. `-jobname` keeps every artifact on the same paths Tectonic uses, so preview, logs, and SyncTeX work unchanged.
- TeX flavor is chosen from the source: `% !TeX program` comment first, fontspec/polyglossia force XeLaTeX, pdfLaTeX is the default (Overleaf's default). Shell-escape is enabled only when the document actually needs it.
- Shared discovery (`tex_distro`) finds MacTeX, TeX Live by year, MiKTeX, and TinyTeX on macOS, Windows, and Linux, and also feeds the compile child's PATH.
- **Imported LaTeX projects select latexmk automatically when a system TeX is detected.** Everything else stays on the bundled Tectonic engine.

## Engine choice that explains itself

- The import-compat taxonomy is now a single catalog consumed by the project-open scan (whole tree, plus `latexmkrc`), the compile-failure classifier, and the engine-picker modal, so every surface tells one story.
- A failed Tectonic compile that matches a known gap (minted, missing index run, shell-escape refusal, unresolved Biber, pdfTeX-only primitives) opens a three-option modal: use system TeX, download TinyTeX, or keep Tectonic. Errors that originate in a publisher class or style file are treated as engine gaps too, which covers journal classes without a specific signature. Errors in the user's own files never trigger it.
- Per-project engine switch lives in the compile options menu. Settings gains a default engine for new projects and a "Manage TeX distributions" panel.

## Seamless TinyTeX install

- Free disk space is checked before a byte is downloaded, with exact numbers in the message.
- Phased progress (download, unpack, packages), resumable downloads across launches after a failure or force-quit, and a retry that continues instead of starting over.
- Starting an install pauses a running compile and re-queues it. Compiling mid-install shows a clear notice and the queued compile fires when the install lands.
- Closing the window or pressing Cmd+Q during an install asks for confirmation. The partial download survives either way.

## Reproducibility

- `project.json` is the portable contract: it pins the engine and a TeX spec (distribution plus tlmgr package versions) so the setup travels with git. Coauthors opening the project are prompted to install missing pinned packages with one click, and a differing distribution gets a one-time heads-up.
- Every successful compile writes a provenance record (engine, distribution, lockfile hash, output fingerprint) under `.oleafly/builds/`, pruned to the last 20.
- `docs/CompilationEngines.md` documents the engine and why the pin lives in `project.json` rather than the gitignored `.oleafly/`.

## Fixes found during manual validation

- Springer's `sn-jnl` class fails under Tectonic with pdfTeX-primitive errors from inside the class file. That failure shape is now a recognized signature, and the import default makes it a non-event when system TeX exists. Verified: the template compiles cleanly through the new engine.
- `tlmgr info --data revision` is rejected by TeX Live 2025, which silently emptied the package pin. Switched to `name,cat-version`.
- One import toast instead of stacked notifications, and notification copy across the app rewritten into plain short sentences.

## Verification

- Real publisher templates (IEEE, ACM, Elsevier, Springer) plus targeted projects for each gap were imported and compiled during manual validation on macOS with MacTeX.
- 1,650 frontend tests, 213 Rust tests, clippy, and the full build pass on every commit.
- Unit coverage is in: compile-failure signatures, missing-package extraction, latexmk flavor and argument shape, main-document inference, wrapper flattening, and the TexSpec round-trip (1,668 frontend tests, 224 Rust tests). A new e2e spec (63-overleaf-import) covers wrapped ZIP import with magic-root inference, lone .tex entry selection, and the scan toast to engine-picker flow; it runs with the next full e2e sweep.
- A failed latexmk compile that reports a missing .sty or .cls now offers a one-click tlmgr install of the named packages and recompiles automatically.

## Follow-ups

- Pin `TINYTEX_TAG` to a fixed release before shipping (currently the moving `daily` tag).
- Cross-platform validation on Windows (MiKTeX) and Linux.
- Optional: tighten the structure-panel partial banner for packs that bundle their own documentation sources.
