### PR TITLE
Overleaf-style compiler choice, editor preferences, and TeX distribution fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Overleaf-style compiler choice.** The compile options menu now offers
+  pdfLaTeX, XeLaTeX, and LuaLaTeX alongside Tectonic and Auto. An explicit
+  choice pins the compiler in `project.json` and overrides source detection,
+  exactly like Overleaf's Compiler setting. Auto keeps the existing behavior:
+  the magic comment or font packages decide, with pdfLaTeX as the default.
+- **Editor preferences.** Settings gains three toggles: Auto-complete
+  (suggestions while typing, with Ctrl+Space always available), Auto-close
+  brackets, and Non-blinking cursor. All three apply instantly without
+  reopening the editor.
+
 ## [0.3.5] - 2026-08-06
 
 ### Added

--- a/e2e/tests/64-compiler-choice.spec.ts
+++ b/e2e/tests/64-compiler-choice.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from "../fixtures";
+import {
+  createBlankProject,
+  openProject,
+  waitLong,
+  type Page,
+} from "../helpers";
+
+// The per-project compiler pin (Overleaf's Compiler setting): picking
+// pdfLaTeX / XeLaTeX / LuaLaTeX moves the project onto latexmk and stores the
+// choice in project.json, Tectonic clears it. Nothing here compiles: CI has no
+// TeX distribution, and the pin is persisted by set_project_engine, which
+// validates the engine against the main document without probing for binaries.
+
+const PROJECT = "Compiler Pin";
+
+// Radix dropdown triggers and menu items react to pointer events, not to the
+// bridge's synthetic element.click().
+function pressWithPointer(selectorExpr: string): string {
+  return `(() => {
+    const el = ${selectorExpr};
+    if (!el) return false;
+    el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerId: 1 }));
+    el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true, pointerId: 1 }));
+    el.click();
+    return true;
+  })()`;
+}
+
+// The default-engine preference decides what a NEW project starts on, and it
+// persists in localStorage across runs. Pin it so these specs assert the
+// per-project choice rather than whatever the machine was left on.
+async function useTectonicDefault(page: Page) {
+  await page.evaluate(
+    `import("/src/store/settings.ts").then((m) => {
+      m.useSettingsStore.getState().setDefaultLatexEngine("tectonic");
+      return 1;
+    })`,
+  );
+}
+
+// Every test starts on a freshly reloaded SPA sitting in the library, so each
+// one opens the project itself instead of inheriting the previous test's view.
+async function openCompilerProject(page: Page) {
+  await waitLong(
+    page,
+    `!!document.querySelector('[data-testid="library"][data-projects-loaded="true"]')`,
+    30_000,
+  );
+  await useTectonicDefault(page);
+  const exists = await page.evaluate<boolean>(
+    `import("/src/store/files.ts").then((m) =>
+      m.useFilesStore.getState().projects.some((p) => p.name === ${JSON.stringify(PROJECT)}))`,
+  );
+  if (exists) {
+    await openProject(page, PROJECT);
+    await waitLong(
+      page,
+      `!!document.querySelector('[data-tour="project-editor"] .cm-content')`,
+      30_000,
+    );
+  } else {
+    await createBlankProject(page, PROJECT);
+  }
+  await waitLong(
+    page,
+    `import("/src/store/files.ts").then((m) => m.useFilesStore.getState().engineLoaded)`,
+    20_000,
+  );
+}
+
+async function openCompileMenu(page: Page) {
+  const opened = await page.evaluate<boolean>(
+    pressWithPointer(
+      `document.querySelector('[data-testid="compile-options-button"]')`,
+    ),
+  );
+  if (!opened) throw new Error("compile options trigger not found");
+  await waitLong(
+    page,
+    `!!document.querySelector('[data-testid="compiler-tectonic"]')`,
+    10_000,
+  );
+}
+
+async function chooseCompiler(page: Page, testid: string) {
+  await openCompileMenu(page);
+  const clicked = await page.evaluate<boolean>(
+    pressWithPointer(`document.querySelector('[data-testid="${testid}"]')`),
+  );
+  if (!clicked) throw new Error(`compiler item ${testid} not found`);
+}
+
+async function engineState(page: Page) {
+  return page.evaluate<{ id: string; flavor: string | null }>(
+    `import("/src/store/files.ts").then((m) => {
+      const engine = m.useFilesStore.getState().engine;
+      return { id: engine.id, flavor: engine.tex_flavor ?? null };
+    })`,
+  );
+}
+
+async function waitForEngine(page: Page, id: string, flavor: string | null) {
+  await waitLong(
+    page,
+    `import("/src/store/files.ts").then((m) => {
+      const engine = m.useFilesStore.getState().engine;
+      return engine.id === ${JSON.stringify(id)}
+        && (engine.tex_flavor ?? null) === ${JSON.stringify(flavor)};
+    })`,
+    20_000,
+  );
+}
+
+// The selected radio item is the one Radix marks checked.
+async function checkedCompiler(page: Page): Promise<string | null> {
+  return page.evaluate<string | null>(
+    `(() => {
+      const checked = [...document.querySelectorAll('[role="menuitemradio"]')]
+        .find((item) => item.getAttribute("aria-checked") === "true"
+          && (item.getAttribute("data-testid") ?? "").startsWith("compiler-"));
+      return checked ? checked.getAttribute("data-testid") : null;
+    })()`,
+  );
+}
+
+test("a new LaTeX project starts on Tectonic with no compiler pinned", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(180_000);
+  await waitLong(
+    tauriPage,
+    `!!document.querySelector('[data-testid="library"][data-projects-loaded="true"]')`,
+    30_000,
+  );
+  await useTectonicDefault(tauriPage);
+  // Always a brand new project: the claim under test is about what a project
+  // starts as, which an already-pinned one from an earlier test cannot show.
+  await createBlankProject(tauriPage, "Compiler Default");
+  await waitLong(
+    tauriPage,
+    `import("/src/store/files.ts").then((m) => m.useFilesStore.getState().engineLoaded)`,
+    20_000,
+  );
+  const initial = await engineState(tauriPage);
+  expect(initial.id).toBe("latex");
+  expect(initial.flavor).toBeNull();
+
+  await openCompileMenu(tauriPage);
+  expect(await checkedCompiler(tauriPage)).toBe("compiler-tectonic");
+  await tauriPage.press("body", "Escape");
+});
+
+test("picking pdfLaTeX moves the project to latexmk and pins the compiler", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(180_000);
+  await openCompilerProject(tauriPage);
+  await chooseCompiler(tauriPage, "compiler-pdflatex");
+  await waitForEngine(tauriPage, "latexmk", "pdflatex");
+
+  // The menu reflects the stored pin, not just the engine.
+  await openCompileMenu(tauriPage);
+  expect(await checkedCompiler(tauriPage)).toBe("compiler-pdflatex");
+  await tauriPage.press("body", "Escape");
+});
+
+test("the pinned compiler survives closing and reopening the project", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(180_000);
+  await openCompilerProject(tauriPage);
+  await chooseCompiler(tauriPage, "compiler-xelatex");
+  await waitForEngine(tauriPage, "latexmk", "xelatex");
+
+  await tauriPage.click('[title="Back to library"]');
+  await openProject(tauriPage, PROJECT);
+  await waitLong(
+    tauriPage,
+    `!!document.querySelector('[data-tour="project-editor"] .cm-content')`,
+    30_000,
+  );
+  // project.json carried the choice, so the reopened project is still pinned.
+  await waitForEngine(tauriPage, "latexmk", "xelatex");
+});
+
+test("switching compilers repins without leaving the latexmk engine", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(180_000);
+  await openCompilerProject(tauriPage);
+  await chooseCompiler(tauriPage, "compiler-pdflatex");
+  await waitForEngine(tauriPage, "latexmk", "pdflatex");
+  await chooseCompiler(tauriPage, "compiler-lualatex");
+  await waitForEngine(tauriPage, "latexmk", "lualatex");
+});
+
+test("Auto keeps latexmk but clears the pin so the source decides", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(180_000);
+  await openCompilerProject(tauriPage);
+  await chooseCompiler(tauriPage, "compiler-pdflatex");
+  await waitForEngine(tauriPage, "latexmk", "pdflatex");
+  await chooseCompiler(tauriPage, "compiler-auto");
+  await waitForEngine(tauriPage, "latexmk", null);
+
+  await openCompileMenu(tauriPage);
+  expect(await checkedCompiler(tauriPage)).toBe("compiler-auto");
+  await tauriPage.press("body", "Escape");
+});
+
+test("Tectonic returns the project to the bundled engine and drops the pin", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(180_000);
+  await openCompilerProject(tauriPage);
+  await chooseCompiler(tauriPage, "compiler-pdflatex");
+  await waitForEngine(tauriPage, "latexmk", "pdflatex");
+  await chooseCompiler(tauriPage, "compiler-tectonic");
+  await waitForEngine(tauriPage, "latex", null);
+});

--- a/e2e/tests/65-editor-preferences.spec.ts
+++ b/e2e/tests/65-editor-preferences.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from "../fixtures";
+import {
+  createBlankProject,
+  editorSource,
+  openProject,
+  openSettings,
+  replaceEditorSource,
+  waitLong,
+  type Page,
+} from "../helpers";
+
+// Editor preferences (Auto-complete, Auto-close brackets, Non-blinking
+// cursor). Each one must reconfigure the live editor through its compartment,
+// so every assertion here is made against the running CodeMirror instance
+// rather than the settings store alone.
+
+const PROJECT = "Editor Prefs";
+
+// Every test starts on a freshly reloaded SPA sitting in the library, so each
+// one opens the editor itself instead of inheriting the previous test's view.
+async function openPrefsProject(page: Page) {
+  await waitLong(
+    page,
+    `!!document.querySelector('[data-testid="library"][data-projects-loaded="true"]')`,
+    30_000,
+  );
+  const exists = await page.evaluate<boolean>(
+    `import("/src/store/files.ts").then((m) =>
+      m.useFilesStore.getState().projects.some((p) => p.name === ${JSON.stringify(PROJECT)}))`,
+  );
+  if (exists) {
+    await openProject(page, PROJECT);
+  } else {
+    await createBlankProject(page, PROJECT);
+  }
+  await waitLong(page, `!!document.querySelector('.cm-content')`, 30_000);
+}
+
+async function toggleSetting(page: Page, label: string, on: boolean) {
+  await openSettings(page, "general");
+  const selector = `[role="switch"][aria-label="${label}"]`;
+  await waitLong(page, `!!document.querySelector('${selector}')`, 10_000);
+  const already = await page.evaluate<boolean>(
+    `document.querySelector('${selector}')?.getAttribute("aria-checked") === "true"`,
+  );
+  if (already !== on) {
+    await page.click(selector);
+    await waitLong(
+      page,
+      `document.querySelector('${selector}')?.getAttribute("aria-checked") === "${on}"`,
+      10_000,
+    );
+  }
+  // The backdrop shares the "Close settings" aria-label with the header
+  // button, so target the button by test id.
+  await page.click('[data-testid="settings-close"]');
+  await waitLong(
+    page,
+    `!document.querySelector('[data-testid="settings-section-appearance"]')`,
+    10_000,
+  );
+  await waitLong(page, `!!document.querySelector('.cm-content')`, 10_000);
+}
+
+// Real typing, one character per input event. execCommand drives the DOM input
+// path, which is the only route CodeMirror's input handlers (and therefore
+// bracket closing and the completion popup) observe, and bracket closing only
+// fires when the inserted text is the single bracket character. A dispatched
+// transaction, or one multi-character insert, would bypass both and prove
+// nothing.
+async function typeAtCaret(page: Page, text: string) {
+  for (const character of text) {
+    const ok = await page.evaluate<boolean>(
+      `(() => {
+        const content = document.querySelector('.cm-content');
+        if (!content) return false;
+        content.focus();
+        return document.execCommand('insertText', false, ${JSON.stringify(character)});
+      })()`,
+    );
+    if (!ok) throw new Error(`typeAtCaret: editor rejected ${character}`);
+  }
+}
+
+async function caretToEnd(page: Page) {
+  await page.evaluate(
+    `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) => {
+      const view = getEditorView();
+      view.dispatch({ selection: { anchor: view.state.doc.length } });
+      view.focus();
+      return 1;
+    })`,
+  );
+}
+
+// Give an asynchronous surface time to appear before asserting it did not.
+async function settle(page: Page, ms: number) {
+  await page.evaluate(
+    `new Promise((resolve) => setTimeout(() => resolve(1), ${ms}))`,
+  );
+}
+
+async function cursorBlinkDuration(page: Page): Promise<string> {
+  return page.evaluate<string>(
+    `document.querySelector('.cm-cursorLayer')?.style.animationDuration ?? ""`,
+  );
+}
+
+test("auto-close brackets inserts the closing brace, and stops when turned off", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openPrefsProject(tauriPage);
+
+  await toggleSetting(tauriPage, "Auto-close brackets", true);
+  await replaceEditorSource(tauriPage, "\\documentclass{article}\n");
+  await caretToEnd(tauriPage);
+  await typeAtCaret(tauriPage, "\\textbf{");
+  await expect
+    .poll(async () => await editorSource(tauriPage), { timeout: 10_000 })
+    .toContain("\\textbf{}");
+
+  await toggleSetting(tauriPage, "Auto-close brackets", false);
+  await replaceEditorSource(tauriPage, "\\documentclass{article}\n");
+  await caretToEnd(tauriPage);
+  await typeAtCaret(tauriPage, "\\textit{");
+  // Give the editor the same settling time the enabled case got before
+  // asserting the closing brace is absent.
+  await expect
+    .poll(async () => await editorSource(tauriPage), { timeout: 10_000 })
+    .toContain("\\textit{");
+  expect(await editorSource(tauriPage)).not.toContain("\\textit{}");
+});
+
+test("auto-complete opens the popup while typing, and stays closed when off", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openPrefsProject(tauriPage);
+  await toggleSetting(tauriPage, "Auto-complete", true);
+  await replaceEditorSource(
+    tauriPage,
+    "\\documentclass{article}\n\\begin{document}\n\n\\end{document}\n",
+  );
+  await tauriPage.evaluate(
+    `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) => {
+      const view = getEditorView();
+      const at = view.state.doc.toString().indexOf("\\\\begin{document}") + "\\\\begin{document}".length + 1;
+      view.dispatch({ selection: { anchor: at } });
+      view.focus();
+      return 1;
+    })`,
+  );
+  await typeAtCaret(tauriPage, "\\alph");
+  await waitLong(
+    tauriPage,
+    `!!document.querySelector('.cm-tooltip-autocomplete')`,
+    15_000,
+  );
+
+  await toggleSetting(tauriPage, "Auto-complete", false);
+  await replaceEditorSource(
+    tauriPage,
+    "\\documentclass{article}\n\\begin{document}\n\n\\end{document}\n",
+  );
+  await caretToEnd(tauriPage);
+  await typeAtCaret(tauriPage, "\\alph");
+  // The popup is asynchronous. Polling would pass on its first read, before a
+  // late popup could appear, so wait out the completion delay first and then
+  // assert it never opened.
+  await settle(tauriPage, 3_000);
+  expect(
+    await tauriPage.evaluate<boolean>(
+      `!!document.querySelector('.cm-tooltip-autocomplete')`,
+    ),
+  ).toBe(false);
+});
+
+test("the non-blinking cursor stops the cursor animation", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openPrefsProject(tauriPage);
+  await toggleSetting(tauriPage, "Non-blinking cursor", false);
+  await expect
+    .poll(async () => await cursorBlinkDuration(tauriPage), { timeout: 10_000 })
+    .not.toBe("0ms");
+
+  await toggleSetting(tauriPage, "Non-blinking cursor", true);
+  // A zero blink rate is how CodeMirror renders a solid cursor.
+  await expect
+    .poll(async () => await cursorBlinkDuration(tauriPage), { timeout: 10_000 })
+    .toBe("0ms");
+
+  // The editor keeps working after the compartment reconfigures.
+  await replaceEditorSource(tauriPage, "\\documentclass{article}\n");
+  await caretToEnd(tauriPage);
+  await typeAtCaret(tauriPage, "solid");
+  await expect
+    .poll(async () => await editorSource(tauriPage), { timeout: 10_000 })
+    .toContain("solid");
+});
+
+test("editor preferences persist across a reload", async ({ tauriPage }) => {
+  test.setTimeout(240_000);
+  await openPrefsProject(tauriPage);
+  await toggleSetting(tauriPage, "Auto-complete", false);
+  await toggleSetting(tauriPage, "Non-blinking cursor", true);
+  const stored = await tauriPage.evaluate<string>(
+    `[
+      localStorage.getItem("oleafly.editor.autocomplete"),
+      localStorage.getItem("oleafly.editor.solidCursor"),
+    ].join(",")`,
+  );
+  expect(stored).toBe("0,1");
+
+  // Restore the defaults so later specs in the shared app instance are not
+  // left with completions disabled.
+  await toggleSetting(tauriPage, "Auto-complete", true);
+  await toggleSetting(tauriPage, "Non-blinking cursor", false);
+});

--- a/packages/editor/src/CodeMirrorEditor.test.ts
+++ b/packages/editor/src/CodeMirrorEditor.test.ts
@@ -62,6 +62,9 @@ describe("CodeMirrorEditor measurement", () => {
         spellcheck: false,
         harper: false,
         editorTheme: "system",
+        autocomplete: true,
+        autoCloseBrackets: true,
+        nonBlinkingCursor: false,
       }),
       useLintRefreshDeps: () => [],
     };

--- a/packages/editor/src/CodeMirrorEditor.tsx
+++ b/packages/editor/src/CodeMirrorEditor.tsx
@@ -62,7 +62,18 @@ export interface EditorHost {
   useDocVersion(): number;
   getContent(path: string): string;
   setContent(path: string, content: string): void;
-  useSettings(): { vim: boolean; spellcheck: boolean; harper: boolean; editorTheme: string };
+  useSettings(): {
+    vim: boolean;
+    spellcheck: boolean;
+    harper: boolean;
+    editorTheme: string;
+    /** Completion popups while typing; explicit Ctrl+Space always works. */
+    autocomplete: boolean;
+    /** Auto-insert closing brackets, parentheses, and quotes. */
+    autoCloseBrackets: boolean;
+    /** Keep the cursor solid instead of blinking. */
+    nonBlinkingCursor: boolean;
+  };
   useLintRefreshDeps(): readonly unknown[];
 }
 
@@ -78,6 +89,7 @@ const isMarkdownDocumentPath = (path: string | null): boolean =>
 function sourceToolsForPath(
   path: string | null,
   completionSources: CompletionSource[],
+  autocompleteWhileTyping: boolean,
 ): Extension[] {
   const mathPreview = isLatexDocumentPath(path)
     ? [liveMathPreview("latex")]
@@ -96,7 +108,7 @@ function sourceToolsForPath(
             : latexCompletions,
           slashCompletions,
         ],
-        activateOnTyping: true,
+        activateOnTyping: autocompleteWhileTyping,
         closeOnBlur: true,
       }),
       ...mathPreview,
@@ -110,11 +122,24 @@ function sourceToolsForPath(
       ? [
           autocompletion({
             override: completionSources,
-            activateOnTyping: true,
+            activateOnTyping: autocompleteWhileTyping,
             closeOnBlur: true,
           }),
         ]
       : []),
+  ];
+}
+
+// Bracket auto-closing and cursor rendering, both user preferences that must
+// reconfigure without recreating the editor.
+function editorPrefExtensions(
+  autoCloseBrackets: boolean,
+  nonBlinkingCursor: boolean,
+): Extension[] {
+  return [
+    autoCloseBrackets ? closeBrackets() : [],
+    // A zero blink cycle keeps the cursor permanently visible.
+    drawSelection(nonBlinkingCursor ? { cursorBlinkRate: 0 } : {}),
   ];
 }
 
@@ -146,6 +171,7 @@ export function CodeMirrorEditor({
   const prevPathRef = useRef<string | null>(null);
   const suppressSyncRef = useRef(false);
 
+  const editorPrefsCompartmentRef = useRef<Compartment | null>(null);
   const activePath = host.useActivePath();
   // NB: the active file's content is read imperatively (host.getContent) inside
   // the file-swap effect below, NOT subscribed to. Subscribing here would
@@ -153,7 +179,15 @@ export function CodeMirrorEditor({
   // edit), which is pure waste since CodeMirror owns the document and the
   // effect only needs the content when the file or docVersion actually changes.
   const docVersion = host.useDocVersion();
-  const { vim: vimEnabled, spellcheck, harper, editorTheme: editorThemeId } = host.useSettings();
+  const {
+    vim: vimEnabled,
+    spellcheck,
+    harper,
+    editorTheme: editorThemeId,
+    autocomplete,
+    autoCloseBrackets,
+    nonBlinkingCursor,
+  } = host.useSettings();
   const lintDeps = host.useLintRefreshDeps();
 
   // Construct during the layout phase. The corrective measurement effect
@@ -176,6 +210,8 @@ export function CodeMirrorEditor({
     sourceToolsCompartmentRef.current = sourceToolsCompartment;
     const hostToolsCompartment = new Compartment();
     hostToolsCompartmentRef.current = hostToolsCompartment;
+    const editorPrefsCompartment = new Compartment();
+    editorPrefsCompartmentRef.current = editorPrefsCompartment;
     prevPathRef.current = initialPath;
     const initialLang = initialPath ? languageForPath(initialPath) : null;
     const initialCompletionSources =
@@ -189,13 +225,14 @@ export function CodeMirrorEditor({
         highlightSpecialChars(),
         foldGutter({ markerDOM: foldMarkerDOM }),
         foldMarkerTheme,
-        drawSelection(),
+        editorPrefsCompartment.of(
+          editorPrefExtensions(autoCloseBrackets, nonBlinkingCursor),
+        ),
         dropCursor(),
         EditorState.allowMultipleSelections.of(true),
         indentOnInput(),
         indentUnit.of("    "),
         bracketMatching(),
-        closeBrackets(),
         rectangularSelection(),
         crosshairCursor(),
         highlightActiveLineWhenCollapsed(),
@@ -207,7 +244,7 @@ export function CodeMirrorEditor({
         historyCompartment.of(history()),
         vscodeSearch(),
         sourceToolsCompartment.of(
-          sourceToolsForPath(initialPath, initialCompletionSources),
+          sourceToolsForPath(initialPath, initialCompletionSources, autocomplete),
         ),
         ...(extraExtensions ?? []),
         hostToolsCompartment.of(extraExtensionsForPath?.(initialPath) ?? []),
@@ -320,7 +357,7 @@ export function CodeMirrorEditor({
     const effects = [langCompartmentRef.current!.reconfigure(lang ? lang : [])];
     effects.push(
       sourceToolsCompartmentRef.current!.reconfigure(
-        sourceToolsForPath(activePath, completionSources),
+        sourceToolsForPath(activePath, completionSources, autocomplete),
       ),
     );
     effects.push(
@@ -368,6 +405,39 @@ export function CodeMirrorEditor({
       effects: compartment.reconfigure(vimEnabled ? vim() : []),
     });
   }, [vimEnabled]);
+
+  // Toggle bracket auto-closing and cursor blinking without recreating the
+  // editor.
+  useEffect(() => {
+    const view = viewRef.current;
+    const compartment = editorPrefsCompartmentRef.current;
+    if (!view || !compartment) return;
+    view.dispatch({
+      effects: compartment.reconfigure(
+        editorPrefExtensions(autoCloseBrackets, nonBlinkingCursor),
+      ),
+    });
+  }, [autoCloseBrackets, nonBlinkingCursor]);
+
+  // Toggle completion-while-typing without recreating the editor. Completions
+  // live inside the source-tools compartment, so rebuild it for the current
+  // path.
+  useEffect(() => {
+    const view = viewRef.current;
+    const compartment = sourceToolsCompartmentRef.current;
+    if (!view || !compartment) return;
+    const path = host.getActivePath();
+    view.dispatch({
+      effects: compartment.reconfigure(
+        sourceToolsForPath(
+          path,
+          extraCompletionSourcesForPath?.(path) ?? [],
+          autocomplete,
+        ),
+      ),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autocomplete]);
 
   // Toggle spellcheck / Harper grammar without recreating the editor.
   useEffect(() => {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -60,7 +60,9 @@ pub fn project_engine(
     project_id: String,
 ) -> Result<crate::document_engine::EngineDescriptor, String> {
     let meta = crate::project::read_meta(&project_id)?;
-    crate::document_engine::descriptor_for(&meta.engine, &meta.main_doc)
+    let mut descriptor = crate::document_engine::descriptor_for(&meta.engine, &meta.main_doc)?;
+    descriptor.tex_flavor = meta.tex_flavor;
+    Ok(descriptor)
 }
 
 /// Whether the running install can apply a downloaded update in place. Tauri's
@@ -209,6 +211,8 @@ pub async fn compile_project(
         offline: offline.unwrap_or(false),
         fast: fast.unwrap_or(false),
         halt_on_error: halt_on_error.unwrap_or(false),
+        // The project's pinned compiler is applied after the meta read below.
+        latex_flavor: None,
     };
     let ticket = state
         .compile_ticket
@@ -260,6 +264,13 @@ pub async fn compile_project(
         ));
     }
     let meta = crate::project::read_compile_meta(&project_id, &main_doc)?;
+    let options = crate::document_engine::CompileOptions {
+        latex_flavor: meta
+            .tex_flavor
+            .as_deref()
+            .and_then(crate::document_engine::LatexmkFlavor::parse),
+        ..options
+    };
     let engine = crate::document_engine::engine_for(&meta.engine, &main_doc)?;
     let prepared_spec = crate::document_engine::prepare_compile_spec(
         engine.id(),

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -107,6 +107,11 @@ pub struct EngineDescriptor {
     pub main_document: String,
     pub source_extensions: Vec<String>,
     pub capabilities: EngineCapabilities,
+    /// The project's pinned latexmk compiler ("pdflatex" | "xelatex" |
+    /// "lualatex"); None means auto-detect. Filled in by `project_engine`
+    /// from project.json, absent in engine-only contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tex_flavor: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -291,7 +296,7 @@ impl DocumentEngine for LatexEngine {
 /// comment wins, fontspec-style packages force a Unicode engine, and everything
 /// else gets pdfLaTeX (Overleaf's own default).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LatexmkFlavor {
+pub enum LatexmkFlavor {
     Pdflatex,
     Xelatex,
     Lualatex,
@@ -305,6 +310,22 @@ impl LatexmkFlavor {
             Self::Lualatex => "-lualatex",
         }
     }
+
+    /// Parse the `project.json` `tex_flavor` value.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "pdflatex" => Some(Self::Pdflatex),
+            "xelatex" => Some(Self::Xelatex),
+            "lualatex" => Some(Self::Lualatex),
+            _ => None,
+        }
+    }
+}
+
+/// The user's pinned compiler wins over every source heuristic (magic comment
+/// included); detection only runs for the default "auto" choice.
+fn resolve_latexmk_flavor(pinned: Option<LatexmkFlavor>, source_head: &str) -> LatexmkFlavor {
+    pinned.unwrap_or_else(|| detect_latexmk_flavor(source_head))
 }
 
 fn detect_tex_program_magic(source: &str) -> Option<LatexmkFlavor> {
@@ -482,7 +503,7 @@ impl DocumentEngine for LatexmkEngine {
             } => (source_path.to_owned(), output_stem),
         };
         let source_head = read_source_head(&input_path);
-        let flavor = detect_latexmk_flavor(&source_head);
+        let flavor = resolve_latexmk_flavor(options.latex_flavor, &source_head);
         let shell_escape = latexmk_needs_shell_escape(&source_head);
         let artifacts = self.artifacts(out_dir, target);
         let args = latexmk_args(
@@ -884,6 +905,7 @@ pub fn descriptor_for(
             .map(|extension| (*extension).to_owned())
             .collect(),
         capabilities: engine.capabilities(),
+        tex_flavor: None,
     })
 }
 
@@ -939,6 +961,9 @@ pub struct CompileOptions {
     pub fast: bool,
     /// Stop at the first TeX error rather than pushing on to a best-effort PDF.
     pub halt_on_error: bool,
+    /// The project's pinned latexmk compiler; None means auto-detect from the
+    /// source. Ignored by every other engine.
+    pub latex_flavor: Option<LatexmkFlavor>,
 }
 
 pub struct CompileRequest<'a> {
@@ -2273,6 +2298,7 @@ mod tests {
             offline: true,
             fast: true,
             halt_on_error: true,
+            latex_flavor: None,
         });
         assert!(args.last().unwrap().ends_with(crate::paths::ENTRY_TEX));
         assert_eq!(&args[..2], ["-X", "compile"]);
@@ -2707,6 +2733,40 @@ mod tests {
             detect_latexmk_flavor("\\documentclass{article}"),
             LatexmkFlavor::Pdflatex
         );
+    }
+
+    #[test]
+    fn pinned_flavor_beats_every_source_heuristic() {
+        // An explicit per-project compiler wins over the magic comment and the
+        // fontspec upgrade; auto (None) falls back to detection.
+        let source = "% !TeX program = xelatex\n\\usepackage{fontspec}";
+        assert_eq!(
+            resolve_latexmk_flavor(Some(LatexmkFlavor::Pdflatex), source),
+            LatexmkFlavor::Pdflatex
+        );
+        assert_eq!(
+            resolve_latexmk_flavor(Some(LatexmkFlavor::Lualatex), source),
+            LatexmkFlavor::Lualatex
+        );
+        assert_eq!(resolve_latexmk_flavor(None, source), LatexmkFlavor::Xelatex);
+    }
+
+    #[test]
+    fn latexmk_flavor_parse_accepts_only_known_compilers() {
+        assert_eq!(
+            LatexmkFlavor::parse("pdflatex"),
+            Some(LatexmkFlavor::Pdflatex)
+        );
+        assert_eq!(
+            LatexmkFlavor::parse(" xelatex "),
+            Some(LatexmkFlavor::Xelatex)
+        );
+        assert_eq!(
+            LatexmkFlavor::parse("lualatex"),
+            Some(LatexmkFlavor::Lualatex)
+        );
+        assert_eq!(LatexmkFlavor::parse("tectonic"), None);
+        assert_eq!(LatexmkFlavor::parse(""), None);
     }
 
     #[test]

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -506,7 +506,7 @@ impl DocumentEngine for LatexmkEngine {
         let flavor = resolve_latexmk_flavor(options.latex_flavor, &source_head);
         let shell_escape = latexmk_needs_shell_escape(&source_head);
         let artifacts = self.artifacts(out_dir, target);
-        let args = latexmk_args(
+        let mut args = latexmk_args(
             &out_dir.to_string_lossy(),
             &input_path.to_string_lossy(),
             stem,
@@ -514,6 +514,14 @@ impl DocumentEngine for LatexmkEngine {
             shell_escape,
             options,
         );
+        // latexmk's dependency database is not portable across TeX
+        // distributions: after a distro switch it can report "Nothing to do"
+        // while replaying the previous run's error. Force one full rebuild
+        // (-gg) whenever the resolved latexmk binary differs from the one
+        // that produced this build directory.
+        if latexmk_binary_changed(out_dir, &latexmk) {
+            args.insert(0, "-gg".into());
+        }
         Ok(EngineCompileSpec {
             executable: EngineExecutable::ExternalPath(latexmk),
             args,
@@ -526,6 +534,21 @@ impl DocumentEngine for LatexmkEngine {
     fn parse_errors(&self, log: &str) -> Vec<CompileError> {
         parse_tex_log_errors(log)
     }
+}
+
+/// True when this build directory was last driven by a different latexmk
+/// binary (or never by latexmk). Records the current binary path in a marker
+/// file so the forced rebuild happens exactly once per switch.
+fn latexmk_binary_changed(out_dir: &Path, latexmk: &Path) -> bool {
+    let marker = out_dir.join(".oleafly-latexmk");
+    let current = latexmk.to_string_lossy();
+    let previous = std::fs::read_to_string(&marker).unwrap_or_default();
+    if previous.trim() == current {
+        return false;
+    }
+    let _ = std::fs::create_dir_all(out_dir);
+    let _ = std::fs::write(&marker, current.as_bytes());
+    true
 }
 
 fn validate_latex_main_document(path: &str) -> Result<(), String> {
@@ -2733,6 +2756,22 @@ mod tests {
             detect_latexmk_flavor("\\documentclass{article}"),
             LatexmkFlavor::Pdflatex
         );
+    }
+
+    #[test]
+    fn latexmk_binary_change_forces_one_rebuild() {
+        let dir = std::env::temp_dir().join(format!("oleafly-lmk-marker-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let tinytex = Path::new("/tiny/bin/latexmk");
+        let mactex = Path::new("/mactex/bin/latexmk");
+        // First compile in a fresh build dir: no marker yet, rebuild once.
+        assert!(latexmk_binary_changed(&dir, tinytex));
+        // Same binary again: incremental.
+        assert!(!latexmk_binary_changed(&dir, tinytex));
+        // Distro switch: rebuild once, then incremental again.
+        assert!(latexmk_binary_changed(&dir, mactex));
+        assert!(!latexmk_binary_changed(&dir, mactex));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -407,8 +407,12 @@ pub async fn install_tinytex(app: tauri::AppHandle) -> Result<EngineInfo, String
     use std::io::Write as _;
     use tauri::Emitter;
 
+    // Only an existing TinyTeX makes this a no-op. A system TeX (MacTeX,
+    // TeX Live) must not short-circuit the install: the user asked for the
+    // managed distribution explicitly, and the old any-lualatex guard made
+    // this command silently succeed without downloading anything.
     let existing = find_engine();
-    if existing.lualatex.is_some() {
+    if existing.kind == "tinytex" {
         return Ok(existing);
     }
 

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -79,6 +79,11 @@ pub struct ProjectMeta {
     /// Present on latexmk projects once an engine spec has been recorded.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tex: Option<TexSpec>,
+    /// Explicit latexmk compiler ("pdflatex" | "xelatex" | "lualatex"), the
+    /// Overleaf-style per-project choice. Absent means auto-detect from the
+    /// source, which stays the default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tex_flavor: Option<String>,
     /// Book-cover color (hex). Empty means "unset" so the UI falls back to its
     /// default. Stored on disk so a project's color survives across machines.
     #[serde(default)]
@@ -176,6 +181,7 @@ pub fn read_meta(project_id: &str) -> Result<ProjectMeta, String> {
             hidden: false,
             forked_from: None,
             tex: None,
+            tex_flavor: None,
         });
     }
     let s = std::fs::read_to_string(&p).map_err(|e| format!("failed to read project.json: {e}"))?;
@@ -892,19 +898,39 @@ pub async fn set_project_engine(
     state: tauri::State<'_, crate::state::AppState>,
     project_id: String,
     engine: String,
+    flavor: Option<String>,
 ) -> Result<ProjectMeta, String> {
     let _guard = state.compile_lock.lock().await;
     let engine = engine.trim().to_string();
     if engine.is_empty() {
         return Err("engine name cannot be empty".into());
     }
+    let flavor = validate_tex_flavor(&engine, flavor.as_deref())?;
     let mut meta = read_meta(&project_id)?;
     // Reject engines that cannot compile the current main document before
     // persisting anything.
     crate::document_engine::engine_for(&engine, &meta.main_doc)?;
     meta.engine = engine;
+    meta.tex_flavor = flavor;
     write_meta(&project_id, &meta)?;
     Ok(meta)
+}
+
+/// Normalize the per-project compiler choice. "auto" and empty mean
+/// auto-detect; an explicit compiler is only meaningful on latexmk, and
+/// switching to any other engine always clears it.
+fn validate_tex_flavor(engine: &str, flavor: Option<&str>) -> Result<Option<String>, String> {
+    match flavor.map(str::trim) {
+        None | Some("") | Some("auto") => Ok(None),
+        Some(value @ ("pdflatex" | "xelatex" | "lualatex")) => {
+            if engine == "latexmk" {
+                Ok(Some(value.to_string()))
+            } else {
+                Err("an explicit compiler needs the latexmk engine".into())
+            }
+        }
+        Some(other) => Err(format!("unknown compiler: {other}")),
+    }
 }
 
 fn epoch_seconds() -> f64 {
@@ -1109,6 +1135,7 @@ fn create_markdown_project_in(root: &Path, name: String) -> Result<String, Strin
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )
     })?;
@@ -1283,6 +1310,7 @@ pub fn create_project(name: String) -> Result<String, String> {
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )
     })?;
@@ -1363,6 +1391,7 @@ pub fn create_project_from_pdf_conversion(
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )?;
         rename_exclusive(&staging, &destination)
@@ -1401,6 +1430,7 @@ fn create_typst_project_in(root: &Path, name: String) -> Result<String, String> 
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )
     })?;
@@ -1794,6 +1824,7 @@ fn create_image_project_in(
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )
     })?;
@@ -1840,6 +1871,7 @@ pub fn create_diagram_project(name: String, source: String) -> Result<String, St
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )
     })?;
@@ -1864,6 +1896,7 @@ pub fn get_or_create_scratch_project() -> Result<String, String> {
                 hidden: true,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )?;
     }
@@ -2293,6 +2326,7 @@ pub async fn create_project_from_docx(name: String, data_base64: String) -> Resu
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )?;
         rename_exclusive(&staging, &destination)
@@ -2593,6 +2627,7 @@ pub fn create_project_from_template(
                 hidden: false,
                 forked_from: None,
                 tex: None,
+                tex_flavor: None,
             },
         )
     })?;
@@ -3139,8 +3174,8 @@ mod tests {
         import_skip, infer_main_document, list_projects, normalize_relative, pandoc_asset_for,
         pandoc_version_supported, read_meta, rel_slash, rename_exclusive, rename_path_in_project,
         search_docs, set_main_doc_synchronized, tex_root_magic_target, validate_conversion_export,
-        write_meta_at, FileConflictStrategy, PdfConversionFigure, ProjectMeta, RenameFileResult,
-        TexSpec, SCRATCH_PROJECT_ID,
+        validate_tex_flavor, write_meta_at, FileConflictStrategy, PdfConversionFigure, ProjectMeta,
+        RenameFileResult, TexSpec, SCRATCH_PROJECT_ID,
     };
     use std::io::Write;
     use std::path::Path;
@@ -3719,6 +3754,7 @@ mod tests {
             hidden: false,
             forked_from: None,
             tex: None,
+            tex_flavor: None,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let decoded: ProjectMeta = serde_json::from_str(&json).unwrap();
@@ -3937,6 +3973,7 @@ mod tests {
             hidden: false,
             forked_from: None,
             tex: None,
+            tex_flavor: None,
         };
 
         let valid = projects.join("valid-project");
@@ -3984,6 +4021,7 @@ mod tests {
                         hidden: false,
                         forked_from: None,
                         tex: None,
+                        tex_flavor: None,
                     },
                 )
                 .unwrap();
@@ -4264,5 +4302,28 @@ mod tests {
         .unwrap();
         assert!(!std::fs::read_to_string(&path).unwrap().contains("\"tex\""));
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn tex_flavor_validation_accepts_compilers_only_on_latexmk() {
+        assert_eq!(
+            validate_tex_flavor("latexmk", Some("pdflatex")).unwrap(),
+            Some("pdflatex".to_string())
+        );
+        assert_eq!(
+            validate_tex_flavor("latexmk", Some("xelatex")).unwrap(),
+            Some("xelatex".to_string())
+        );
+        assert_eq!(
+            validate_tex_flavor("latexmk", Some("lualatex")).unwrap(),
+            Some("lualatex".to_string())
+        );
+        // Auto and empty clear the pin on any engine.
+        assert_eq!(validate_tex_flavor("latexmk", Some("auto")).unwrap(), None);
+        assert_eq!(validate_tex_flavor("latexmk", None).unwrap(), None);
+        assert_eq!(validate_tex_flavor("xetex", Some("")).unwrap(), None);
+        // An explicit compiler is meaningless off latexmk, and typos fail.
+        assert!(validate_tex_flavor("xetex", Some("pdflatex")).is_err());
+        assert!(validate_tex_flavor("latexmk", Some("pdftex")).is_err());
     }
 }

--- a/src-tauri/src/tex_distro.rs
+++ b/src-tauri/src/tex_distro.rs
@@ -18,33 +18,26 @@ pub fn exe(name: &str) -> String {
     }
 }
 
-/// TeX binary directories to probe, best-first: Oleafly's managed TinyTeX
-/// (pinned, tlmgr-writable), then versioned system installs (MacTeX, TeX Live
-/// by year, MiKTeX), then generic locations. Only existing directories are
-/// returned.
+/// TeX binary directories to probe, best-first: full system installs (MacTeX,
+/// TeX Live by year, MiKTeX), then Oleafly's managed TinyTeX, then generic
+/// locations. A complete system distribution must outrank the compact TinyTeX:
+/// installing TinyTeX next to a full TeX Live used to silently downgrade every
+/// latexmk compile to the smaller package set and break previously working
+/// projects. Only existing directories are returned.
 pub fn tex_bin_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     let home = crate::paths::home_dir().ok();
-
-    // Oleafly's own TinyTeX (managed install; may nest TinyTeX/bin/<platform>).
-    if let Ok(root) = crate::paths::oleafly_root() {
-        push_texdir_bins(&mut dirs, &root.join("tinytex"));
-    }
 
     #[cfg(target_os = "macos")]
     {
         push_existing(&mut dirs, PathBuf::from("/Library/TeX/texbin"));
         push_texlive_year_bins(&mut dirs, Path::new("/usr/local/texlive"));
-        push_existing(&mut dirs, PathBuf::from("/usr/local/bin"));
-        push_existing(&mut dirs, PathBuf::from("/opt/homebrew/bin"));
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
         push_texlive_year_bins(&mut dirs, Path::new("/usr/local/texlive"));
         push_texlive_year_bins(&mut dirs, Path::new("/opt/texlive"));
-        push_existing(&mut dirs, PathBuf::from("/usr/local/bin"));
-        push_existing(&mut dirs, PathBuf::from("/usr/bin"));
     }
 
     #[cfg(windows)]
@@ -68,9 +61,28 @@ pub fn tex_bin_dirs() -> Vec<PathBuf> {
         );
     }
 
+    // Oleafly's own TinyTeX (managed install; may nest TinyTeX/bin/<platform>).
+    if let Ok(root) = crate::paths::oleafly_root() {
+        push_texdir_bins(&mut dirs, &root.join("tinytex"));
+    }
+
     // A user-installed TinyTeX in the home directory (any platform).
     if let Some(home) = &home {
         push_texdir_bins(&mut dirs, &home.join(".TinyTeX"));
+    }
+
+    // Generic locations last: these usually hold symlinks into one of the real
+    // distributions above.
+    #[cfg(target_os = "macos")]
+    {
+        push_existing(&mut dirs, PathBuf::from("/usr/local/bin"));
+        push_existing(&mut dirs, PathBuf::from("/opt/homebrew/bin"));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        push_existing(&mut dirs, PathBuf::from("/usr/local/bin"));
+        push_existing(&mut dirs, PathBuf::from("/usr/bin"));
     }
 
     dirs

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -151,6 +151,9 @@ const HOST: EditorHost = {
     spellcheck: useSettingsStore((s) => s.spellcheck),
     harper: useSettingsStore((s) => s.harper),
     editorTheme: useSettingsStore((s) => s.editorTheme),
+    autocomplete: useSettingsStore((s) => s.editorAutocomplete),
+    autoCloseBrackets: useSettingsStore((s) => s.editorAutoCloseBrackets),
+    nonBlinkingCursor: useSettingsStore((s) => s.editorNonBlinkingCursor),
   }),
   useLintRefreshDeps: () => [
     useSettingsStore((s) => s.showRegionalism),

--- a/src/components/layout/CompileControls.tsx
+++ b/src/components/layout/CompileControls.tsx
@@ -2,6 +2,7 @@ import {
   AlertTriangle,
   ChevronDown,
   FileText,
+  Info,
   Loader2,
   Play,
   RefreshCw,
@@ -225,7 +226,16 @@ export function CompileControls() {
         {engine.source_format === "latex" && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuLabel>Compiler (this project)</DropdownMenuLabel>
+            <DropdownMenuLabel className="flex items-center gap-1.5">
+              Compiler (this project)
+              <Tooltip
+                wide
+                side="right"
+                label="Tectonic is built in and needs no setup. Auto uses your system TeX and picks the compiler from the source. pdfLaTeX is the Overleaf default and matches most journal templates. XeLaTeX and LuaLaTeX add system fonts and full Unicode. LuaLaTeX also enables tagged accessible PDFs."
+              >
+                <Info className="size-3 cursor-help text-muted-foreground/60 hover:text-muted-foreground" />
+              </Tooltip>
+            </DropdownMenuLabel>
             <DropdownMenuRadioGroup
               value={
                 engine.id === "latexmk"

--- a/src/components/layout/CompileControls.tsx
+++ b/src/components/layout/CompileControls.tsx
@@ -262,19 +262,19 @@ export function CompileControls() {
                 }
               }}
             >
-              <DropdownMenuRadioItem value="tectonic">
+              <DropdownMenuRadioItem value="tectonic" data-testid="compiler-tectonic">
                 Tectonic <span className="ml-1 text-muted-foreground">[built in]</span>
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="auto">
+              <DropdownMenuRadioItem value="auto" data-testid="compiler-auto">
                 Auto <span className="ml-1 text-muted-foreground">[system TeX]</span>
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="pdflatex">
+              <DropdownMenuRadioItem value="pdflatex" data-testid="compiler-pdflatex">
                 pdfLaTeX <span className="ml-1 text-muted-foreground">[system TeX]</span>
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="xelatex">
+              <DropdownMenuRadioItem value="xelatex" data-testid="compiler-xelatex">
                 XeLaTeX <span className="ml-1 text-muted-foreground">[system TeX]</span>
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="lualatex">
+              <DropdownMenuRadioItem value="lualatex" data-testid="compiler-lualatex">
                 LuaLaTeX <span className="ml-1 text-muted-foreground">[system TeX]</span>
               </DropdownMenuRadioItem>
             </DropdownMenuRadioGroup>

--- a/src/components/layout/CompileControls.tsx
+++ b/src/components/layout/CompileControls.tsx
@@ -24,6 +24,7 @@ import { useCompileStore } from "@/store/compile";
 import { useFilesStore } from "@/store/files";
 import { useSettingsStore } from "@/store/settings";
 import { resolveEffectiveMainDoc } from "@/lib/tex-root";
+import type { TexFlavor } from "@/lib/tauri";
 import { cn, shortcut } from "@/lib/utils";
 
 function basename(path: string): string {
@@ -224,21 +225,47 @@ export function CompileControls() {
         {engine.source_format === "latex" && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuLabel>Engine (this project)</DropdownMenuLabel>
+            <DropdownMenuLabel>Compiler (this project)</DropdownMenuLabel>
             <DropdownMenuRadioGroup
-              value={engine.id === "latexmk" ? "latexmk" : "tectonic"}
+              value={
+                engine.id === "latexmk"
+                  ? (engine.tex_flavor ?? "auto")
+                  : "tectonic"
+              }
               onValueChange={(value) => {
-                const isLatexmk = engine.id === "latexmk";
-                if (value === "latexmk" && !isLatexmk) void setEngine("latexmk");
-                // "xetex" is the stored default for the bundled Tectonic engine.
-                if (value === "tectonic" && isLatexmk) void setEngine("xetex");
+                const current =
+                  engine.id === "latexmk"
+                    ? (engine.tex_flavor ?? "auto")
+                    : "tectonic";
+                if (value === current) return;
+                // "xetex" is the stored default for the bundled Tectonic
+                // engine. Everything else runs through latexmk on a system
+                // TeX: "auto" picks the compiler from the source, an explicit
+                // choice pins it (Overleaf's Compiler setting).
+                if (value === "tectonic") {
+                  void setEngine("xetex");
+                } else {
+                  void setEngine(
+                    "latexmk",
+                    value === "auto" ? null : (value as TexFlavor),
+                  );
+                }
               }}
             >
               <DropdownMenuRadioItem value="tectonic">
                 Tectonic <span className="ml-1 text-muted-foreground">[built in]</span>
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="latexmk">
-                latexmk <span className="ml-1 text-muted-foreground">[system TeX]</span>
+              <DropdownMenuRadioItem value="auto">
+                Auto <span className="ml-1 text-muted-foreground">[system TeX]</span>
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="pdflatex">
+                pdfLaTeX <span className="ml-1 text-muted-foreground">[system TeX]</span>
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="xelatex">
+                XeLaTeX <span className="ml-1 text-muted-foreground">[system TeX]</span>
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="lualatex">
+                LuaLaTeX <span className="ml-1 text-muted-foreground">[system TeX]</span>
               </DropdownMenuRadioItem>
             </DropdownMenuRadioGroup>
           </>

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -371,6 +371,7 @@ export function SettingsModal() {
               size="icon"
               className="size-7"
               aria-label="Close settings"
+              data-testid="settings-close"
               onClick={closeSettings}
             >
               <X className="size-4" />

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -188,6 +188,12 @@ export function SettingsModal() {
   const { theme, setTheme, toggleTheme } = useTheme();
   const vim = useSettingsStore((s) => s.vim);
   const toggleVim = useSettingsStore((s) => s.toggleVim);
+  const editorAutocomplete = useSettingsStore((s) => s.editorAutocomplete);
+  const setEditorAutocomplete = useSettingsStore((s) => s.setEditorAutocomplete);
+  const editorAutoCloseBrackets = useSettingsStore((s) => s.editorAutoCloseBrackets);
+  const setEditorAutoCloseBrackets = useSettingsStore((s) => s.setEditorAutoCloseBrackets);
+  const editorNonBlinkingCursor = useSettingsStore((s) => s.editorNonBlinkingCursor);
+  const setEditorNonBlinkingCursor = useSettingsStore((s) => s.setEditorNonBlinkingCursor);
   const spellcheck = useSettingsStore((s) => s.spellcheck);
   const toggleSpellcheck = useSettingsStore((s) => s.toggleSpellcheck);
   const harper = useSettingsStore((s) => s.harper);
@@ -671,6 +677,24 @@ export function SettingsModal() {
                   desc="Enable Vim keybindings in the editor."
                   checked={vim}
                   onChange={toggleVim}
+                />
+                <ToggleRow
+                  label="Auto-complete"
+                  desc="Suggest code completions while typing. Ctrl+Space still opens suggestions when this is off."
+                  checked={editorAutocomplete}
+                  onChange={setEditorAutocomplete}
+                />
+                <ToggleRow
+                  label="Auto-close brackets"
+                  desc="Automatically insert closing brackets and parentheses."
+                  checked={editorAutoCloseBrackets}
+                  onChange={setEditorAutoCloseBrackets}
+                />
+                <ToggleRow
+                  label="Non-blinking cursor"
+                  desc="Reduce visual distraction by keeping the cursor solid."
+                  checked={editorNonBlinkingCursor}
+                  onChange={setEditorNonBlinkingCursor}
                 />
                 <ToggleRow
                   label="Spellcheck"

--- a/src/components/settings/EngineSection.tsx
+++ b/src/components/settings/EngineSection.tsx
@@ -62,7 +62,7 @@ export function EngineSection() {
   // Reload the distribution list whenever an install or removal lands, so the
   // freshly installed TinyTeX row replaces the download card immediately (and
   // returns after a removal).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: info is a deliberate trigger, remove() updates it after deleting TinyTeX and the list must refresh then too
+  // biome-ignore lint/correctness/useExhaustiveDependencies: info triggers a reload after remove()
   useEffect(() => {
     if (installing || !isTauri()) return;
     void texDistributions().then(setDistros).catch(() => {});

--- a/src/components/settings/EngineSection.tsx
+++ b/src/components/settings/EngineSection.tsx
@@ -23,9 +23,20 @@ const ENGINE_CHOICES: Array<{
     id: "latexmk",
     name: "latexmk (system TeX)",
     detail:
-      "Uses a TeX distribution on this machine (MacTeX, TeX Live, MiKTeX, or TinyTeX). Required for minted code highlighting, glossaries/makeindex, pythontex, and shell-escape-heavy journal templates.",
+      "Runs pdfLaTeX, XeLaTeX, or LuaLaTeX from a TeX distribution on this machine (MacTeX, TeX Live, MiKTeX, or TinyTeX). Required for minted code highlighting, glossaries/makeindex, pythontex, and shell-escape-heavy journal templates.",
   },
 ];
+
+// Plain-sentence summary of what a detected distribution ships and where
+// Oleafly runs it from, for the info icon on each row.
+function distroTooltip(distro: TexDistribution): string {
+  const tools = [distro.latexmk && "latexmk", distro.tlmgr && "tlmgr"].filter(Boolean);
+  const bundled =
+    tools.length > 0
+      ? `Bundled with ${tools.join(" and ")}.`
+      : "No latexmk or tlmgr was found in this install.";
+  return `${bundled} Oleafly runs its TeX tools from ${distro.bin_dir}.`;
+}
 
 const TAG_BADGE: Record<TaggingStatus, { label: string; className: string } | null> = {
   ok: null,
@@ -46,8 +57,16 @@ export function EngineSection() {
   useEffect(() => {
     // refreshPackages() needs engine info from refresh() first, so run in sequence.
     void refresh().then(() => refreshPackages());
-    if (isTauri()) void texDistributions().then(setDistros).catch(() => {});
   }, [refresh, refreshPackages]);
+
+  // Reload the distribution list whenever an install or removal lands, so the
+  // freshly installed TinyTeX row replaces the download card immediately (and
+  // returns after a removal).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: info is a deliberate trigger, remove() updates it after deleting TinyTeX and the list must refresh then too
+  useEffect(() => {
+    if (installing || !isTauri()) return;
+    void texDistributions().then(setDistros).catch(() => {});
+  }, [installing, info]);
 
   const kind = info?.kind ?? "none";
   const hasEngine = kind !== "none";
@@ -121,6 +140,9 @@ export function EngineSection() {
             <div className="flex items-center gap-2">
               <HardDrive className="size-4 shrink-0 text-muted-foreground" />
               <span className="text-sm">{distro.label}</span>
+              <Tooltip wide side="right" label={distroTooltip(distro)}>
+                <Info className="size-3.5 shrink-0 cursor-help text-muted-foreground/60 hover:text-muted-foreground" />
+              </Tooltip>
               {distro.latexmk && (
                 <span className="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-400">
                   latexmk

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -100,9 +100,12 @@ export function Tooltip({
             role="tooltip"
             className={cn(
               "pointer-events-none fixed z-[200] rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md",
+              // overflow-wrap anywhere: labels can carry long unbroken paths
+              // (TeX bin directories), which must wrap instead of spilling
+              // past the bubble.
               wide
-                ? "max-w-xs whitespace-normal font-normal leading-relaxed"
-                : "w-max max-w-[260px] whitespace-normal font-medium",
+                ? "max-w-xs whitespace-normal font-normal leading-relaxed [overflow-wrap:anywhere]"
+                : "w-max max-w-[260px] whitespace-normal font-medium [overflow-wrap:anywhere]",
               !pos && "opacity-0"
             )}
             style={pos ? { top: pos.top, left: pos.left } : { top: -9999, left: -9999 }}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -51,7 +51,11 @@ export interface DocumentEngineDescriptor {
   main_document: string;
   source_extensions: string[];
   capabilities: EngineCapabilities;
+  /** Pinned latexmk compiler; absent means auto-detect from the source. */
+  tex_flavor?: TexFlavor;
 }
+
+export type TexFlavor = "pdflatex" | "xelatex" | "lualatex";
 
 export type DocumentEngineId = "latex" | "latexmk" | "typst" | "markdown" | "unknown";
 
@@ -257,9 +261,13 @@ export const setMainDocCmd = (projectId: string, mainDoc: string) =>
   invoke<ProjectMeta>("set_main_doc", { projectId, mainDoc });
 
 // Pin a project's compile engine ("xetex" for bundled Tectonic, "latexmk" for
-// a system TeX toolchain) in its project.json.
-export const setProjectEngineCmd = (projectId: string, engine: string) =>
-  invoke<ProjectMeta>("set_project_engine", { projectId, engine });
+// a system TeX toolchain) in its project.json. On latexmk, `flavor` pins the
+// compiler (pdflatex / xelatex / lualatex); null keeps auto-detection.
+export const setProjectEngineCmd = (
+  projectId: string,
+  engine: string,
+  flavor: TexFlavor | null = null,
+) => invoke<ProjectMeta>("set_project_engine", { projectId, engine, flavor });
 
 export const renameProjectCmd = (projectId: string, name: string) =>
   invoke<ProjectMeta>("rename_project", { projectId, name });

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -76,6 +76,26 @@ async function checkTexPinStatus(
     }
   };
   const missing = status.missing_packages;
+  // A handful of missing packages gets a one-click install. A huge gap means
+  // the project was pinned on a much larger distribution (for example a full
+  // TeX Live against TinyTeX), where installing thousands of packages one by
+  // one is the wrong tool. Point at the distribution mismatch instead.
+  const MAX_ONE_CLICK_INSTALL = 25;
+  if (
+    missing.length > MAX_ONE_CLICK_INSTALL &&
+    status.pinned_label &&
+    status.local_label
+  ) {
+    const fresh = remember(
+      `oleafly.texGap.${projectId}`,
+      `bulk|${status.pinned_label}|${status.local_label}|${missing.length}`,
+    );
+    if (!fresh) return;
+    toast.info(
+      `This project was pinned with ${status.pinned_label}. The active ${status.local_label} is missing ${missing.length} of its packages, so compiles may fail until that distribution is used again.`,
+    );
+    return;
+  }
   if (missing.length > 0 && status.can_install_missing) {
     const fresh = remember(`oleafly.texGap.${projectId}`, [...missing].sort().join(","));
     if (!fresh) return;
@@ -108,7 +128,7 @@ async function checkTexPinStatus(
     );
     if (!fresh) return;
     toast.info(
-      `This project was pinned with ${status.pinned_label}; this machine compiles with ${status.local_label}. Output may differ slightly.`,
+      `This project was pinned with ${status.pinned_label} and this machine compiles with ${status.local_label}. Output may differ slightly.`,
     );
   }
 }

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -28,6 +28,7 @@ import {
   type FileEntry,
   type ProjectInfo,
   type DocumentEngineDescriptor,
+  type TexFlavor,
 } from "@/lib/tauri";
 import { UNKNOWN_ENGINE } from "@/lib/document-engine";
 import { flushAutoCommit, scheduleAutoCommit } from "@/lib/auto-commit";
@@ -167,7 +168,7 @@ interface FilesStore {
   applyExternalDelete: (path: string) => void;
   applyExternalRename: (from: string, to: string) => void;
   setMainDoc: (path: string) => Promise<void>;
-  setEngine: (engine: string) => Promise<void>;
+  setEngine: (engine: string, flavor?: TexFlavor | null) => Promise<void>;
 }
 
 let autosaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -971,7 +972,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     }
   },
 
-  setEngine: async (engineName) => {
+  setEngine: async (engineName, flavor = null) => {
     const { projectId } = get();
     if (!projectId) return;
     // Same race protections as setMainDoc: an engine switch invalidates the
@@ -981,7 +982,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     const compileStore = import("@/store/compile");
     set({ engine: UNKNOWN_ENGINE, engineLoaded: false, engineError: null });
     try {
-      const meta = await setProjectEngineCmd(projectId, engineName);
+      const meta = await setProjectEngineCmd(projectId, engineName, flavor);
       // Capture the reproducibility pin (distro + tlmgr packages) for the new
       // latexmk project in the background; slow tlmgr calls stay off this path.
       if (engineName === "latexmk") void recordProjectTexSpec(projectId).catch(() => {});

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -201,6 +201,15 @@ export const GRAMMAR_DIALECTS: {
 interface SettingsState {
   vim: boolean;
   toggleVim: () => void;
+  /** Completion popups while typing (Ctrl+Space always works). */
+  editorAutocomplete: boolean;
+  setEditorAutocomplete: (v: boolean) => void;
+  /** Auto-insert closing brackets, parentheses, and quotes. */
+  editorAutoCloseBrackets: boolean;
+  setEditorAutoCloseBrackets: (v: boolean) => void;
+  /** Keep the cursor solid instead of blinking. */
+  editorNonBlinkingCursor: boolean;
+  setEditorNonBlinkingCursor: (v: boolean) => void;
   spellcheck: boolean;
   toggleSpellcheck: () => void;
   harper: boolean;
@@ -323,6 +332,21 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       saveLs("oleafly.vim", s.vim ? "0" : "1");
       return { vim: !s.vim };
     }),
+  editorAutocomplete: ls("oleafly.editor.autocomplete", "1") !== "0",
+  setEditorAutocomplete: (v) => {
+    saveLs("oleafly.editor.autocomplete", v ? "1" : "0");
+    set({ editorAutocomplete: v });
+  },
+  editorAutoCloseBrackets: ls("oleafly.editor.closeBrackets", "1") !== "0",
+  setEditorAutoCloseBrackets: (v) => {
+    saveLs("oleafly.editor.closeBrackets", v ? "1" : "0");
+    set({ editorAutoCloseBrackets: v });
+  },
+  editorNonBlinkingCursor: ls("oleafly.editor.solidCursor", "0") === "1",
+  setEditorNonBlinkingCursor: (v) => {
+    saveLs("oleafly.editor.solidCursor", v ? "1" : "0");
+    set({ editorNonBlinkingCursor: v });
+  },
   spellcheck: ls("oleafly.spellcheck", "1") !== "0",
   toggleSpellcheck: () => {
     const spellcheck = !get().spellcheck;


### PR DESCRIPTION
## What this does

### Compiler choice per project (Overleaf parity)
The compile options menu replaces the Tectonic/latexmk toggle with a full compiler picker: **Tectonic, Auto, pdfLaTeX, XeLaTeX, LuaLaTeX**, mirroring Overleaf's Compiler setting. An explicit pick is stored as `tex_flavor` in `project.json` and forces the matching latexmk mode, overriding the `% !TeX program` magic comment and font heuristics. Auto keeps source detection with pdfLaTeX as the default. An info icon on the menu explains when to use each option.

### Editor preferences
Settings gains three toggles under General: **Auto-complete** (suggestions while typing, Ctrl+Space always available), **Auto-close brackets**, and **Non-blinking cursor**. Each reconfigures the live CodeMirror instance through compartments, so changes apply instantly without reopening the project.

### TeX distribution fixes found during manual testing
- **TinyTeX install was a silent no-op on machines with a system TeX.** `install_tinytex` returned early whenever any LuaLaTeX existed, so the Download button reported success instantly without installing anything. It now only short-circuits when TinyTeX itself is already installed.
- **Installing TinyTeX broke working projects.** The managed TinyTeX came first in the distribution probe order, so it silently displaced a full MacTeX/TeX Live and projects using journal classes like `acmart` started failing. Full system installs now outrank TinyTeX everywhere (compile PATH, tool lookup, panel order).
- **Stale latexmk state after a distribution switch.** latexmk's dependency database is not portable across distributions and could report "Nothing to do" while replaying the previous run's error. The build directory now records which latexmk binary drove it and forces one full rebuild (`-gg`) when that changes.
- **Pin toast sanity.** When the missing-package gap is really a distribution mismatch (thousands of packages), the toast names the pinned and active distributions instead of offering to install them all. Small gaps keep the one-click install.
- **Settings polish.** The distribution list refreshes after installs and removals so the Download button gives way to the installed row, every distribution row gets an info tooltip saying what it bundles and where it runs from, the latexmk engine card names pdfLaTeX/XeLaTeX/LuaLaTeX, and tooltips wrap long paths instead of overflowing.

## Testing
- Rust: 237 unit tests including new coverage for flavor precedence (pinned beats magic comment), `tex_flavor` validation, the latexmk-binary change marker, and `LatexmkFlavor` parsing.
- Frontend: 1659 vitest tests, tsc, biome all green.
- Manual: verified on a machine with MacTeX + TeX Live 2025 + managed TinyTeX side by side, including the acm-article regression that first exposed the priority bug.