### PR TITLE
Inline ghost completion in the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (suggestions while typing, with Ctrl+Space always available), Auto-close
   brackets, and Non-blinking cursor. All three apply instantly without
   reopening the editor.
+- **Inline suggestion.** The rest of the most likely completion now appears in
+  dim text after the cursor, accepted with Tab and dismissed with Escape. The
+  candidate comes from the completion sources the editor already runs, so
+  there is no model call, no network, and no delay. While the completion popup
+  is open the preview mirrors the highlighted option and Tab stays with the
+  popup, so the two surfaces can never disagree. Turn it off under Settings,
+  Inline suggestion.
 
 ## [0.3.5] - 2026-08-06
 

--- a/e2e/tests/66-ghost-completion.spec.ts
+++ b/e2e/tests/66-ghost-completion.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect } from "../fixtures";
+import {
+  createBlankProject,
+  editorSource,
+  openProject,
+  openSettings,
+  replaceEditorSource,
+  waitLong,
+  type Page,
+} from "../helpers";
+
+// Inline ghost completion in the real editor: a dim preview of the top
+// candidate after the cursor, accepted with Tab. The suggestion comes from the
+// completion sources the popup already uses, so this spec drives real typing
+// against the real LaTeX corpus rather than a stub.
+
+const PROJECT = "Ghost Completion";
+const GHOST = ".cm-ghostCompletion";
+
+async function openGhostProject(page: Page) {
+  await waitLong(
+    page,
+    `!!document.querySelector('[data-testid="library"][data-projects-loaded="true"]')`,
+    30_000,
+  );
+  const exists = await page.evaluate<boolean>(
+    `import("/src/store/files.ts").then((m) =>
+      m.useFilesStore.getState().projects.some((p) => p.name === ${JSON.stringify(PROJECT)}))`,
+  );
+  if (exists) {
+    await openProject(page, PROJECT);
+  } else {
+    await createBlankProject(page, PROJECT);
+  }
+  await waitLong(page, `!!document.querySelector('.cm-content')`, 30_000);
+}
+
+async function toggleSetting(page: Page, label: string, on: boolean) {
+  await openSettings(page, "general");
+  const selector = `[role="switch"][aria-label="${label}"]`;
+  await waitLong(page, `!!document.querySelector('${selector}')`, 10_000);
+  const already = await page.evaluate<boolean>(
+    `document.querySelector('${selector}')?.getAttribute("aria-checked") === "true"`,
+  );
+  if (already !== on) {
+    await page.click(selector);
+    await waitLong(
+      page,
+      `document.querySelector('${selector}')?.getAttribute("aria-checked") === "${on}"`,
+      10_000,
+    );
+  }
+  await page.click('[data-testid="settings-close"]');
+  await waitLong(page, `!!document.querySelector('.cm-content')`, 10_000);
+}
+
+// One character per input event, the only path CodeMirror's input handling
+// observes.
+async function typeAtCaret(page: Page, text: string) {
+  for (const character of text) {
+    const ok = await page.evaluate<boolean>(
+      `(() => {
+        const content = document.querySelector('.cm-content');
+        if (!content) return false;
+        content.focus();
+        return document.execCommand('insertText', false, ${JSON.stringify(character)});
+      })()`,
+    );
+    if (!ok) throw new Error(`typeAtCaret: editor rejected ${character}`);
+  }
+}
+
+async function caretToEnd(page: Page) {
+  await page.evaluate(
+    `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) => {
+      const view = getEditorView();
+      view.dispatch({ selection: { anchor: view.state.doc.length } });
+      view.focus();
+      return 1;
+    })`,
+  );
+}
+
+async function ghostText(page: Page): Promise<string> {
+  return page.evaluate<string>(
+    `document.querySelector('${GHOST}')?.textContent ?? ""`,
+  );
+}
+
+// Tab reaches the editor only as a real key event; the ghost binding sits in
+// the keymap ahead of indentWithTab.
+async function pressTab(page: Page) {
+  await page.evaluate(
+    `(() => {
+      const content = document.querySelector('.cm-content');
+      content.focus();
+      content.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Tab', code: 'Tab', bubbles: true, cancelable: true,
+      }));
+      return 1;
+    })()`,
+  );
+}
+
+async function settle(page: Page, ms: number) {
+  await page.evaluate(
+    `new Promise((resolve) => setTimeout(() => resolve(1), ${ms}))`,
+  );
+}
+
+async function startDocument(page: Page) {
+  await replaceEditorSource(
+    page,
+    "\\documentclass{article}\n\\begin{document}\n\n\\end{document}\n",
+  );
+  // Type on the blank line inside the document body.
+  await page.evaluate(
+    `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) => {
+      const view = getEditorView();
+      const marker = "\\\\begin{document}";
+      const at = view.state.doc.toString().indexOf(marker) + marker.length + 1;
+      view.dispatch({ selection: { anchor: at } });
+      view.focus();
+      return 1;
+    })`,
+  );
+}
+
+test("a dim suggestion appears while typing a command", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openGhostProject(tauriPage);
+  await toggleSetting(tauriPage, "Inline suggestion", true);
+  await startDocument(tauriPage);
+
+  await typeAtCaret(tauriPage, "\\alph");
+  await waitLong(tauriPage, `!!document.querySelector('${GHOST}')`, 15_000);
+  const suggestion = await ghostText(tauriPage);
+  expect(suggestion.length).toBeGreaterThan(0);
+  // The preview is the remainder only: it never repeats what was typed.
+  expect(suggestion.startsWith("\\")).toBe(false);
+  expect(`\\alph${suggestion}`.startsWith("\\alph")).toBe(true);
+});
+
+test("Tab accepts the suggestion into the document", async ({ tauriPage }) => {
+  test.setTimeout(240_000);
+  await openGhostProject(tauriPage);
+  await toggleSetting(tauriPage, "Inline suggestion", true);
+  await startDocument(tauriPage);
+
+  await typeAtCaret(tauriPage, "\\alph");
+  await waitLong(tauriPage, `!!document.querySelector('${GHOST}')`, 15_000);
+  const suggestion = await ghostText(tauriPage);
+  await pressTab(tauriPage);
+
+  await expect
+    .poll(async () => await editorSource(tauriPage), { timeout: 10_000 })
+    .toContain(`\\alph${suggestion}`);
+  // Accepting consumes the preview.
+  expect(await ghostText(tauriPage)).toBe("");
+});
+
+test("Escape dismisses the suggestion and leaves the text alone", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openGhostProject(tauriPage);
+  await toggleSetting(tauriPage, "Inline suggestion", true);
+  await startDocument(tauriPage);
+
+  await typeAtCaret(tauriPage, "\\alph");
+  await waitLong(tauriPage, `!!document.querySelector('${GHOST}')`, 15_000);
+  await tauriPage.evaluate(
+    `(() => {
+      const content = document.querySelector('.cm-content');
+      content.focus();
+      content.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape', code: 'Escape', bubbles: true, cancelable: true,
+      }));
+      return 1;
+    })()`,
+  );
+  await waitLong(tauriPage, `!document.querySelector('${GHOST}')`, 10_000);
+  expect(await editorSource(tauriPage)).toContain("\\alph");
+  expect(await editorSource(tauriPage)).not.toContain("\\alpha ");
+});
+
+test("no suggestion appears when the preference is off", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openGhostProject(tauriPage);
+  await toggleSetting(tauriPage, "Inline suggestion", false);
+  await startDocument(tauriPage);
+
+  await typeAtCaret(tauriPage, "\\alph");
+  // The widget is asynchronous, so wait out the window in which it would have
+  // appeared before asserting that it never did.
+  await settle(tauriPage, 3_000);
+  expect(await ghostText(tauriPage)).toBe("");
+
+  // With the preference off, Tab is the editor's own indent again.
+  const before = await editorSource(tauriPage);
+  await pressTab(tauriPage);
+  await settle(tauriPage, 500);
+  expect(await editorSource(tauriPage)).not.toBe(`${before}alpha`);
+});
+
+test("the preference persists and stays out of the way of plain typing", async ({
+  tauriPage,
+}) => {
+  test.setTimeout(240_000);
+  await openGhostProject(tauriPage);
+  await toggleSetting(tauriPage, "Inline suggestion", true);
+  expect(
+    await tauriPage.evaluate<string | null>(
+      `localStorage.getItem("oleafly.editor.ghostCompletion")`,
+    ),
+  ).toBe("1");
+
+  await startDocument(tauriPage);
+  // Ordinary prose must not attract a suggestion on every short word.
+  await typeAtCaret(tauriPage, "Hi ");
+  await settle(tauriPage, 1_500);
+  expect(await ghostText(tauriPage)).toBe("");
+  await caretToEnd(tauriPage);
+});

--- a/packages/editor/src/CodeMirrorEditor.test.ts
+++ b/packages/editor/src/CodeMirrorEditor.test.ts
@@ -65,6 +65,7 @@ describe("CodeMirrorEditor measurement", () => {
         autocomplete: true,
         autoCloseBrackets: true,
         nonBlinkingCursor: false,
+        ghostCompletion: true,
       }),
       useLintRefreshDeps: () => [],
     };

--- a/packages/editor/src/CodeMirrorEditor.tsx
+++ b/packages/editor/src/CodeMirrorEditor.tsx
@@ -52,6 +52,7 @@ import {
 import { liveMathPreview } from "./math-preview";
 import { createLatexLinter } from "./latex-linter";
 import { latexFolding } from "./latex-folding";
+import { ghostCompletion } from "./ghost-completion";
 import { foldMarkerDOM, foldMarkerTheme } from "./fold-marker";
 
 // The use* members are React hooks: must follow hook rules, and the host
@@ -73,6 +74,8 @@ export interface EditorHost {
     autoCloseBrackets: boolean;
     /** Keep the cursor solid instead of blinking. */
     nonBlinkingCursor: boolean;
+    /** Dim inline preview of the top completion, accepted with Tab. */
+    ghostCompletion: boolean;
   };
   useLintRefreshDeps(): readonly unknown[];
 }
@@ -90,6 +93,7 @@ function sourceToolsForPath(
   path: string | null,
   completionSources: CompletionSource[],
   autocompleteWhileTyping: boolean,
+  ghostCompletionEnabled: boolean,
 ): Extension[] {
   const mathPreview = isLatexDocumentPath(path)
     ? [liveMathPreview("latex")]
@@ -98,16 +102,22 @@ function sourceToolsForPath(
       : [];
 
   if (isLatexSourcePath(path)) {
+    // The ghost preview reads the same sources the popup does, so the two can
+    // never suggest different things.
+    const sources = [
+      ...completionSources,
+      completionSources.length > 0 ? latexCommandCompletions : latexCompletions,
+      slashCompletions,
+    ];
     return [
       latexFolding(),
+      // Before autocompletion: both register keymaps at the highest
+      // precedence, where the earlier extension wins, and the ghost's Escape
+      // has to record its dismissal before the popup consumes the key. Its
+      // handlers decline whenever the popup should own the key instead.
+      ...(ghostCompletionEnabled ? [ghostCompletion(sources)] : []),
       autocompletion({
-        override: [
-          ...completionSources,
-          completionSources.length > 0
-            ? latexCommandCompletions
-            : latexCompletions,
-          slashCompletions,
-        ],
+        override: sources,
         activateOnTyping: autocompleteWhileTyping,
         closeOnBlur: true,
       }),
@@ -120,6 +130,7 @@ function sourceToolsForPath(
     ...mathPreview,
     ...(completionSources.length > 0
       ? [
+          ...(ghostCompletionEnabled ? [ghostCompletion(completionSources)] : []),
           autocompletion({
             override: completionSources,
             activateOnTyping: autocompleteWhileTyping,
@@ -187,6 +198,7 @@ export function CodeMirrorEditor({
     autocomplete,
     autoCloseBrackets,
     nonBlinkingCursor,
+    ghostCompletion: ghostCompletionEnabled,
   } = host.useSettings();
   const lintDeps = host.useLintRefreshDeps();
 
@@ -244,7 +256,12 @@ export function CodeMirrorEditor({
         historyCompartment.of(history()),
         vscodeSearch(),
         sourceToolsCompartment.of(
-          sourceToolsForPath(initialPath, initialCompletionSources, autocomplete),
+          sourceToolsForPath(
+            initialPath,
+            initialCompletionSources,
+            autocomplete,
+            ghostCompletionEnabled,
+          ),
         ),
         ...(extraExtensions ?? []),
         hostToolsCompartment.of(extraExtensionsForPath?.(initialPath) ?? []),
@@ -357,7 +374,12 @@ export function CodeMirrorEditor({
     const effects = [langCompartmentRef.current!.reconfigure(lang ? lang : [])];
     effects.push(
       sourceToolsCompartmentRef.current!.reconfigure(
-        sourceToolsForPath(activePath, completionSources, autocomplete),
+        sourceToolsForPath(
+          activePath,
+          completionSources,
+          autocomplete,
+          ghostCompletionEnabled,
+        ),
       ),
     );
     effects.push(
@@ -433,11 +455,12 @@ export function CodeMirrorEditor({
           path,
           extraCompletionSourcesForPath?.(path) ?? [],
           autocomplete,
+          ghostCompletionEnabled,
         ),
       ),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autocomplete]);
+  }, [autocomplete, ghostCompletionEnabled]);
 
   // Toggle spellcheck / Harper grammar without recreating the editor.
   useEffect(() => {

--- a/packages/editor/src/ghost-completion.test.ts
+++ b/packages/editor/src/ghost-completion.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import type { CompletionSource } from "@codemirror/autocomplete";
+import {
+  acceptGhostCompletion,
+  clearGhostCompletion,
+  ghostCompletion,
+  pendingGhostCompletion,
+} from "./ghost-completion";
+
+// A source that offers the given labels whenever a backslash command or word
+// is being typed, mirroring how the real LaTeX sources behave.
+function sourceOf(
+  labels: Array<string | { label: string; boost?: number; apply?: unknown }>,
+): CompletionSource {
+  return (context) => {
+    const match = context.matchBefore(/(\\[a-zA-Z@]*|[A-Za-z][A-Za-z0-9]*)$/);
+    if (!match) return null;
+    return {
+      from: match.from,
+      options: labels.map((entry) =>
+        typeof entry === "string" ? { label: entry } : entry,
+      ) as never,
+    };
+  };
+}
+
+// jsdom has no layout, but the ghost only needs the state field and the view
+// plugin, both of which run headless.
+function mount(doc: string, sources: CompletionSource[]): EditorView {
+  const view = new EditorView({
+    state: EditorState.create({ doc, extensions: [ghostCompletion(sources)] }),
+    parent: document.body,
+  });
+  view.focus();
+  return view;
+}
+
+function caretToEnd(view: EditorView) {
+  view.dispatch({ selection: { anchor: view.state.doc.length } });
+}
+
+// The plugin recomputes in a microtask so it never dispatches mid-update.
+const settle = () => new Promise((resolve) => queueMicrotask(() => resolve(null)));
+
+describe("ghost completion suggestions", () => {
+  it("offers the remainder of the best matching command", async () => {
+    const view = mount("\\alp", [sourceOf(["\\alpha", "\\alphabet"])]);
+    caretToEnd(view);
+    await settle();
+    // Ties on boost go to the shortest completion.
+    expect(pendingGhostCompletion(view)).toBe("ha");
+    view.destroy();
+  });
+
+  it("prefers a higher boost over a shorter label", async () => {
+    const view = mount("\\alp", [
+      sourceOf([
+        { label: "\\alpha" },
+        { label: "\\alphabetical", boost: 50 },
+      ]),
+    ]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("habetical");
+    view.destroy();
+  });
+
+  it("stays quiet until enough characters are typed", async () => {
+    const view = mount("\\a", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBeNull();
+
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "l" } });
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("pha");
+    view.destroy();
+  });
+
+  it("needs three characters for a plain word", async () => {
+    const view = mount("se", [sourceOf(["section"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBeNull();
+
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "c" } });
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("tion");
+    view.destroy();
+  });
+
+  it("previews the label even when apply is a guarded function", async () => {
+    // Every real source wraps apply in a guard, so rejecting function applies
+    // would silence the feature entirely. The label is what Tab inserts.
+    const view = mount("\\sec", [
+      sourceOf([{ label: "\\section", apply: () => undefined }]),
+    ]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("tion");
+    view.destroy();
+  });
+
+  it("previews a string apply rather than the label", async () => {
+    const view = mount("\\ite", [
+      sourceOf([{ label: "\\item", apply: "\\item " }]),
+    ]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("m ");
+    view.destroy();
+  });
+
+  it("does not suggest in the middle of a word", async () => {
+    const view = mount("\\alpX", [sourceOf(["\\alpha"])]);
+    view.dispatch({ selection: { anchor: 4 } });
+    await settle();
+    expect(pendingGhostCompletion(view)).toBeNull();
+    view.destroy();
+  });
+
+  it("suggests when a closing brace follows the cursor", async () => {
+    const view = mount("{\\alp}", [sourceOf(["\\alpha"])]);
+    view.dispatch({ selection: { anchor: 5 } });
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("ha");
+    view.destroy();
+  });
+
+  it("stays quiet when nothing matches the typed prefix", async () => {
+    const view = mount("\\zzz", [sourceOf(["\\alpha", "\\beta"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBeNull();
+    view.destroy();
+  });
+
+  it("ignores an exact match, which has nothing left to suggest", async () => {
+    const view = mount("\\alpha", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBeNull();
+    view.destroy();
+  });
+
+  it("skips asynchronous sources and falls through to a sync one", async () => {
+    const slow: CompletionSource = () => Promise.resolve(null);
+    const view = mount("\\alp", [slow, sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("ha");
+    view.destroy();
+  });
+
+  it("survives a source that throws", async () => {
+    const broken: CompletionSource = () => {
+      throw new Error("source failure");
+    };
+    const view = mount("\\alp", [broken, sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("ha");
+    view.destroy();
+  });
+
+  it("clears the suggestion when the selection is not empty", async () => {
+    const view = mount("\\alp", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("ha");
+
+    view.dispatch({ selection: { anchor: 0, head: 4 } });
+    await settle();
+    expect(pendingGhostCompletion(view)).toBeNull();
+    view.destroy();
+  });
+});
+
+describe("accepting and dismissing", () => {
+  it("Tab inserts the suggestion and leaves the cursor after it", async () => {
+    const view = mount("\\alp", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(acceptGhostCompletion(view)).toBe(true);
+    expect(view.state.doc.toString()).toBe("\\alpha");
+    expect(view.state.selection.main.head).toBe(6);
+    expect(pendingGhostCompletion(view)).toBeNull();
+    view.destroy();
+  });
+
+  it("declines when there is nothing to accept, so Tab keeps indenting", async () => {
+    const view = mount("plain text", [sourceOf(["\\alpha"])]);
+    view.dispatch({ selection: { anchor: 0 } });
+    await settle();
+    expect(acceptGhostCompletion(view)).toBe(false);
+    expect(clearGhostCompletion(view)).toBe(false);
+    view.destroy();
+  });
+
+  it("Escape dismisses without changing the document", async () => {
+    const view = mount("\\alp", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(clearGhostCompletion(view)).toBe(true);
+    expect(pendingGhostCompletion(view)).toBeNull();
+    expect(view.state.doc.toString()).toBe("\\alp");
+    view.destroy();
+  });
+
+  it("renders the suggestion as a dim widget in the document", async () => {
+    const view = mount("\\alp", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    const widget = view.dom.querySelector(".cm-ghostCompletion");
+    expect(widget?.textContent).toBe("ha");
+    expect(widget?.getAttribute("aria-hidden")).toBe("true");
+    view.destroy();
+  });
+});
+
+describe("dismissal", () => {
+  it("stays dismissed at the same cursor, and returns after the next edit", async () => {
+    const view = mount("\\alp", [sourceOf(["\\alpha"])]);
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("ha");
+
+    clearGhostCompletion(view);
+    await settle();
+    // Dismissing does not move the cursor, so without the dismissal memory the
+    // very next recompute would offer the same candidate again.
+    expect(pendingGhostCompletion(view)).toBeNull();
+
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "h" } });
+    caretToEnd(view);
+    await settle();
+    expect(pendingGhostCompletion(view)).toBe("a");
+    view.destroy();
+  });
+});

--- a/packages/editor/src/ghost-completion.ts
+++ b/packages/editor/src/ghost-completion.ts
@@ -1,0 +1,338 @@
+import {
+  CompletionContext,
+  selectedCompletion,
+  completionStatus,
+  type Completion,
+  type CompletionResult,
+  type CompletionSource,
+} from "@codemirror/autocomplete";
+import { Prec, StateEffect, StateField, type Extension } from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+  keymap,
+  type DecorationSet,
+  type ViewUpdate,
+} from "@codemirror/view";
+
+// Inline "ghost" completion: the rest of the most likely candidate, drawn dim
+// after the cursor and accepted with Tab.
+//
+// Everything shown here comes from the completion sources the editor already
+// runs, so there is no model call, no network, and no latency. Only
+// synchronous source results are considered: a suggestion that arrives after
+// the next keystroke would flicker, and the popup already covers async
+// sources.
+//
+// While the completion popup is open the ghost mirrors the highlighted option
+// instead of guessing separately, so the two surfaces can never disagree, and
+// Tab is left to the popup's own handler.
+
+const GHOST_CLASS = "cm-ghostCompletion";
+
+// Enough typed characters that a single suggestion is a fair guess. Commands
+// carry their backslash, so "\al" is three characters but two letters.
+const MIN_COMMAND_LETTERS = 2;
+const MIN_WORD_LETTERS = 3;
+// Scanning every candidate of a 400k-command corpus on each keystroke would be
+// wasted work: the best match is decided by prefix and boost alone.
+const MAX_OPTIONS_SCANNED = 2000;
+
+interface GhostSuggestion {
+  /** Cursor position the ghost is anchored to. */
+  pos: number;
+  /** The text that would be inserted, already stripped of what was typed. */
+  text: string;
+}
+
+const setGhost = StateEffect.define<GhostSuggestion | null>();
+const setDismissed = StateEffect.define<number | null>();
+
+/**
+ * Where the user pressed Escape. Without this the suggestion would return
+ * immediately: dismissing does not move the cursor or change the document, so
+ * the very next recompute would offer the same candidate again. Reset by any
+ * edit or cursor move, so dismissing is a one-shot rather than a mode.
+ */
+const dismissedField = StateField.define<number | null>({
+  create: () => null,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setDismissed)) return effect.value;
+    }
+    if (tr.docChanged || tr.selection) return null;
+    return value;
+  },
+});
+
+class GhostWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+
+  eq(other: GhostWidget): boolean {
+    return other.text === this.text;
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = GHOST_CLASS;
+    span.textContent = this.text;
+    // Decorative: screen readers announce the real document, and the popup
+    // remains the accessible way to choose a completion.
+    span.setAttribute("aria-hidden", "true");
+    return span;
+  }
+
+  // The widget must not swallow clicks aimed at the text behind it.
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+const ghostField = StateField.define<GhostSuggestion | null>({
+  create: () => null,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setGhost)) return effect.value;
+    }
+    // Any edit or cursor move invalidates the suggestion. The view plugin
+    // recomputes one immediately after, so the ghost never lags the document.
+    if (tr.docChanged || tr.selection) return null;
+    return value;
+  },
+  provide: (field) =>
+    EditorView.decorations.from(field, (ghost): DecorationSet =>
+      ghost
+        ? Decoration.set([
+            Decoration.widget({
+              widget: new GhostWidget(ghost.text),
+              // Draw after the cursor rather than pushing it right.
+              side: 1,
+            }).range(ghost.pos),
+          ])
+        : Decoration.none,
+    ),
+});
+
+/** The identifier being typed at `pos`: a LaTeX command or a plain word. */
+function typedPrefix(
+  view: EditorView,
+  pos: number,
+): { from: number; text: string } | null {
+  const line = view.state.doc.lineAt(pos);
+  const before = line.text.slice(0, pos - line.from);
+  const match = before.match(/(\\[a-zA-Z@]*|[A-Za-z][A-Za-z0-9]*)$/);
+  if (!match) return null;
+  const text = match[1];
+  const letters = text.startsWith("\\") ? text.length - 1 : text.length;
+  const minimum = text.startsWith("\\") ? MIN_COMMAND_LETTERS : MIN_WORD_LETTERS;
+  if (letters < minimum) return null;
+  return { from: pos - text.length, text };
+}
+
+/** Only suggest at the end of a word, never in the middle of one. */
+function atWordEnd(view: EditorView, pos: number): boolean {
+  const line = view.state.doc.lineAt(pos);
+  const after = line.text.slice(pos - line.from);
+  return after === "" || /^[\s}\]),.;:$&]/.test(after);
+}
+
+/**
+ * What the ghost shows, and exactly what Tab inserts.
+ *
+ * The label is used rather than the option's `apply`, because every source
+ * here wraps `apply` in a guard function whose expansion cannot be inspected.
+ * Inserting the label keeps the preview honest: what is shown is what lands.
+ * Choosing the same option from the popup may expand further (a command with
+ * arguments becomes a snippet), which is the popup's job, not this one's.
+ */
+function previewLabel(option: Completion, prefix: string): string | null {
+  const label = typeof option.apply === "string" ? option.apply : option.label;
+  if (label.length <= prefix.length || !label.startsWith(prefix)) return null;
+  return label;
+}
+
+function bestOption(options: readonly Completion[], prefix: string): string | null {
+  let best: string | null = null;
+  let bestBoost = Number.NEGATIVE_INFINITY;
+  const scanned = Math.min(options.length, MAX_OPTIONS_SCANNED);
+  for (let index = 0; index < scanned; index++) {
+    const label = previewLabel(options[index], prefix);
+    if (!label) continue;
+    const boost = options[index].boost ?? 0;
+    // Higher boost wins; ties go to the shortest completion, which is the one
+    // the typist is most likely reaching for.
+    if (
+      boost > bestBoost ||
+      (boost === bestBoost && best !== null && label.length < best.length)
+    ) {
+      best = label;
+      bestBoost = boost;
+    }
+  }
+  return best;
+}
+
+function syncResult(
+  source: CompletionSource,
+  context: CompletionContext,
+): CompletionResult | null {
+  let result: ReturnType<CompletionSource>;
+  try {
+    result = source(context);
+  } catch {
+    return null;
+  }
+  // Promises are skipped by design: see the module comment.
+  return result && !(result instanceof Promise) ? result : null;
+}
+
+function computeGhost(
+  view: EditorView,
+  sources: CompletionSource[],
+): GhostSuggestion | null {
+  const selection = view.state.selection.main;
+  if (!selection.empty || view.state.readOnly) return null;
+  const pos = selection.head;
+  if (view.state.field(dismissedField, false) === pos) return null;
+  if (!atWordEnd(view, pos)) return null;
+  const prefix = typedPrefix(view, pos);
+  if (!prefix) return null;
+
+  // Popup open: mirror the highlighted option so the two never disagree.
+  if (completionStatus(view.state) === "active") {
+    const selected = selectedCompletion(view.state);
+    const label = selected ? previewLabel(selected, prefix.text) : null;
+    return label ? { pos, text: label.slice(prefix.text.length) } : null;
+  }
+
+  const context = new CompletionContext(view.state, pos, false);
+  for (const source of sources) {
+    const result = syncResult(source, context);
+    if (!result) continue;
+    const label = bestOption(result.options, prefix.text);
+    if (label) return { pos, text: label.slice(prefix.text.length) };
+  }
+  return null;
+}
+
+/** Insert the pending ghost suggestion. Bound to Tab. */
+export function acceptGhostCompletion(view: EditorView): boolean {
+  // With the popup open the ghost is only a preview of the highlighted option,
+  // so Tab belongs to the popup: its own handler runs the option's apply and
+  // expands snippets, which inserting the label here would not.
+  if (completionStatus(view.state) === "active") return false;
+  const ghost = view.state.field(ghostField, false);
+  if (!ghost || ghost.pos !== view.state.selection.main.head) return false;
+  view.dispatch({
+    changes: { from: ghost.pos, insert: ghost.text },
+    selection: { anchor: ghost.pos + ghost.text.length },
+    effects: setGhost.of(null),
+    userEvent: "input.complete",
+    scrollIntoView: true,
+  });
+  return true;
+}
+
+/** Dismiss the pending suggestion. Bound to Escape. */
+export function clearGhostCompletion(view: EditorView): boolean {
+  const ghost = view.state.field(ghostField, false);
+  if (!ghost) return false;
+  const popupOpen = completionStatus(view.state) === "active";
+  view.dispatch({
+    effects: [setGhost.of(null), setDismissed.of(ghost.pos)],
+  });
+  // With the popup open, report the key as unhandled so Escape also closes it.
+  // One press should clear both surfaces, not just this one.
+  return !popupOpen;
+}
+
+const ghostTheme = EditorView.baseTheme({
+  [`.${GHOST_CLASS}`]: {
+    opacity: "0.45",
+    // The suggestion is a preview, so it must never be mistaken for text that
+    // is already in the document, nor become a selection target.
+    pointerEvents: "none",
+    userSelect: "none",
+  },
+});
+
+/**
+ * Inline ghost completion driven by `sources`, which should be the same
+ * completion sources the popup uses so both surfaces agree.
+ */
+export function ghostCompletion(sources: CompletionSource[]): Extension {
+  const plugin = ViewPlugin.fromClass(
+    class {
+      // Recomputing inside update() would dispatch during an update, so the
+      // work is deferred to a microtask and guarded against a stale view.
+      private scheduled = false;
+
+      constructor(readonly view: EditorView) {
+        this.schedule();
+      }
+
+      update(update: ViewUpdate) {
+        // The popup opening or closing changes where the suggestion comes
+        // from, and closing it moves neither cursor nor document, so without
+        // this the last preview would linger on screen.
+        const popupChanged =
+          completionStatus(update.startState) !== completionStatus(update.state);
+        if (update.docChanged || update.selectionSet || popupChanged) {
+          this.schedule();
+        }
+      }
+
+      schedule() {
+        if (this.scheduled) return;
+        this.scheduled = true;
+        queueMicrotask(() => {
+          this.scheduled = false;
+          this.refresh();
+        });
+      }
+
+      refresh() {
+        const view = this.view;
+        // The plugin is destroyed with the view; bail if that already happened.
+        if (!view.dom.isConnected) return;
+        // Deliberately not gated on view.hasFocus: it depends on
+        // document.hasFocus(), which an embedded webview reports as false even
+        // while the user types. The suggestion is anchored to the cursor and
+        // only survives until the next edit, so an unfocused editor cannot
+        // accumulate stale previews anyway.
+        const next = computeGhost(view, sources);
+        const current = view.state.field(ghostField, false) ?? null;
+        if (next?.text === current?.text && next?.pos === current?.pos) return;
+        view.dispatch({ effects: setGhost.of(next) });
+      }
+
+      destroy() {
+        this.scheduled = true;
+      }
+    },
+  );
+
+  return [
+    ghostField,
+    dismissedField,
+    plugin,
+    ghostTheme,
+    // Ahead of indentWithTab and the completion keymap: both handlers decline
+    // when there is no ghost, so normal Tab behavior is untouched.
+    Prec.highest(
+      keymap.of([
+        { key: "Tab", run: acceptGhostCompletion },
+        { key: "Escape", run: clearGhostCompletion },
+      ]),
+    ),
+  ];
+}
+
+/** The pending suggestion text, for tests and diagnostics. */
+export function pendingGhostCompletion(view: EditorView): string | null {
+  return view.state.field(ghostField, false)?.text ?? null;
+}

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -154,6 +154,7 @@ const HOST: EditorHost = {
     autocomplete: useSettingsStore((s) => s.editorAutocomplete),
     autoCloseBrackets: useSettingsStore((s) => s.editorAutoCloseBrackets),
     nonBlinkingCursor: useSettingsStore((s) => s.editorNonBlinkingCursor),
+    ghostCompletion: useSettingsStore((s) => s.editorGhostCompletion),
   }),
   useLintRefreshDeps: () => [
     useSettingsStore((s) => s.showRegionalism),

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -192,6 +192,8 @@ export function SettingsModal() {
   const setEditorAutocomplete = useSettingsStore((s) => s.setEditorAutocomplete);
   const editorAutoCloseBrackets = useSettingsStore((s) => s.editorAutoCloseBrackets);
   const setEditorAutoCloseBrackets = useSettingsStore((s) => s.setEditorAutoCloseBrackets);
+  const editorGhostCompletion = useSettingsStore((s) => s.editorGhostCompletion);
+  const setEditorGhostCompletion = useSettingsStore((s) => s.setEditorGhostCompletion);
   const editorNonBlinkingCursor = useSettingsStore((s) => s.editorNonBlinkingCursor);
   const setEditorNonBlinkingCursor = useSettingsStore((s) => s.setEditorNonBlinkingCursor);
   const spellcheck = useSettingsStore((s) => s.spellcheck);
@@ -690,6 +692,12 @@ export function SettingsModal() {
                   desc="Automatically insert closing brackets and parentheses."
                   checked={editorAutoCloseBrackets}
                   onChange={setEditorAutoCloseBrackets}
+                />
+                <ToggleRow
+                  label="Inline suggestion"
+                  desc="Preview the most likely completion in dim text after the cursor. Press Tab to accept it."
+                  checked={editorGhostCompletion}
+                  onChange={setEditorGhostCompletion}
                 />
                 <ToggleRow
                   label="Non-blinking cursor"

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -207,6 +207,9 @@ interface SettingsState {
   /** Auto-insert closing brackets, parentheses, and quotes. */
   editorAutoCloseBrackets: boolean;
   setEditorAutoCloseBrackets: (v: boolean) => void;
+  /** Dim inline preview of the most likely completion, accepted with Tab. */
+  editorGhostCompletion: boolean;
+  setEditorGhostCompletion: (v: boolean) => void;
   /** Keep the cursor solid instead of blinking. */
   editorNonBlinkingCursor: boolean;
   setEditorNonBlinkingCursor: (v: boolean) => void;
@@ -341,6 +344,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   setEditorAutoCloseBrackets: (v) => {
     saveLs("oleafly.editor.closeBrackets", v ? "1" : "0");
     set({ editorAutoCloseBrackets: v });
+  },
+  editorGhostCompletion: ls("oleafly.editor.ghostCompletion", "1") !== "0",
+  setEditorGhostCompletion: (v) => {
+    saveLs("oleafly.editor.ghostCompletion", v ? "1" : "0");
+    set({ editorGhostCompletion: v });
   },
   editorNonBlinkingCursor: ls("oleafly.editor.solidCursor", "0") === "1",
   setEditorNonBlinkingCursor: (v) => {


### PR DESCRIPTION
## What this does

The rest of the most likely completion now appears in dim text after the cursor. Tab accepts it, Escape dismisses it, and it turns off under Settings as **Inline suggestion**.

Candidates come from the completion sources the editor already runs (LaTeX corpus, project intelligence, language service), so there is **no model call, no network, and no delay**. Only synchronous source results are considered: a suggestion arriving after the next keystroke would flicker, and the popup already covers async sources.

## How it behaves next to the existing popup

The two surfaces are deliberately coordinated rather than competing:

- **Popup open** — the preview mirrors the highlighted option, and Tab declines so the popup runs the option's `apply` and expands snippets as it always did.
- **Popup closed** — Tab inserts exactly the previewed text. The preview never promises something different from what lands.
- **Escape** — clears the preview and, when the popup is open, reports the key as unhandled so one press closes both.

Three things this ran into that are worth knowing, since they are not obvious from the CodeMirror docs:

1. **Ordering matters.** `autocompletion()` registers its keymap at `Prec.highest` too, and at equal precedence the earlier extension wins. The ghost has to come first so Escape records its dismissal before the popup consumes the key.
2. **Dismissal needs memory.** Pressing Escape changes neither document nor selection, so without a dismissal keyed to the cursor position the next recompute offered the same candidate again. It clears on the next edit, so dismissing is a one-shot rather than a mode.
3. **Every completion carries a function `apply`.** `guardCompletionForSource` wraps them all, so an initial rule that skipped function applies silenced the feature completely in the real app while passing against stubs. The preview now uses the label, which is also exactly what Tab inserts.

Suggestions stay quiet until there is a real prefix (two letters after a backslash, three for a plain word), only appear at the end of a word, and never repeat what was typed.

## Testing

- 18 unit tests in `packages/editor/src/ghost-completion.test.ts`: ranking by boost and length, the character thresholds, mid-word and no-match cases, async and throwing sources, accept, dismiss, dismissal memory, and the rendered widget.
- 5 e2e tests in `e2e/tests/66-ghost-completion.spec.ts` against the real app and the real LaTeX corpus: the preview appears while typing, Tab accepts it into the document, Escape dismisses without changing text, nothing appears when the preference is off, and ordinary prose does not attract a suggestion.
- Full suite green: 1677 vitest, tsc, biome, and the neighbouring editor and code-intel specs.
- Production graph grew about 4 KB, well inside the budget.