### PR TITLE
Scope live provider validation to publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,8 +391,46 @@ jobs:
           done
           gh release upload "$TAG" latest.json --repo "$GITHUB_REPOSITORY" --clobber
 
+  # Live contracts are a PUBLISH gate: shipping an updater feed without proving
+  # the providers still answer is the failure this catches. A draft is a build
+  # for review, so missing credentials downgrade it to an unverified draft with
+  # a loud warning instead of failing the tag. Resolving that here, off the
+  # macOS runner, keeps a skipped verification from booting a billed machine.
+  provider-credentials:
+    name: Live provider credentials
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      verify: ${{ steps.resolve.outputs.verify }}
+    steps:
+      - name: Resolve live-provider release credentials
+        id: resolve
+        env:
+          ANTHROPIC_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_TOKEN: ${{ secrets.GOOGLE_API_KEY }}
+          PUBLISHING: ${{ inputs.publish == true }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "$ANTHROPIC_TOKEN" ] || missing+=("ANTHROPIC_API_KEY")
+          [ -n "$GOOGLE_TOKEN" ] || missing+=("GOOGLE_API_KEY")
+          if ((${#missing[@]} == 0)); then
+            echo "verify=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$PUBLISHING" = "true" ]; then
+            printf 'publishing requires live provider credentials; missing: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+          echo "verify=false" >>"$GITHUB_OUTPUT"
+          printf '::warning::Live provider contracts were not verified (missing %s). This draft is unverified against the providers, and publishing the tag will fail until the secrets exist.\n' "${missing[*]}"
+
   provider-live:
     name: Release-candidate live provider contracts
+    needs: provider-credentials
+    if: ${{ needs.provider-credentials.outputs.verify == 'true' }}
     runs-on: macos-14
     timeout-minutes: 45
     permissions:
@@ -437,16 +475,6 @@ jobs:
       - name: Install Playwright browser
         run: pnpm exec playwright install chromium
 
-      - name: Require live-provider release credentials
-        env:
-          ANTHROPIC_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_TOKEN: ${{ secrets.GOOGLE_API_KEY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [ -n "$ANTHROPIC_TOKEN" ] || { echo "ANTHROPIC_API_KEY is required to publish" >&2; exit 1; }
-          [ -n "$GOOGLE_TOKEN" ] || { echo "GOOGLE_API_KEY is required to publish" >&2; exit 1; }
-
       - name: Verify Anthropic against the release candidate
         env:
           E2E_AI_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -484,7 +512,7 @@ jobs:
   # for the same tag with "Publish the release" checked.
   publish:
     name: Publish (all platforms present)
-    needs: [build, finalize-updater, provider-live]
+    needs: [build, finalize-updater, provider-credentials, provider-live]
     if: ${{ inputs.publish == true }}
     runs-on: ubuntu-22.04
     permissions:
@@ -528,7 +556,7 @@ jobs:
   # artifact and updater-feed checks as a publish - it just never flips live.
   draft-ready:
     name: Draft is complete (not published)
-    needs: [build, finalize-updater, provider-live]
+    needs: [build, finalize-updater, provider-credentials, provider-live]
     if: ${{ always() && inputs.publish != true }}
     runs-on: ubuntu-22.04
     permissions:
@@ -545,10 +573,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ needs.build.result }}" != "success" ] || [ "${{ needs['finalize-updater'].result }}" != "success" ] || [ "${{ needs['provider-live'].result }}" != "success" ]; then
-            echo "build, updater finalization, or live-provider validation did not succeed; the draft is incomplete" >&2
+          if [ "${{ needs.build.result }}" != "success" ] || [ "${{ needs['finalize-updater'].result }}" != "success" ] || [ "${{ needs['provider-credentials'].result }}" != "success" ]; then
+            echo "build or updater finalization did not succeed; the draft is incomplete" >&2
             exit 1
           fi
+          # Skipped means the credentials job found no provider secrets and said
+          # so; the draft stands, unverified. A failure is a real contract break.
+          case "${{ needs['provider-live'].result }}" in
+            success) ;;
+            skipped) echo "::warning::$TAG is a draft that was never verified against the live providers" ;;
+            *) echo "live-provider validation did not succeed; the draft is incomplete" >&2; exit 1 ;;
+          esac
           assets="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
           echo "$assets"
           missing=()
@@ -572,8 +607,8 @@ jobs:
 
   guard-incomplete:
     name: Keep an incomplete release unpublished
-    needs: [build, finalize-updater, provider-live, publish]
-    if: always() && inputs.publish == true && (needs.build.result != 'success' || needs['finalize-updater'].result != 'success' || needs['provider-live'].result != 'success' || needs.publish.result != 'success')
+    needs: [build, finalize-updater, provider-credentials, provider-live, publish]
+    if: always() && inputs.publish == true && (needs.build.result != 'success' || needs['finalize-updater'].result != 'success' || needs['provider-credentials'].result != 'success' || needs['provider-live'].result != 'success' || needs.publish.result != 'success')
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -52,6 +52,26 @@ in-app updater only *does* something once there are **two** published releases:
 the version a user has installed, and a newer one to update to. Your first
 release just establishes the baseline.
 
+## Live provider validation
+
+Publishing runs the agent contract tests against the real Anthropic and Google
+APIs, so a release can never ship an updater feed while a provider integration
+is broken. That needs two repository secrets, `ANTHROPIC_API_KEY` and
+`GOOGLE_API_KEY`.
+
+The gate is scoped to publishing, not to tagging:
+
+| Run | Secrets present | Result |
+| --- | --- | --- |
+| Tag push (draft) | yes | Contracts verified; draft is fully verified |
+| Tag push (draft) | no | Contracts skipped with a warning; draft still completes |
+| Publish | yes | Contracts must pass, or the release stays a draft |
+| Publish | no | Fails immediately; nothing is published |
+
+So a missing key never blocks cutting a draft, and never lets one reach users.
+If a draft carries the "never verified against the live providers" warning, add
+the secrets and re-run the workflow for the same tag before publishing.
+
 ## Gotchas
 
 - **The tag must match the manifests.** That's the whole job of


### PR DESCRIPTION
## Summary

Cutting `v0.3.6` failed at the new `provider-live` job's credential check: `ANTHROPIC_API_KEY` and `GOOGLE_API_KEY` are not configured, and #52 made a draft build depend on them. A tag push produces a draft for review, so it should not require live third-party API credentials to complete.

## Changes

- move credential resolution into its own `provider-credentials` job on `ubuntu-22.04`, so a skipped verification never boots a billed macOS runner
- publishing still fails immediately when either key is missing
- a draft without the keys skips verification, emits a warning, and completes
- a contract that actually runs and fails still blocks the draft, unchanged
- `draft-ready` and `guard-incomplete` distinguish a skipped verification from a failed one
- document the gate in `docs/releasing.md`

## Behavior matrix

| Run | Secrets present | Result |
| --- | --- | --- |
| Tag push (draft) | yes | contracts verified |
| Tag push (draft) | no | skipped with a warning, draft completes |
| Publish | yes | contracts must pass |
| Publish | no | fails immediately, nothing published |

## How was this tested?

- [x] workflow parses and the job graph resolves as intended
- [x] the credential-gate script exercised across all six publish/secret combinations, confirming hard failure only on the publish paths
- [x] `pnpm lint`
- [x] verified `inputs.publish` is falsy for tag-push events, so a tag always takes the draft path

Re-running the Release workflow for `v0.3.6` after this merges will produce a complete draft.