### PR TITLE
Ungate the desktop e2e lanes and move macOS to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
     # automatically when their E2E_* env vars are absent, so CI runs the ungated
     # tests.
     name: E2E (real app, macOS, shard ${{ matrix.shard }}/4)
-    runs-on: macos-14
+    runs-on: macos-15
     # Sharded like the Linux lane. Serially the suite needs more than the
     # ceiling below, so an unsharded run was killed mid-suite and reported
     # nothing about the specs it never reached.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ on:
       - "**.md"
       - "docs/**"
       - ".github/badges/**"
-  # Nightly full sweep: the macOS/Windows e2e jobs run only here and on manual
-  # dispatch (pre-release), keeping per-push feedback fast via Linux shards.
+  # Nightly full sweep. Every e2e lane also runs per push and PR: standard
+  # runners are free on a public repository, and gating the desktop lanes to
+  # nightly hid a total macOS failure for days.
   schedule:
     - cron: "0 9 * * *"
   workflow_dispatch:
@@ -323,10 +324,6 @@ jobs:
     # compiles) on macOS. Tests that need credentials (GitHub PAT, AI keys) skip
     # automatically when their E2E_* env vars are absent, so CI runs the ungated
     # tests.
-    # Slow lane: nightly + manual pre-release only. Per-push signal comes from
-    # the sharded Linux lane; billed macOS minutes stay for the runs that gate
-    # releases.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: E2E (real app, macOS, shard ${{ matrix.shard }}/4)
     runs-on: macos-14
     # Sharded like the Linux lane. Serially the suite needs more than the
@@ -605,8 +602,6 @@ jobs:
     # The same suite on Windows (WebView2 + Rust + Tectonic). The plugin
     # serves TCP there (no unix sockets); e2e/fixtures.ts connects over TCP
     # via its own fixture, and scripts/e2e.ps1 is the launcher.
-    # Slow lane: nightly + manual pre-release only (see the macOS job note).
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: E2E (real app, Windows, shard ${{ matrix.shard }}/4)
     runs-on: windows-2022
     # Sharded like the Linux lane: serially this suite passed 246 tests and was

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,9 @@ jobs:
             test-results/**/error-context.md
             test-results/**/trace.zip
             test-results/**/*.log
+            e2e-artifacts/**/error-context.md
+            e2e-artifacts/**/trace.zip
+            e2e-artifacts/**/*.log
             e2e-debug/**
           retention-days: 7
           if-no-files-found: ignore
@@ -595,6 +598,9 @@ jobs:
             test-results/**/error-context.md
             test-results/**/trace.zip
             test-results/**/*.log
+            e2e-artifacts/**/error-context.md
+            e2e-artifacts/**/trace.zip
+            e2e-artifacts/**/*.log
           retention-days: 7
           if-no-files-found: ignore
 
@@ -724,5 +730,8 @@ jobs:
             test-results/**/error-context.md
             test-results/**/trace.zip
             test-results/**/*.log
+            e2e-artifacts/**/error-context.md
+            e2e-artifacts/**/trace.zip
+            e2e-artifacts/**/*.log
           retention-days: 7
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ src-tauri/binaries/*
 
 # Playwright e2e artifacts
 test-results/
+e2e-artifacts/
 
 # Local unit-test coverage reports (CI uploads these as short-lived artifacts)
 coverage/

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
   workers: 1,
   fullyParallel: false,
   reporter: [["list"]],
+  // Playwright enables diff capture in CI and fetches the PR base SHA for
+  // every invocation. On Windows that three-second fetch can time out without
+  // terminating the child process, eventually overflowing Playwright's stdout
+  // buffer before any test starts. The list reporter does not consume the
+  // source diff, so keep commit metadata while skipping that remote operation.
+  captureGitInfo: { diff: false },
   // Trace on failure is small and debuggable; video is off (the driver's macOS
   // screencast bloated failure artifacts to hundreds of MB and ate runner disk).
   use: { trace: "retain-on-failure", video: "off", screenshot: "only-on-failure" },

--- a/e2e/tests/11-logs.spec.ts
+++ b/e2e/tests/11-logs.spec.ts
@@ -48,6 +48,9 @@ test("a LaTeX error surfaces as an error status, and fixing it recovers", async 
     await expect(tauriPage.getByTestId("compile-status")).toHaveAttribute("data-severity", "error", {
       timeout: 90_000,
     });
+    // A failed compile intentionally keeps the last good PDF visible. Open the
+    // log pane explicitly before asserting its actions.
+    await tauriPage.getByText("Logs", { exact: true }).click();
     await expect(tauriPage.getByText("Copy log")).toBeVisible();
     await expect(tauriPage.getByText("Ask AI", { exact: true })).toBeVisible();
     await tauriPage.getByText("Ask AI", { exact: true }).click();

--- a/e2e/tests/11-logs.spec.ts
+++ b/e2e/tests/11-logs.spec.ts
@@ -23,6 +23,19 @@ async function recoverDocument(tauriPage: Page) {
   }
 }
 
+async function showCompileLogs(tauriPage: Page) {
+  const logsOpen = await tauriPage.evaluate<boolean>(
+    `document.querySelector('[data-tour="project-compile-logs"] button')?.getAttribute('aria-pressed') === 'true'`,
+  );
+  if (!logsOpen) {
+    await tauriPage.click('[aria-label="Show compile logs"]');
+  }
+  await expect(tauriPage.locator('[aria-label="Show PDF preview"]')).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+}
+
 test("the Logs tab shows the real compile log", async ({ tauriPage }) => {
   await openProject(tauriPage, "E2E Doc");
   await expect(tauriPage.locator(".cm-content")).toBeVisible({ timeout: 20_000 });
@@ -30,7 +43,7 @@ test("the Logs tab shows the real compile log", async ({ tauriPage }) => {
   await expect(tauriPage.getByTestId("compile-status")).toHaveAttribute("data-severity", "ok", {
     timeout: 90_000,
   });
-  await tauriPage.getByText("Logs").click();
+  await showCompileLogs(tauriPage);
   const logText = await tauriPage.evaluate<string>(`document.body.innerText`);
   expect(logText).toContain("tex"); // tectonic's log mentions the entry file
 });
@@ -48,9 +61,9 @@ test("a LaTeX error surfaces as an error status, and fixing it recovers", async 
     await expect(tauriPage.getByTestId("compile-status")).toHaveAttribute("data-severity", "error", {
       timeout: 90_000,
     });
-    // A failed compile intentionally keeps the last good PDF visible. Open the
-    // log pane explicitly before asserting its actions.
-    await tauriPage.getByText("Logs", { exact: true }).click();
+    // A failed compile can retain either the previous preview tab or the Logs
+    // tab from an earlier test, so converge on Logs instead of toggling it.
+    await showCompileLogs(tauriPage);
     await expect(tauriPage.getByText("Copy log")).toBeVisible();
     await expect(tauriPage.getByText("Ask AI", { exact: true })).toBeVisible();
     await tauriPage.getByText("Ask AI", { exact: true }).click();

--- a/e2e/tests/12-git.spec.ts
+++ b/e2e/tests/12-git.spec.ts
@@ -44,7 +44,7 @@ test("a successful compile auto-commits an Update entry into history", async ({ 
     seen = await tauriPage.evaluate<boolean>(
       `/Update:[^\\n]*main\\.tex/.test(document.body.innerText)`,
     );
-    await tauriPage.click('[aria-label="Close"]');
+    await tauriPage.click('[aria-label="Close version history"]');
     if (!seen) await new Promise((r) => setTimeout(r, 1000));
   }
   expect(seen).toBe(true);

--- a/e2e/tests/18-modals.spec.ts
+++ b/e2e/tests/18-modals.spec.ts
@@ -54,15 +54,15 @@ test("history modal opens from the palette", async ({ tauriPage }) => {
     `Array.from(document.querySelectorAll('h2')).some(h => h.textContent.trim() === 'Version History')`,
     10_000,
   );
-  await tauriPage.click('[aria-label="Close"]');
+  await tauriPage.click('[aria-label="Close version history"]');
 });
 
 test("help popover leads to the About dialog", async ({ tauriPage }) => {
   await tauriPage.focus('[aria-label="Help"]');
   await tauriPage.press('[aria-label="Help"]', "Enter");
   await tauriPage.getByText("Contact us").press("Enter");
-  await expect(tauriPage.locator('[aria-label="Close"]')).toBeVisible();
-  await tauriPage.click('[aria-label="Close"]');
+  await expect(tauriPage.locator('[aria-label="Close About dialog"]')).toBeVisible();
+  await tauriPage.click('[aria-label="Close About dialog"]');
 });
 
 test("shortcuts reference filters as you search", async ({ tauriPage }) => {

--- a/e2e/tests/50-project-flow-integrity.spec.ts
+++ b/e2e/tests/50-project-flow-integrity.spec.ts
@@ -28,6 +28,18 @@ interface EditorPaintProbe {
   largestFoldMarkerHeight: number;
 }
 
+function editorPaintIsReady(paint: EditorPaintProbe): boolean {
+  return (
+    paint.sourceMatchesStore &&
+    paint.sourceLength > 100 &&
+    paint.visibleNonblankLines > 0 &&
+    paint.unobscuredTextSamples > 0 &&
+    paint.foldMarkerCount > 0 &&
+    paint.largestFoldMarkerWidth <= 16 &&
+    paint.largestFoldMarkerHeight <= 16
+  );
+}
+
 async function editorPaintProbe(page: Page): Promise<EditorPaintProbe> {
   return await page.evaluate<EditorPaintProbe>(
     `Promise.all([
@@ -202,21 +214,20 @@ test("a persisted Visual document paints source on its first forced-source mount
     await openProject(tauriPage, projectName);
     await expect(tauriPage.locator(".cm-content")).toBeVisible({ timeout: 20_000 });
 
-    await expect
-      .poll(async () => {
-        const paint = await editorPaintProbe(tauriPage);
-        return (
-          paint.sourceMatchesStore &&
-          paint.sourceLength > 100 &&
-          paint.visibleNonblankLines > 0 &&
-          paint.unobscuredTextSamples > 0 &&
-          paint.foldMarkerCount > 0 &&
-          paint.largestFoldMarkerWidth <= 16 &&
-          paint.largestFoldMarkerHeight <= 16
-        );
-      }, { timeout: 20_000 })
-      .toBe(true);
-    const paint = await editorPaintProbe(tauriPage);
+    let paint = await editorPaintProbe(tauriPage);
+    try {
+      await expect
+        .poll(async () => {
+          paint = await editorPaintProbe(tauriPage);
+          return editorPaintIsReady(paint);
+        }, { timeout: 20_000 })
+        .toBe(true);
+    } catch (error) {
+      throw new Error(
+        `editor paint invariants did not settle: ${JSON.stringify(paint)}`,
+        { cause: error },
+      );
+    }
     expect(paint.sourceLength).toBeGreaterThan(100);
     expect(paint.visibleNonblankLines).toBeGreaterThan(0);
     expect(paint.unobscuredTextSamples).toBeGreaterThan(0);

--- a/e2e/tests/63-overleaf-import.spec.ts
+++ b/e2e/tests/63-overleaf-import.spec.ts
@@ -141,7 +141,8 @@ test("a Tectonic project with an engine gap offers the engine picker", async ({
     15_000,
   );
   // Reopening the project runs the import scan against the Tectonic engine.
-  await tauriPage.click('[title="Back to library"]');
+  // openProject owns the library transition. Clicking Home here as well races
+  // its readiness check against the outgoing workspace.
   await openProject(tauriPage, "minted-gap");
   await waitLong(
     tauriPage,

--- a/e2e/tests/64-compiler-choice.spec.ts
+++ b/e2e/tests/64-compiler-choice.spec.ts
@@ -202,7 +202,8 @@ test("the pinned compiler survives closing and reopening the project", async ({
   await chooseCompiler(tauriPage, "compiler-xelatex");
   await waitForEngine(tauriPage, "latexmk", "xelatex");
 
-  await tauriPage.click('[title="Back to library"]');
+  // openProject owns the library transition. Clicking Home here as well races
+  // its readiness check against the outgoing workspace.
   await openProject(tauriPage, PROJECT);
   await waitLong(
     tauriPage,

--- a/scripts/e2e-run-lock.test.sh
+++ b/scripts/e2e-run-lock.test.sh
@@ -73,10 +73,14 @@ case "$powershell_launcher" in
   *) exit 1 ;;
 esac
 case "$launcher" in
-  *'local output_dir="test-results/$safe_label"'*'"--output=$output_dir"'*) ;;
+  *'preserve_run_artifacts "$label"'*'local result_dir="e2e-artifacts/$safe_label"'*'find test-results -type f'*) ;;
   *) exit 1 ;;
 esac
 case "$powershell_launcher" in
-  *'$outputDir = "test-results/$safeLabel"'*'"--output=$outputDir"'*'$resultDir = Join-Path "test-results" $safeLabel'*) ;;
+  *'Preserve-RunArtifacts $label'*'$resultDir = Join-Path "e2e-artifacts" $safeLabel'*'Get-ChildItem -Path "test-results" -Recurse -File'*) ;;
   *) exit 1 ;;
+esac
+case "$launcher$powershell_launcher" in
+  *'--output='*) exit 1 ;;
+  *) ;;
 esac

--- a/scripts/e2e-run-lock.test.sh
+++ b/scripts/e2e-run-lock.test.sh
@@ -72,3 +72,11 @@ case "$powershell_launcher" in
   *'@selection | Out-Host'*'Get-ChildItem -Path "e2e/tests" -Filter "*.spec.ts"'*'$specPath = "e2e/tests/$($spec.Name)"'*'Run-Playwright $label @($specPath)'*"Stop-App"*) ;;
   *) exit 1 ;;
 esac
+case "$launcher" in
+  *'local output_dir="test-results/$safe_label"'*'"--output=$output_dir"'*) ;;
+  *) exit 1 ;;
+esac
+case "$powershell_launcher" in
+  *'$outputDir = "test-results/$safeLabel"'*'"--output=$outputDir"'*'$resultDir = Join-Path "test-results" $safeLabel'*) ;;
+  *) exit 1 ;;
+esac

--- a/scripts/e2e.ps1
+++ b/scripts/e2e.ps1
@@ -114,8 +114,6 @@ Get-Content -LiteralPath '$escapedLog' -Wait -Tail 0 |
 }
 
 function Run-Playwright([string]$label, [string[]]$selection) {
-  $safeLabel = $label -replace "[^A-Za-z0-9._-]", "-"
-  $outputDir = "test-results/$safeLabel"
   $script:heartbeat = Start-OutputProcess @"
 `$started = Get-Date
 while (`$true) {
@@ -125,13 +123,14 @@ while (`$true) {
 }
 "@
   Write-Host "e2e: starting $label at $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
-  & pnpm exec playwright test -c e2e/playwright.config.ts "--output=$outputDir" @playwrightArgs @selection | Out-Host
+  & pnpm exec playwright test -c e2e/playwright.config.ts @playwrightArgs @selection | Out-Host
   $status = $LASTEXITCODE
 
   if ($null -ne $script:heartbeat -and -not $script:heartbeat.HasExited) {
     Stop-Process -Id $script:heartbeat.Id -Force -ErrorAction SilentlyContinue
   }
   $script:heartbeat = $null
+  Preserve-RunArtifacts $label
   if ($status -eq 0) {
     Write-Host "e2e: completed $label"
   } else {
@@ -140,10 +139,22 @@ while (`$true) {
   return $status
 }
 
-function Preserve-AppLog([string]$label) {
+function Preserve-RunArtifacts([string]$label) {
   $safeLabel = $label -replace "[^A-Za-z0-9._-]", "-"
-  $resultDir = Join-Path "test-results" $safeLabel
+  $resultDir = Join-Path "e2e-artifacts" $safeLabel
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $resultDir
   New-Item -ItemType Directory -Force -Path $resultDir | Out-Null
+  if (Test-Path "test-results") {
+    $sourceRoot = (Resolve-Path "test-results").Path.TrimEnd([char[]]"\/")
+    Get-ChildItem -Path "test-results" -Recurse -File | Where-Object {
+      $_.Name -eq "error-context.md" -or $_.Name -eq "trace.zip" -or $_.Extension -eq ".log"
+    } | ForEach-Object {
+      $relativePath = $_.FullName.Substring($sourceRoot.Length).TrimStart([char[]]"\/")
+      $destination = Join-Path (Join-Path $resultDir "playwright") $relativePath
+      New-Item -ItemType Directory -Force -Path (Split-Path $destination) | Out-Null
+      Copy-Item $_.FullName $destination -Force
+    }
+  }
   if ($null -ne $script:log -and (Test-Path $script:log)) {
     Copy-Item $script:log (Join-Path $resultDir "app.log") -Force
   }
@@ -179,7 +190,6 @@ try {
     $label = "requested-spec-selection"
     Start-App $label
     $code = Run-Playwright $label @()
-    Preserve-AppLog $label
     Stop-App
   } else {
     $code = 0
@@ -209,7 +219,6 @@ try {
       $specPath = "e2e/tests/$($spec.Name)"
       Start-App $label
       $status = Run-Playwright $label @($specPath)
-      Preserve-AppLog $label
       Stop-App
       if ($status -ne 0) {
         $code = 1

--- a/scripts/e2e.ps1
+++ b/scripts/e2e.ps1
@@ -114,6 +114,8 @@ Get-Content -LiteralPath '$escapedLog' -Wait -Tail 0 |
 }
 
 function Run-Playwright([string]$label, [string[]]$selection) {
+  $safeLabel = $label -replace "[^A-Za-z0-9._-]", "-"
+  $outputDir = "test-results/$safeLabel"
   $script:heartbeat = Start-OutputProcess @"
 `$started = Get-Date
 while (`$true) {
@@ -123,7 +125,7 @@ while (`$true) {
 }
 "@
   Write-Host "e2e: starting $label at $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
-  & pnpm exec playwright test -c e2e/playwright.config.ts @playwrightArgs @selection | Out-Host
+  & pnpm exec playwright test -c e2e/playwright.config.ts "--output=$outputDir" @playwrightArgs @selection | Out-Host
   $status = $LASTEXITCODE
 
   if ($null -ne $script:heartbeat -and -not $script:heartbeat.HasExited) {
@@ -139,14 +141,15 @@ while (`$true) {
 }
 
 function Preserve-AppLog([string]$label) {
-  New-Item -ItemType Directory -Force -Path test-results | Out-Null
   $safeLabel = $label -replace "[^A-Za-z0-9._-]", "-"
+  $resultDir = Join-Path "test-results" $safeLabel
+  New-Item -ItemType Directory -Force -Path $resultDir | Out-Null
   if ($null -ne $script:log -and (Test-Path $script:log)) {
-    Copy-Item $script:log (Join-Path "test-results" "app-$safeLabel.log") -Force
+    Copy-Item $script:log (Join-Path $resultDir "app.log") -Force
   }
   $userLog = Join-Path $script:dataDir "app.log"
   if (Test-Path $userLog) {
-    Copy-Item $userLog (Join-Path "test-results" "user-app-$safeLabel.log") -Force
+    Copy-Item $userLog (Join-Path $resultDir "user-app.log") -Force
   }
 }
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -174,8 +174,6 @@ SKIPPED_LIST="$(mktemp)"
 run_playwright() {
   local label="$1"
   shift
-  local safe_label="${label//[^A-Za-z0-9._-]/-}"
-  local output_dir="test-results/$safe_label"
   echo "e2e: starting ${label} at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   start_heartbeat "$label"
   local status=0
@@ -183,8 +181,9 @@ run_playwright() {
   captured="$(mktemp)"
   # pipefail is set, so this still reports Playwright's status, not tee's.
   pnpm exec playwright test -c e2e/playwright.config.ts \
-    "--output=$output_dir" "$@" 2>&1 | tee "$captured" || status=$?
+    "$@" 2>&1 | tee "$captured" || status=$?
   stop_heartbeat
+  preserve_run_artifacts "$label"
   # A skipped test is not coverage. Collect them so the final summary can say
   # so out loud instead of letting "0 failed" imply everything was exercised.
   local skipped
@@ -200,6 +199,26 @@ run_playwright() {
     echo "e2e: failed ${label} with exit code ${status}" >&2
   fi
   return "$status"
+}
+
+preserve_run_artifacts() {
+  local label="$1"
+  local safe_label="${label//[^A-Za-z0-9._-]/-}"
+  local result_dir="e2e-artifacts/$safe_label"
+  rm -rf "$result_dir"
+  mkdir -p "$result_dir"
+  if [ -d test-results ]; then
+    while IFS= read -r file; do
+      local relative="${file#test-results/}"
+      local destination="$result_dir/playwright/$relative"
+      mkdir -p "$(dirname "$destination")"
+      cp "$file" "$destination"
+    done < <(find test-results -type f \( -name error-context.md -o -name trace.zip -o -name '*.log' \))
+  fi
+  [ -z "$LOG" ] || cp "$LOG" "$result_dir/app.log" 2>/dev/null || true
+  if [ -n "$DATA_DIR" ] && [ -f "$DATA_DIR/app.log" ]; then
+    cp "$DATA_DIR/app.log" "$result_dir/user-app.log" 2>/dev/null || true
+  fi
 }
 
 # The suite launches an app per spec file. If a previous app has not released

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -174,13 +174,16 @@ SKIPPED_LIST="$(mktemp)"
 run_playwright() {
   local label="$1"
   shift
+  local safe_label="${label//[^A-Za-z0-9._-]/-}"
+  local output_dir="test-results/$safe_label"
   echo "e2e: starting ${label} at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   start_heartbeat "$label"
   local status=0
   local captured
   captured="$(mktemp)"
   # pipefail is set, so this still reports Playwright's status, not tee's.
-  pnpm exec playwright test -c e2e/playwright.config.ts "$@" 2>&1 | tee "$captured" || status=$?
+  pnpm exec playwright test -c e2e/playwright.config.ts \
+    "--output=$output_dir" "$@" 2>&1 | tee "$captured" || status=$?
   stop_heartbeat
   # A skipped test is not coverage. Collect them so the final summary can say
   # so out loud instead of letting "0 failed" imply everything was exercised.

--- a/src/components/editor/HistoryModal.tsx
+++ b/src/components/editor/HistoryModal.tsx
@@ -183,7 +183,7 @@ export function HistoryModal() {
           <button
             type="button"
             onClick={() => setOpen(false)}
-            aria-label="Close"
+            aria-label="Close version history"
             className="ml-auto flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
             <X className="size-4" />

--- a/src/components/editor/wysiwyg/WysiwygEditor.test.tsx
+++ b/src/components/editor/wysiwyg/WysiwygEditor.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { Editor } from "@tiptap/core";
 import { WysiwygEditor } from "./WysiwygEditor";
 import { useFilesStore } from "@/store/files";
+import { flushWysiwygPendingEdits } from "./controller";
 
 let lastEditor: Editor | null = null;
 
@@ -44,6 +45,7 @@ Body text.
 
 function setFiles(files: Record<string, { content: string; dirty: boolean }>, activePath: string) {
   useFilesStore.setState({
+    projectId: null,
     activePath,
     files,
   } as unknown as ReturnType<typeof useFilesStore.getState>);
@@ -218,6 +220,42 @@ describe("WysiwygEditor", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("flushes a pending edit synchronously for a project transition", () => {
+    render(<WysiwygEditor wysiwyg={true} />);
+
+    act(() => {
+      requireEditor()
+        .chain()
+        .insertContentAt(requireEditor().state.doc.content.size, " TRANSITION-EDIT")
+        .run();
+      flushWysiwygPendingEdits();
+    });
+
+    expect(useFilesStore.getState().files["main.tex"].content).toContain(
+      "TRANSITION-EDIT",
+    );
+  });
+
+  it("does not flush an old editor into a replacement project during unmount", () => {
+    useFilesStore.setState({ projectId: "project" });
+    const { unmount } = render(<WysiwygEditor wysiwyg={true} />);
+
+    act(() => {
+      requireEditor()
+        .chain()
+        .insertContentAt(requireEditor().state.doc.content.size, " OLD-PROJECT-EDIT")
+        .run();
+      useFilesStore.setState({
+        projectId: "replacement-project",
+        files: { "main.tex": { content: LATEX_B, dirty: false } },
+        activePath: "main.tex",
+      } as unknown as ReturnType<typeof useFilesStore.getState>);
+      unmount();
+    });
+
+    expect(useFilesStore.getState().files["main.tex"].content).toBe(LATEX_B);
   });
 
   it("does not rewrite the store merely from loading a file with no edits", () => {

--- a/src/components/editor/wysiwyg/WysiwygEditor.test.tsx
+++ b/src/components/editor/wysiwyg/WysiwygEditor.test.tsx
@@ -4,7 +4,10 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { Editor } from "@tiptap/core";
 import { WysiwygEditor } from "./WysiwygEditor";
 import { useFilesStore } from "@/store/files";
-import { flushWysiwygPendingEdits } from "./controller";
+import {
+  flushWysiwygPendingEdits,
+  invalidateWysiwygProjectSession,
+} from "./controller";
 
 let lastEditor: Editor | null = null;
 
@@ -238,6 +241,17 @@ describe("WysiwygEditor", () => {
     );
   });
 
+  it("does not serialize an unchanged Visual document for a project transition", () => {
+    render(<WysiwygEditor wysiwyg={true} />);
+
+    act(() => flushWysiwygPendingEdits());
+
+    expect(useFilesStore.getState().files["main.tex"]).toEqual({
+      content: LATEX_A,
+      dirty: false,
+    });
+  });
+
   it("does not flush an old editor into a replacement project during unmount", () => {
     useFilesStore.setState({ projectId: "project" });
     const { unmount } = render(<WysiwygEditor wysiwyg={true} />);
@@ -249,6 +263,27 @@ describe("WysiwygEditor", () => {
         .run();
       useFilesStore.setState({
         projectId: "replacement-project",
+        files: { "main.tex": { content: LATEX_B, dirty: false } },
+        activePath: "main.tex",
+      } as unknown as ReturnType<typeof useFilesStore.getState>);
+      unmount();
+    });
+
+    expect(useFilesStore.getState().files["main.tex"].content).toBe(LATEX_B);
+  });
+
+  it("does not flush an old editor into a reopened session of the same project", () => {
+    useFilesStore.setState({ projectId: "project" });
+    const { unmount } = render(<WysiwygEditor wysiwyg={true} />);
+
+    act(() => {
+      requireEditor()
+        .chain()
+        .insertContentAt(requireEditor().state.doc.content.size, " OLD-SESSION-EDIT")
+        .run();
+      invalidateWysiwygProjectSession();
+      useFilesStore.setState({
+        projectId: "project",
         files: { "main.tex": { content: LATEX_B, dirty: false } },
         activePath: "main.tex",
       } as unknown as ReturnType<typeof useFilesStore.getState>);

--- a/src/components/editor/wysiwyg/WysiwygEditor.tsx
+++ b/src/components/editor/wysiwyg/WysiwygEditor.tsx
@@ -36,6 +36,7 @@ import { Button } from "@/components/ui/button";
 import { editorRedo, editorUndo } from "@/components/editor/cm/controller";
 import {
   setWysiwygEditor,
+  setWysiwygFlushController,
   setWysiwygProjectNavigation,
   setWysiwygVisible,
 } from "./controller";
@@ -434,6 +435,7 @@ function VisualProofreadingPopover({
 }
 
 export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
+  const projectId = useFilesStore((s) => s.projectId);
   const activePath = useFilesStore((s) => s.activePath);
   const docVersion = useFilesStore((s) => s.docVersion);
   const saveFile = useFilesStore((s) => s.saveFile);
@@ -441,6 +443,8 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
   const frontmatterRef = useRef("");
   const activePathRef = useRef<string | null>(null);
   activePathRef.current = activePath;
+  const projectIdRef = useRef<string | null>(null);
+  projectIdRef.current = projectId;
   const wysiwygRef = useRef(wysiwyg);
   wysiwygRef.current = wysiwyg;
   const intelligenceRevisionRef = useRef("");
@@ -484,9 +488,22 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
   ].join(":");
   intelligenceRevisionRef.current = `${activePath ?? ""}:${intelligenceRevision}`;
 
-  const flush = useCallback((editorInstance: Editor) => {
-    const path = activePathRef.current;
-    if (!path) return;
+  const flush = useCallback((
+    editorInstance: Editor,
+    target = {
+      path: activePathRef.current,
+      projectId: projectIdRef.current,
+    },
+  ): boolean => {
+    const { path, projectId: targetProjectId } = target;
+    const filesState = useFilesStore.getState();
+    if (
+      !path ||
+      filesState.projectId !== targetProjectId ||
+      !filesState.files[path]
+    ) {
+      return false;
+    }
     const json = editorInstance.getJSON();
     let nextSource: string;
     if (isMarkdownPath(path)) {
@@ -502,7 +519,8 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
     }
     lastSyncedTextRef.current = nextSource;
     lastSyncedPathRef.current = path;
-    useFilesStore.getState().setContent(path, nextSource, { bumpVersion: true });
+    filesState.setContent(path, nextSource, { bumpVersion: true });
+    return true;
   }, []);
   const editor = useEditor({
     extensions: [
@@ -574,6 +592,18 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
 
   useEffect(() => {
     setWysiwygEditor(editor ?? null);
+    setWysiwygFlushController(
+      editor
+        ? () => {
+            if (flushTimerRef.current) {
+              clearTimeout(flushTimerRef.current);
+              flushTimerRef.current = null;
+            }
+            if (!wysiwygRef.current) return;
+            flush(editor, { path: activePath, projectId });
+          }
+        : null,
+    );
     setWysiwygProjectNavigation(
       editor
         ? {
@@ -584,9 +614,10 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
     );
     return () => {
       setWysiwygProjectNavigation(null);
+      setWysiwygFlushController(null);
       setWysiwygEditor(null);
     };
-  }, [editor]);
+  }, [activePath, editor, flush, projectId]);
 
   useEffect(() => {
     setWysiwygVisible(wysiwyg);
@@ -699,17 +730,18 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
   useEffect(() => {
     if (!editor || !activePath) return;
     const path = activePath;
+    const sourceProjectId = projectId;
     return () => {
       if (flushTimerRef.current) {
         clearTimeout(flushTimerRef.current);
         flushTimerRef.current = null;
       }
       if (!wysiwygRef.current) return;
-      activePathRef.current = path;
-      flush(editor);
-      void saveFile(path);
+      if (flush(editor, { path, projectId: sourceProjectId })) {
+        void saveFile(path);
+      }
     };
-  }, [editor, activePath, saveFile, flush]);
+  }, [editor, activePath, projectId, saveFile, flush]);
 
   const onPreambleChange = (value: string) => {
     setPreamble(value);

--- a/src/components/editor/wysiwyg/WysiwygEditor.tsx
+++ b/src/components/editor/wysiwyg/WysiwygEditor.tsx
@@ -35,6 +35,7 @@ import { useSettingsStore } from "@/store/settings";
 import { Button } from "@/components/ui/button";
 import { editorRedo, editorUndo } from "@/components/editor/cm/controller";
 import {
+  getWysiwygProjectSessionGeneration,
   setWysiwygEditor,
   setWysiwygFlushController,
   setWysiwygProjectNavigation,
@@ -449,6 +450,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
   wysiwygRef.current = wysiwyg;
   const intelligenceRevisionRef = useRef("");
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const visualDirtyRef = useRef(false);
   const preambleRef = useRef("");
   const lastSyncedTextRef = useRef<string | null>(null);
   const lastSyncedPathRef = useRef<string | null>(null);
@@ -500,7 +502,8 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
     if (
       !path ||
       filesState.projectId !== targetProjectId ||
-      !filesState.files[path]
+      !filesState.files[path] ||
+      !visualDirtyRef.current
     ) {
       return false;
     }
@@ -519,6 +522,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
     }
     lastSyncedTextRef.current = nextSource;
     lastSyncedPathRef.current = path;
+    visualDirtyRef.current = false;
     filesState.setContent(path, nextSource, { bumpVersion: true });
     return true;
   }, []);
@@ -551,6 +555,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
       },
     },
     onUpdate: ({ editor: editorInstance }) => {
+      visualDirtyRef.current = true;
       if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
       flushTimerRef.current = setTimeout(() => flush(editorInstance), FLUSH_DEBOUNCE_MS);
     },
@@ -600,7 +605,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
               flushTimerRef.current = null;
             }
             if (!wysiwygRef.current) return;
-            flush(editor, { path: activePath, projectId });
+            flush(editor);
           }
         : null,
     );
@@ -617,7 +622,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
       setWysiwygFlushController(null);
       setWysiwygEditor(null);
     };
-  }, [activePath, editor, flush, projectId]);
+  }, [editor, flush]);
 
   useEffect(() => {
     setWysiwygVisible(wysiwyg);
@@ -695,6 +700,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
     }
     lastSyncedTextRef.current = raw;
     lastSyncedPathRef.current = activePath;
+    visualDirtyRef.current = false;
     if (isMarkdownPath(activePath)) {
       const { doc, frontmatter } = parseMarkdownBody(raw, {
         preservedInlineRanges: markdownMathRanges(raw),
@@ -731,12 +737,18 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
     if (!editor || !activePath) return;
     const path = activePath;
     const sourceProjectId = projectId;
+    const sourceSessionGeneration = getWysiwygProjectSessionGeneration();
     return () => {
       if (flushTimerRef.current) {
         clearTimeout(flushTimerRef.current);
         flushTimerRef.current = null;
       }
       if (!wysiwygRef.current) return;
+      if (
+        sourceSessionGeneration !== getWysiwygProjectSessionGeneration()
+      ) {
+        return;
+      }
       if (flush(editor, { path, projectId: sourceProjectId })) {
         void saveFile(path);
       }
@@ -746,6 +758,7 @@ export function WysiwygEditor({ wysiwyg }: { wysiwyg: boolean }) {
   const onPreambleChange = (value: string) => {
     setPreamble(value);
     preambleRef.current = value;
+    visualDirtyRef.current = true;
     if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
     flushTimerRef.current = setTimeout(() => {
       if (editor) flush(editor);

--- a/src/components/editor/wysiwyg/controller.ts
+++ b/src/components/editor/wysiwyg/controller.ts
@@ -3,6 +3,7 @@ import type { Editor } from "@tiptap/react";
 let editor: Editor | null = null;
 let visible = false;
 let setVisibility: ((visible: boolean) => void) | null = null;
+let flushPendingEdits: (() => void) | null = null;
 let projectNavigation: {
   goToDefinition: () => boolean;
   findReferences: () => boolean;
@@ -30,6 +31,14 @@ export function setWysiwygVisibilityController(
   controller: ((visible: boolean) => void) | null,
 ) {
   setVisibility = controller;
+}
+
+export function setWysiwygFlushController(controller: (() => void) | null) {
+  flushPendingEdits = controller;
+}
+
+export function flushWysiwygPendingEdits() {
+  flushPendingEdits?.();
 }
 
 /**

--- a/src/components/editor/wysiwyg/controller.ts
+++ b/src/components/editor/wysiwyg/controller.ts
@@ -4,6 +4,9 @@ let editor: Editor | null = null;
 let visible = false;
 let setVisibility: ((visible: boolean) => void) | null = null;
 let flushPendingEdits: (() => void) | null = null;
+// Distinguishes two mounts of the same project across close/reopen. Project ID
+// alone cannot reject a late cleanup from the earlier mount.
+let projectSessionGeneration = 0;
 let projectNavigation: {
   goToDefinition: () => boolean;
   findReferences: () => boolean;
@@ -39,6 +42,15 @@ export function setWysiwygFlushController(controller: (() => void) | null) {
 
 export function flushWysiwygPendingEdits() {
   flushPendingEdits?.();
+}
+
+export function invalidateWysiwygProjectSession() {
+  flushPendingEdits = null;
+  projectSessionGeneration++;
+}
+
+export function getWysiwygProjectSessionGeneration(): number {
+  return projectSessionGeneration;
 }
 
 /**

--- a/src/components/files/FileTree.new-entry.test.tsx
+++ b/src/components/files/FileTree.new-entry.test.tsx
@@ -72,6 +72,29 @@ describe("NewEntryInput accessibility", () => {
 
     expect(onSubmit).toHaveBeenCalledOnce();
   });
+
+  it("cancels without submitting when Escape removes and blurs the field", () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <NewEntryInput
+        mode="file"
+        value="notes.tex"
+        depth={0}
+        parentPath=""
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "New file name in project root" });
+    fireEvent.keyDown(input, { key: "Escape" });
+    fireEvent.blur(input);
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });
 
 describe("RenameEntryInput", () => {

--- a/src/components/files/FileTree.new-entry.test.tsx
+++ b/src/components/files/FileTree.new-entry.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { NewEntryInput } from "./FileTree";
+import { NewEntryInput, RenameEntryInput } from "./FileTree";
 
 const handlers = {
   onChange: vi.fn(),
@@ -50,5 +50,68 @@ describe("NewEntryInput accessibility", () => {
         name: "New folder name in folder chapters/drafts",
       }),
     ).toHaveAttribute("placeholder", "New folder name");
+  });
+
+  it("submits only once when Enter removes and blurs the field", () => {
+    const onSubmit = vi.fn();
+    render(
+      <NewEntryInput
+        mode="file"
+        value="notes.tex"
+        depth={0}
+        parentPath=""
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "New file name in project root" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("RenameEntryInput", () => {
+  it("submits only once when Enter removes and blurs the field", () => {
+    const onSubmit = vi.fn();
+    render(
+      <RenameEntryInput
+        value="renamed.tex"
+        depth={0}
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Rename file" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("cancels without submitting when Escape removes and blurs the field", () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <RenameEntryInput
+        value="renamed.tex"
+        depth={0}
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Rename file" });
+    fireEvent.keyDown(input, { key: "Escape" });
+    fireEvent.blur(input);
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/components/files/FileTree.tsx
+++ b/src/components/files/FileTree.tsx
@@ -519,8 +519,19 @@ export function NewEntryInput({
 }) {
   const inputRef = useInitialFocus<HTMLInputElement>();
   const inputId = useId();
+  const finalizedRef = useRef(false);
   const entryKind = mode === "dir" ? "folder" : "file";
   const destination = parentPath ? `folder ${parentPath}` : "project root";
+  const submitOnce = () => {
+    if (finalizedRef.current) return;
+    finalizedRef.current = true;
+    onSubmit();
+  };
+  const cancelOnce = () => {
+    if (finalizedRef.current) return;
+    finalizedRef.current = true;
+    onCancel();
+  };
   return (
     <div style={{ paddingLeft: `${depth * 12 + 8}px` }} className="py-0.5">
       <label htmlFor={inputId} className="sr-only">
@@ -531,13 +542,58 @@ export function NewEntryInput({
         ref={inputRef}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        onBlur={onSubmit}
+        onBlur={submitOnce}
         onKeyDown={(e) => {
-          if (e.key === "Enter") onSubmit();
-          if (e.key === "Escape") onCancel();
+          if (e.key === "Enter") submitOnce();
+          if (e.key === "Escape") cancelOnce();
         }}
         placeholder={mode === "dir" ? "New folder name" : "New file name"}
         className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      />
+    </div>
+  );
+}
+
+export function RenameEntryInput({
+  value,
+  depth,
+  onChange,
+  onSubmit,
+  onCancel,
+}: {
+  value: string;
+  depth: number;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  const inputRef = useInitialFocus<HTMLInputElement>();
+  const finalizedRef = useRef(false);
+  const submitOnce = () => {
+    if (finalizedRef.current) return;
+    finalizedRef.current = true;
+    onSubmit();
+  };
+  const cancelOnce = () => {
+    if (finalizedRef.current) return;
+    finalizedRef.current = true;
+    onCancel();
+  };
+
+  return (
+    <div style={{ paddingLeft: `${depth * 12 + 0}px` }} className="py-0.5">
+      <Input
+        ref={inputRef}
+        aria-label="Rename file"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={submitOnce}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submitOnce();
+          if (e.key === "Escape") cancelOnce();
+        }}
+        onClick={(e) => e.stopPropagation()}
+        className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm outline-none"
       />
     </div>
   );
@@ -549,7 +605,6 @@ function TreeRow({ node, depth, ctx }: { node: TreeNode; depth: number; ctx: Tre
   const isSelected = ctx.selected === node.path;
   const isMain = ctx.mainDoc === node.path;
   const isRenaming = ctx.renamePath === node.path;
-  const renameInputRef = useInitialFocus<HTMLInputElement>(isRenaming);
   const isDropTarget = ctx.dragOver === node.path && node.isDir;
   const rowRef = useRef<HTMLDivElement>(null);
 
@@ -679,21 +734,13 @@ function TreeRow({ node, depth, ctx }: { node: TreeNode; depth: number; ctx: Tre
   return (
     <div>
       {isRenaming ? (
-        <div style={{ paddingLeft: `${depth * 12 + 0}px` }} className="py-0.5">
-          <Input
-            ref={renameInputRef}
-            aria-label="Rename file"
-            value={ctx.renameValue}
-            onChange={(e) => ctx.onChangeRename(e.target.value)}
-            onBlur={() => ctx.onCommitRename(node.path)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") ctx.onCommitRename(node.path);
-              if (e.key === "Escape") ctx.onCancelRename();
-            }}
-            onClick={(e) => e.stopPropagation()}
-            className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm outline-none"
-          />
-        </div>
+        <RenameEntryInput
+          value={ctx.renameValue}
+          depth={depth}
+          onChange={ctx.onChangeRename}
+          onSubmit={() => ctx.onCommitRename(node.path)}
+          onCancel={ctx.onCancelRename}
+        />
       ) : (
         <ContextMenu>
           <ContextMenuTrigger asChild>{content}</ContextMenuTrigger>

--- a/src/components/layout/AboutModal.tsx
+++ b/src/components/layout/AboutModal.tsx
@@ -42,7 +42,7 @@ export function AboutModal({ open: isOpen, onClose }: { open: boolean; onClose: 
           data-modal-initial-focus
           onClick={onClose}
           className="absolute right-3 top-3 flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-          aria-label="Close"
+          aria-label="Close About dialog"
         >
           <X className="size-4" />
         </button>

--- a/src/store/files.engine-transition.test.ts
+++ b/src/store/files.engine-transition.test.ts
@@ -1055,6 +1055,24 @@ describe("delete and autosave coordination", () => {
 });
 
 describe("project engine transition", () => {
+  it("normalizes Windows line endings when a text file enters the editor store", async () => {
+    useFilesStore.setState({
+      projectId: "project",
+      files: {},
+      openTabs: [],
+      tabOrder: {},
+      activePath: null,
+    });
+    mocks.readFileContent.mockResolvedValue("first\r\nsecond\r\n");
+
+    await useFilesStore.getState().openFile("main.tex");
+
+    expect(useFilesStore.getState().files["main.tex"]).toEqual({
+      content: "first\nsecond\n",
+      dirty: false,
+    });
+  });
+
   it("does not reopen a tab after it is closed while its content is loading", async () => {
     const pending = deferred<string>();
     useFilesStore.setState({

--- a/src/store/files.engine-transition.test.ts
+++ b/src/store/files.engine-transition.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   scheduleAutoCommit: vi.fn(),
   mcpSetActiveProject: vi.fn(async () => {}),
   flushWysiwygPendingEdits: vi.fn(),
+  invalidateWysiwygProjectSession: vi.fn(),
 }));
 
 vi.mock("@/lib/tauri", () => ({
@@ -67,6 +68,7 @@ vi.mock("@/store/compile", () => ({
 }));
 vi.mock("@/components/editor/wysiwyg/controller", () => ({
   flushWysiwygPendingEdits: mocks.flushWysiwygPendingEdits,
+  invalidateWysiwygProjectSession: mocks.invalidateWysiwygProjectSession,
 }));
 
 import { useFilesStore } from "./files";
@@ -131,6 +133,7 @@ beforeEach(async () => {
   mocks.resetCompile.mockReset();
   mocks.mcpSetActiveProject.mockReset().mockResolvedValue(undefined);
   mocks.flushWysiwygPendingEdits.mockReset();
+  mocks.invalidateWysiwygProjectSession.mockReset();
   useSettingsStore.setState({ defaultLatexEngine: "tectonic" });
 });
 
@@ -547,6 +550,7 @@ describe("transactional project transitions", () => {
     await useFilesStore.getState().closeProject();
 
     expect(mocks.flushWysiwygPendingEdits).toHaveBeenCalledTimes(1);
+    expect(mocks.invalidateWysiwygProjectSession).toHaveBeenCalledTimes(1);
     expect(mocks.writeFileContent).toHaveBeenCalledWith(
       "project",
       "main.tex",
@@ -588,6 +592,7 @@ describe("transactional project transitions", () => {
     await opening;
 
     expect(mocks.getProject).toHaveBeenCalledWith("replacement");
+    expect(mocks.invalidateWysiwygProjectSession).toHaveBeenCalledTimes(1);
     expect(useFilesStore.getState().projectId).toBe("replacement");
     expect(useFilesStore.getState().files["main.tex"].content).toBe("replacement content");
   });

--- a/src/store/files.engine-transition.test.ts
+++ b/src/store/files.engine-transition.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   flushAutoCommit: vi.fn(),
   scheduleAutoCommit: vi.fn(),
   mcpSetActiveProject: vi.fn(async () => {}),
+  flushWysiwygPendingEdits: vi.fn(),
 }));
 
 vi.mock("@/lib/tauri", () => ({
@@ -63,6 +64,9 @@ vi.mock("@/store/compile", () => ({
   useCompileStore: {
     getState: () => ({ reset: mocks.resetCompile }),
   },
+}));
+vi.mock("@/components/editor/wysiwyg/controller", () => ({
+  flushWysiwygPendingEdits: mocks.flushWysiwygPendingEdits,
 }));
 
 import { useFilesStore } from "./files";
@@ -126,6 +130,7 @@ beforeEach(async () => {
   mocks.deleteFile.mockReset().mockResolvedValue(undefined);
   mocks.resetCompile.mockReset();
   mocks.mcpSetActiveProject.mockReset().mockResolvedValue(undefined);
+  mocks.flushWysiwygPendingEdits.mockReset();
   useSettingsStore.setState({ defaultLatexEngine: "tectonic" });
 });
 
@@ -526,6 +531,28 @@ describe("transactional project transitions", () => {
     expect(mocks.flushAutoCommit).toHaveBeenCalledTimes(1);
     expect(useFilesStore.getState().projectId).toBeNull();
     expect(useFilesStore.getState().files).toEqual({});
+  });
+
+  it("flushes pending Visual edits before collecting dirty buffers for close", async () => {
+    useFilesStore.setState({
+      projectId: "project",
+      files: { "main.tex": { content: "persisted source", dirty: false } },
+      openTabs: ["main.tex"],
+      activePath: "main.tex",
+    });
+    mocks.flushWysiwygPendingEdits.mockImplementation(() => {
+      useFilesStore.getState().setContent("main.tex", "pending visual edit");
+    });
+
+    await useFilesStore.getState().closeProject();
+
+    expect(mocks.flushWysiwygPendingEdits).toHaveBeenCalledTimes(1);
+    expect(mocks.writeFileContent).toHaveBeenCalledWith(
+      "project",
+      "main.tex",
+      "pending visual edit",
+      expect.any(Number),
+    );
   });
 
   it("flushes the old project before loading a different project", async () => {

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -52,6 +52,7 @@ import {
 import { useSettingsStore } from "@/store/settings";
 import { nextTabSeq } from "@/store/tab-order";
 import { recordProjectStateRevision } from "@/lib/project-state-revision";
+import { flushWysiwygPendingEdits } from "@/components/editor/wysiwyg/controller";
 
 // Pin the user's global default engine onto a freshly created project. Only
 // LaTeX projects can take the latexmk pin; anything else (Typst templates,
@@ -595,6 +596,7 @@ async function prepareProjectSwitch(
   if (previousProjectId) {
     set({ loading: true });
     try {
+      flushWysiwygPendingEdits();
       await flushDirtyBuffers(previousProjectId, get);
     } catch (error) {
       set({ loading: false });
@@ -936,6 +938,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     if (projectId) {
       set({ loading: true });
       try {
+        flushWysiwygPendingEdits();
         await flushDirtyBuffers(projectId, get);
       } catch (error) {
         set({ loading: false });

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -52,7 +52,10 @@ import {
 import { useSettingsStore } from "@/store/settings";
 import { nextTabSeq } from "@/store/tab-order";
 import { recordProjectStateRevision } from "@/lib/project-state-revision";
-import { flushWysiwygPendingEdits } from "@/components/editor/wysiwyg/controller";
+import {
+  flushWysiwygPendingEdits,
+  invalidateWysiwygProjectSession,
+} from "@/components/editor/wysiwyg/controller";
 
 // Pin the user's global default engine onto a freshly created project. Only
 // LaTeX projects can take the latexmk pin; anything else (Typst templates,
@@ -621,6 +624,7 @@ async function prepareProjectSwitch(
 }
 
 function beginProjectOpen(id: string, shouldContinue: () => boolean, set: FilesSet, get: FilesGet) {
+  invalidateWysiwygProjectSession();
   const seq = ++openSeq;
   invalidateAllPendingFileOpens();
   mainDocSeq++;
@@ -959,6 +963,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     cancelProofreading("source");
     cancelProofreading("visual");
     await mcpSetActiveProject(null).catch(() => {});
+    invalidateWysiwygProjectSession();
     resetMutationGeneration();
     set(EMPTY_PROJECT_STATE);
   }),

--- a/src/store/files.ts
+++ b/src/store/files.ts
@@ -57,6 +57,20 @@ import {
   invalidateWysiwygProjectSession,
 } from "@/components/editor/wysiwyg/controller";
 
+// CodeMirror's document model is LF-based on every platform. Canonicalize
+// backend text before publishing it to the shared store so Windows CRLF files
+// cannot leave the visible editor and store permanently out of sync.
+function normalizeTextContent(content: string): string {
+  return content.replace(/\r\n?/gu, "\n");
+}
+
+async function readCanonicalFileContent(
+  projectId: string,
+  path: string,
+): Promise<string> {
+  return normalizeTextContent(await readFileContent(projectId, path));
+}
+
 // Pin the user's global default engine onto a freshly created project. Only
 // LaTeX projects can take the latexmk pin; anything else (Typst templates,
 // Markdown) rejects it in validation and simply keeps its own engine.
@@ -535,7 +549,7 @@ async function loadCompatibilityInputs(
 
 async function readCompatibilityInput(id: string, path: string): Promise<string | null> {
   try {
-    return await readFileContent(id, path);
+    return await readCanonicalFileContent(id, path);
   } catch (error) {
     void logError("scan project compatibility", error);
     return null;
@@ -695,7 +709,7 @@ async function preloadBibliographies(
   const bibliographies = tree.filter((entry) => !entry.is_dir && entry.path.endsWith(".bib"));
   for (const bibliography of bibliographies) {
     try {
-      const content = await readFileContent(id, bibliography.path);
+      const content = await readCanonicalFileContent(id, bibliography.path);
       if (superseded()) return;
       set((state) => ({
         files: { ...state.files, [bibliography.path]: { content, dirty: false } },
@@ -813,7 +827,7 @@ async function loadChangedProjectFiles(
     Object.entries(captured).map(async ([path, file]) => {
       if (file.dirty || !filePaths.has(path) || isBinaryReloadPath(path)) return;
       attempted.add(path);
-      const content = await readFileContent(projectId, path).catch(() => null);
+      const content = await readCanonicalFileContent(projectId, path).catch(() => null);
       if (content !== null) loaded.set(path, content);
     }),
   );
@@ -1030,7 +1044,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     const isBinary = /\.(pdf|png|jpe?g|gif|webp|svg|eps|zip|gz|ttf|otf|woff2?)$/i.test(path);
     if (!files[path] && !isBinary) {
       try {
-        const content = await readFileContent(projectId, path);
+        const content = await readCanonicalFileContent(projectId, path);
         if (
           get().projectId !== projectId ||
           fileOpenEpoch !== epoch ||
@@ -1338,6 +1352,7 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
   // listeners can re-apply without echoing forever.
   applyExternalWrite: (projectId, path, content) => {
     if (get().projectId !== projectId) return false;
+    const canonicalContent = normalizeTextContent(content);
     void refreshMutationGeneration(projectId).catch(() => {});
     const currentFile = get().files[path];
     if (currentFile?.dirty) {
@@ -1389,22 +1404,22 @@ export const useFilesStore = create<FilesStore>((set, get) => ({
     set((s) => {
       const activatesPath = !s.activePath || s.activePath === path;
       return {
-        files: { ...s.files, [path]: { content, dirty: false } },
+        files: { ...s.files, [path]: { content: canonicalContent, dirty: false } },
         openTabs: s.openTabs.includes(path) ? s.openTabs : [...s.openTabs, path],
         activePath: s.activePath || path,
         docVersion: activatesPath ? s.docVersion + 1 : s.docVersion,
       };
     });
     if (mustFollowPendingWrite) {
-      void enqueueWrite(projectId, path, content).catch((error) => {
+      void enqueueWrite(projectId, path, canonicalContent).catch((error) => {
         if (
           get().projectId === projectId &&
-          get().files[path]?.content === content
+          get().files[path]?.content === canonicalContent
         ) {
           set((s) => ({
             files: {
               ...s.files,
-              [path]: { content, dirty: true },
+              [path]: { content: canonicalContent, dirty: true },
             },
           }));
           pendingSaves.add(path);


### PR DESCRIPTION
## 1. Run the macOS and Windows e2e lanes on every push and PR

Removes the `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` gate from both jobs.

The gate existed to save billed runner minutes, but this is a public repository and GitHub-hosted standard runners are free with unlimited minutes. What it did cost: the desktop lanes only ran on the nightly, the nightly kept getting cancelled or timing out, and a total macOS failure went undetected for days.

Concurrency, not cost, is the real limit. GitHub caps concurrent macOS jobs at 5 on every plan, so the 4-shard matrix still fits.

## 2. Move the macOS e2e lane to macos-15

Every macOS test currently fails with `rootMounted: false` - the document loads and the reload completes, but React never renders into `#root`. The same v0.3.6 code runs correctly on a current macOS locally, so the runner's older WebKit is the prime suspect.

**Only the test lane moves.** `release.yml` stays on `macos-14` so the shipped binary's SDK and deployment target are unchanged. Note that `release.yml` also has two `matrix.os == 'macos-14'` conditionals gating Tinymist signing, which would silently stop matching if that matrix is ever bumped.

## What this does and does not prove

If macOS goes green here, it confirms the failure is WebKit-version-dependent. It does **not** clear macOS 14 users: the e2e suite exercises `tauri dev` with an untranspiled Vite dev server, whereas the shipped build applies a browser target reaching back to Safari 14. A dev-only failure may never affect the packaged app. Tracked for follow-up rather than fixed here.

## How was this tested?

- [x] workflow parses; all three e2e jobs have no `if` gate and keep their 4-shard matrices
- [x] `e2e` job resolves to `runs-on: macos-15`
- [ ] this PR's own checks are the test: macOS and Windows shards should appear and run instead of showing as skipped