### PR TITLE
fix(deps): raise nanoid override to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   undici@<7.29.0: 7.29.0
   mermaid@<11.16.1: 11.16.1
@@ -4422,8 +4422,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8844,7 +8844,7 @@ snapshots:
   emscripten-wasm-loader@3.0.3(patch_hash=8eebb0ec457e29444d0f4c2ee9e4e45a8932e088e09b12a6a099daad3251fb65):
     dependencies:
       getroot: 1.0.0
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       unixify: 1.0.0
 
   enhanced-resolve@5.24.5:
@@ -9191,7 +9191,7 @@ snapshots:
   hunspell-asm@4.0.2(patch_hash=f5634e1c2ed4fdf8fe6c238d5f6d3c9006136c951a3ecfadea19ef30c7092726):
     dependencies:
       emscripten-wasm-loader: 3.0.3(patch_hash=8eebb0ec457e29444d0f4c2ee9e4e45a8932e088e09b12a6a099daad3251fb65)
-      nanoid: 3.3.17
+      nanoid: 3.3.18
 
   iconv-lite@0.6.3:
     dependencies:
@@ -10031,7 +10031,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.50: {}
 
@@ -10136,7 +10136,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,10 +6,10 @@ allowBuilds:
 
 # Force the transitive nanoid (via hunspell-asm) to a patched version.
 # GHSA-mwcw-c2x4-8c55: predictable results in nanoid < 3.3.8.
-# GHSA-2v37-7h3g-55p8: custom generators loop forever on size zero, < 3.3.17.
+# GHSA-2v37-7h3g-55p8: custom generators loop forever on size zero, < 3.3.18.
 # Force transitive build and test dependencies to patched versions.
 overrides:
-  nanoid@<3.3.17: "3.3.17"
+  nanoid@<3.3.18: "3.3.18"
   # GHSA-6g55-p6wh-862q: source map disclosure in postcss < 8.5.23.
   postcss@<8.5.23: "8.5.23"
   # GHSA-g9mf-h72j-4rw9 and related advisories fixed in undici 7.29.0.


### PR DESCRIPTION
## Problem

`main` CI has been red since Aug 14. Not a test failure: the `pnpm audit --prod --audit-level high` gate in the **Frontend (typecheck + build)** job (`.github/workflows/ci.yml:75`).

```
high  nanoid: custom generators can loop indefinitely when size is zero
      vulnerable <3.3.18, installed 3.3.17
      via  hunspell-asm > nanoid
           hunspell-asm > emscripten-wasm-loader > nanoid
```

## Root cause

`pnpm-workspace.yaml` already pinned nanoid, but to `3.3.17`, with a comment stating GHSA-2v37-7h3g-55p8 was fixed there. The real advisory boundary is `<3.3.18`, so the pin sat one patch short and the transitive nanoid under `hunspell-asm` stayed vulnerable. GitHub published the advisory on Aug 14, which turned the gate red on `main` and on every PR the moment its CI is rerun.

## Fix

Bump the override constraint and target to `3.3.18`, and correct the comment's version boundary.

Note: overrides live in `pnpm-workspace.yaml`, not `package.json`. pnpm 11 no longer reads the `pnpm` field from `package.json`, so an override placed there is silently ignored.

## Verification

- `pnpm audit --prod --audit-level high` -> "No known vulnerabilities found", exit 0
- `pnpm build` (tsc -b && vite build) -> exit 0
- `pnpm vitest run src/lib/proofreading` (the hunspell consumer) -> 9/9 pass
- pre-commit hook re-ran biome lint + typecheck + build clean