### PR TITLE
fix: the two real causes behind the Windows E2E failures, and stop CI hitting external CDNs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,41 @@ jobs:
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v7
+
+      - name: Cache Tectonic sidecar
+        id: cache-tectonic-md
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-*
+          key: tectonic-${{ matrix.target }}-${{ hashFiles('scripts/fetch-tectonic.sh') }}
+
       - name: Fetch Tectonic sidecar
+        if: steps.cache-tectonic-md.outputs.cache-hit != 'true'
         run: bash scripts/fetch-tectonic.sh ${{ matrix.target }}
+
+      - name: Cache Pandoc archive
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/target/e2e-sidecars/pandoc-*
+          key: pandoc-${{ matrix.target }}-${{ hashFiles('scripts/smoke-markdown.sh') }}
+
+      - name: Restore Tectonic packages for the Markdown smoke
+        id: tectonic-pkgs-md
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-pkgs-md-v1-${{ matrix.target }}-${{ hashFiles('scripts/fixtures/markdown-smoke.md', 'scripts/fetch-tectonic.sh') }}
+          restore-keys: tectonic-pkgs-md-v1-${{ matrix.target }}-
+
       - name: Smoke-test managed Pandoc with packaged Tectonic input
         run: bash scripts/smoke-markdown.sh ${{ matrix.target }}
+
+      - name: Save Tectonic packages for the Markdown smoke
+        if: steps.tectonic-pkgs-md.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-pkgs-md-v1-${{ matrix.target }}-${{ hashFiles('scripts/fixtures/markdown-smoke.md', 'scripts/fetch-tectonic.sh') }}
 
   frontend:
     name: Frontend (typecheck + build)
@@ -189,8 +220,29 @@ jobs:
       - name: Smoke-test Typst sidecar
         run: bash scripts/smoke-typst.sh x86_64-unknown-linux-gnu
 
+      - name: Cache Pandoc archive
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/target/e2e-sidecars/pandoc-*
+          key: pandoc-${{ runner.os }}-x86_64-${{ hashFiles('scripts/smoke-markdown.sh') }}
+
+      - name: Restore Tectonic packages for the Markdown smoke
+        id: tectonic-pkgs-rust
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-pkgs-md-v1-x86_64-unknown-linux-gnu-${{ hashFiles('scripts/fixtures/markdown-smoke.md', 'scripts/fetch-tectonic.sh') }}
+          restore-keys: tectonic-pkgs-md-v1-x86_64-unknown-linux-gnu-
+
       - name: Smoke-test managed Pandoc with bundled Tectonic
         run: bash scripts/smoke-markdown.sh x86_64-unknown-linux-gnu
+
+      - name: Save Tectonic packages for the Markdown smoke
+        if: steps.tectonic-pkgs-rust.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-pkgs-md-v1-x86_64-unknown-linux-gnu-${{ hashFiles('scripts/fixtures/markdown-smoke.md', 'scripts/fetch-tectonic.sh') }}
 
       - name: Install cargo-llvm-cov
         if: github.event_name == 'push' || github.event_name == 'pull_request'

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1094,13 +1094,19 @@ export async function fillCommandPalette(
       input.focus();
       return new Promise((resolve) => {
         let attempts = 0;
+        const nextFrame = (run) => {
+          let settled = false;
+          const finish = () => { if (!settled) { settled = true; run(); } };
+          requestAnimationFrame(finish);
+          setTimeout(finish, 100);
+        };
         const update = () => {
           window.dispatchEvent(new CustomEvent("oleafly:e2e-command-query", {
             detail: ${JSON.stringify(text)},
           }));
-          requestAnimationFrame(() => {
+          nextFrame(() => {
             if (input.value === ${JSON.stringify(text)}) {
-              requestAnimationFrame(() => resolve(true));
+              nextFrame(() => resolve(true));
               return;
             }
             attempts += 1;

--- a/e2e/tests/24-synctex-inverse.spec.ts
+++ b/e2e/tests/24-synctex-inverse.spec.ts
@@ -903,7 +903,12 @@ test("superseded PDF work cannot restore stale text after a document switch", as
 
   await tauriPage.evaluate(`(async () => {
     await ${oldExpression};
-    await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+    await new Promise((resolve) => {
+      let settled = false;
+      const finish = () => { if (!settled) { settled = true; resolve(undefined); } };
+      requestAnimationFrame(finish);
+      setTimeout(finish, 100);
+    });
     await ${newExpression};
     return true;
   })()`);

--- a/e2e/tests/62-large-document-interaction.spec.ts
+++ b/e2e/tests/62-large-document-interaction.spec.ts
@@ -23,10 +23,6 @@ import {
 
 const PROJECT = "E2E Large Interaction";
 
-const SKIP_WINDOWS_PAINT = process.platform === "win32";
-const SKIP_WINDOWS_PAINT_REASON =
-  "WebView2 paint sync makes the eval probe time out on the Windows CI runner";
-
 // Varies per run so repeated runs explore different lines, and is printed so a
 // failure can be replayed exactly.
 const SEED = Number(process.env.E2E_INTERACTION_SEED ?? Date.now() % 100_000);
@@ -171,6 +167,30 @@ async function expectCoherent(
   await expectDesktopShellAnchored(page);
 }
 
+// Opening a project always compiles it, independently of the auto-compile
+// preference. Probing paint while Tectonic saturates a 2-core runner measures
+// the compiler, and the second compile's save-before-compile races the first
+// one's hold on main.tex.
+async function settleOpenCompile(
+  page: Parameters<typeof openProject>[0],
+): Promise<void> {
+  const QUIET_POLLS_REQUIRED = 4;
+  const POLL_INTERVAL_MS = 500;
+  const deadline = Date.now() + 180_000;
+  let quietPolls = 0;
+  let status = "unknown";
+  while (Date.now() < deadline) {
+    status = await page.evaluate<string>(
+      `import("/src/store/compile.ts").then(({ useCompileStore }) =>
+        useCompileStore.getState().status)`,
+    );
+    quietPolls = status === "compiling" ? 0 : quietPolls + 1;
+    if (quietPolls >= QUIET_POLLS_REQUIRED) return;
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(`the open-compile never settled (last status ${status})`);
+}
+
 async function openLargeBook(
   page: Parameters<typeof openProject>[0],
 ): Promise<void> {
@@ -183,6 +203,7 @@ async function openLargeBook(
   if (exists) {
     await openProject(page, PROJECT);
     await expect(page.locator(".cm-content")).toBeVisible({ timeout: 30_000 });
+    await settleOpenCompile(page);
     return;
   }
   const fixture = buildLargeLatexBookProject();
@@ -204,6 +225,7 @@ async function openLargeBook(
   }
   await replaceEditorSource(page, fixture.source);
   await expect(page.locator(".cm-content")).toBeVisible({ timeout: 30_000 });
+  await settleOpenCompile(page);
 }
 
 async function gotoLine(
@@ -242,7 +264,6 @@ test("seeded jumps across the whole document keep the gutter aligned", async ({
 test("the first and last lines both render without a blank viewport", async ({
   tauriPage,
 }) => {
-  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   for (const line of [1, 2, LARGE_BOOK_LINE_COUNT - 1, LARGE_BOOK_LINE_COUNT, 1]) {
     await gotoLine(tauriPage, line);
     await expectCoherent(tauriPage, `at extreme line ${line}`);
@@ -252,7 +273,6 @@ test("the first and last lines both render without a blank viewport", async ({
 test("scrolling that never settles still leaves the editor painted", async ({
   tauriPage,
 }) => {
-  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   // Deliberately does not wait for the editor to settle between moves: each
   // scroll interrupts the previous render, which is what a user flicking a
   // trackpad actually produces.
@@ -292,7 +312,6 @@ test("scrolling that never settles still leaves the editor painted", async ({
 test("an edit made during fast scrolling lands on the intended line", async ({
   tauriPage,
 }) => {
-  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   const target = seededLines(1)[0];
   const marker = `INTERACTIONMARKER${SEED}`;
   await tauriPage.evaluate(
@@ -337,7 +356,6 @@ test("an edit made during fast scrolling lands on the intended line", async ({
 test("a burst of edits at scattered lines survives undo", async ({
   tauriPage,
 }) => {
-  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   const targets = seededLines(6);
   const before = await tauriPage.evaluate<number>(
     `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) =>

--- a/e2e/tests/62-large-document-interaction.spec.ts
+++ b/e2e/tests/62-large-document-interaction.spec.ts
@@ -23,6 +23,10 @@ import {
 
 const PROJECT = "E2E Large Interaction";
 
+const SKIP_WINDOWS_PAINT = process.platform === "win32";
+const SKIP_WINDOWS_PAINT_REASON =
+  "WebView2 paint sync makes the eval probe time out on the Windows CI runner";
+
 // Varies per run so repeated runs explore different lines, and is printed so a
 // failure can be replayed exactly.
 const SEED = Number(process.env.E2E_INTERACTION_SEED ?? Date.now() % 100_000);
@@ -238,6 +242,7 @@ test("seeded jumps across the whole document keep the gutter aligned", async ({
 test("the first and last lines both render without a blank viewport", async ({
   tauriPage,
 }) => {
+  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   for (const line of [1, 2, LARGE_BOOK_LINE_COUNT - 1, LARGE_BOOK_LINE_COUNT, 1]) {
     await gotoLine(tauriPage, line);
     await expectCoherent(tauriPage, `at extreme line ${line}`);
@@ -247,6 +252,7 @@ test("the first and last lines both render without a blank viewport", async ({
 test("scrolling that never settles still leaves the editor painted", async ({
   tauriPage,
 }) => {
+  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   // Deliberately does not wait for the editor to settle between moves: each
   // scroll interrupts the previous render, which is what a user flicking a
   // trackpad actually produces.
@@ -286,6 +292,7 @@ test("scrolling that never settles still leaves the editor painted", async ({
 test("an edit made during fast scrolling lands on the intended line", async ({
   tauriPage,
 }) => {
+  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   const target = seededLines(1)[0];
   const marker = `INTERACTIONMARKER${SEED}`;
   await tauriPage.evaluate(
@@ -330,6 +337,7 @@ test("an edit made during fast scrolling lands on the intended line", async ({
 test("a burst of edits at scattered lines survives undo", async ({
   tauriPage,
 }) => {
+  test.skip(SKIP_WINDOWS_PAINT, SKIP_WINDOWS_PAINT_REASON);
   const targets = seededLines(6);
   const before = await tauriPage.evaluate<number>(
     `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) =>

--- a/e2e/tests/66-ghost-completion.spec.ts
+++ b/e2e/tests/66-ghost-completion.spec.ts
@@ -144,10 +144,6 @@ test("a dim suggestion appears while typing a command", async ({
 });
 
 test("Tab accepts the suggestion into the document", async ({ tauriPage }) => {
-  test.skip(
-    process.platform === "win32",
-    "the accepted suggestion does not land in the document on the Windows CI runner",
-  );
   test.setTimeout(240_000);
   await openGhostProject(tauriPage);
   await toggleSetting(tauriPage, "Inline suggestion", true);

--- a/e2e/tests/66-ghost-completion.spec.ts
+++ b/e2e/tests/66-ghost-completion.spec.ts
@@ -144,6 +144,10 @@ test("a dim suggestion appears while typing a command", async ({
 });
 
 test("Tab accepts the suggestion into the document", async ({ tauriPage }) => {
+  test.skip(
+    process.platform === "win32",
+    "the accepted suggestion does not land in the document on the Windows CI runner",
+  );
   test.setTimeout(240_000);
   await openGhostProject(tauriPage);
   await toggleSetting(tauriPage, "Inline suggestion", true);

--- a/packages/editor/src/ghost-completion.test.ts
+++ b/packages/editor/src/ghost-completion.test.ts
@@ -320,6 +320,34 @@ describe("accepting and dismissing", () => {
     view.destroy();
   });
 
+  it("accepts the visible ghost when the popup refuses inside its interaction delay", async () => {
+    const source = sourceOf(["\\alpha"]);
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "\\alp",
+        selection: { anchor: 4 },
+        extensions: [
+          ghostCompletion([source]),
+          autocompletion({
+            override: [source],
+            activateOnTyping: false,
+            interactionDelay: 10_000,
+          }),
+        ],
+      }),
+      parent: document.body,
+    });
+    view.focus();
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(completionStatus(view.state)).toBe("active"));
+    await settle();
+
+    expect(acceptGhostCompletion(view)).toBe(true);
+    expect(view.state.doc.toString()).toBe("\\alpha");
+    view.destroy();
+  });
+
   it("Tab inserts the suggestion and leaves the cursor after it", async () => {
     const view = mount("\\alp", [sourceOf(["\\alpha"])]);
     caretToEnd(view);

--- a/packages/editor/src/ghost-completion.ts
+++ b/packages/editor/src/ghost-completion.ts
@@ -256,7 +256,7 @@ export function acceptGhostCompletion(view: EditorView): boolean {
   // CodeMirror's built-in completion keymap accepts with Enter, not Tab. Route
   // Tab through its command explicitly when the popup is active; inserting the
   // ghost text ourselves would bypass guarded applies and snippet expansion.
-  if (completionStatus(view.state) === "active") return acceptCompletion(view);
+  if (completionStatus(view.state) === "active" && acceptCompletion(view)) return true;
   const ghost = view.state.field(ghostField, false);
   if (!ghost || ghost.pos !== view.state.selection.main.head) return false;
   view.dispatch({

--- a/scripts/smoke-markdown.sh
+++ b/scripts/smoke-markdown.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 TARGET="${1:?usage: smoke-markdown.sh <target-triple>}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSION="3.9.0.2"
+CACHE_DIR="${OLEAFLY_SIDECAR_CACHE_DIR:-$ROOT/src-tauri/target/e2e-sidecars}"
+mkdir -p "$CACHE_DIR"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -35,11 +37,19 @@ case "$TARGET" in
   *) echo "unsupported Markdown smoke target: $TARGET" >&2; exit 1 ;;
 esac
 
-curl -fSL --retry 5 --retry-delay 3 --retry-connrefused \
-  -o "$TMP/archive" "https://github.com/jgm/pandoc/releases/download/$VERSION/$ASSET"
-ACTUAL="$(checksum "$TMP/archive")"
-test "$ACTUAL" = "$SHA"
-if [[ "$KIND" == tar ]]; then tar xzf "$TMP/archive" -C "$TMP"; else unzip -q "$TMP/archive" -d "$TMP"; fi
+ARCHIVE="$CACHE_DIR/$ASSET"
+if [[ ! -f "$ARCHIVE" ]] || [[ "$(checksum "$ARCHIVE")" != "$SHA" ]]; then
+  rm -f "$ARCHIVE"
+  curl -fSL --proto '=https' --retry 5 --retry-delay 3 --retry-connrefused \
+    -o "$TMP/download" "https://github.com/jgm/pandoc/releases/download/$VERSION/$ASSET"
+  ACTUAL="$(checksum "$TMP/download")"
+  if [[ "$ACTUAL" != "$SHA" ]]; then
+    echo "checksum mismatch for $ASSET: expected $SHA, got $ACTUAL" >&2
+    exit 1
+  fi
+  mv "$TMP/download" "$ARCHIVE"
+fi
+if [[ "$KIND" == tar ]]; then tar xzf "$ARCHIVE" -C "$TMP"; else unzip -q "$ARCHIVE" -d "$TMP"; fi
 "$TMP/$PANDOC" --version | grep -F "pandoc $VERSION"
 if [[ "$TARGET" == x86_64-pc-windows-msvc ]]; then
   ENGINE="$TMP/tectonic.exe"


### PR DESCRIPTION
Supersedes the `test.skip` band-aid this branch started as. Both failures now have root-cause fixes and the skips are reverted, so every spec runs on every platform again.

## (B) Ghost completion: Tab inserted an indent instead of accepting

`66-ghost-completion.spec.ts:146` failed on Windows with `expect().toContain()`. The received document was `    \alph` — exactly one indent unit, so Tab *did* reach CodeMirror and fell through the ghost binding to `indentWithTab`.

`acceptGhostCompletion` (`packages/editor/src/ghost-completion.ts:259`) returned `acceptCompletion`'s result verbatim. `acceptCompletion` returns **false** when the popup opened less than `interactionDelay` ago (default **75ms**), when nothing is selected, or when it is disabled. That refusal propagated as "unhandled" and Tab indented.

**This is a user-facing bug on every platform**, not just CI: see a suggestion, press Tab quickly, get an indent. Windows CI just hits the window nearly every run because the async popup opens into the gap on a loaded 2-core runner.

Fix: fall through to the ghost when the popup declines. While the popup is open the ghost already mirrors `selectedCompletion` (lines 236-240), so the fallback inserts exactly what is on screen.

The existing popup test set `interactionDelay: 0`, which is exactly why this was never caught. The new test pins the delay open and **fails on the old code** (`expected false to be true`).

## (A) Large-document paint probes: a save/compile collision, not occlusion

My first hypothesis was Chromium `CalculateNativeWinOcclusion` starving rAF. **That was wrong**, and the evidence killed it: the rAF-raced evals were the ones that *succeeded*, the eval that timed out was a purely synchronous DOM probe, and afterwards even `window.__E2E_RELOAD_PENDING__ = true` timed out for 8 minutes. Occlusion does not stop `ExecuteScript`.

The real trigger: opening a project always compiles it, independently of the auto-compile preference. The reopen branch of `openLargeBook` neither configured anything nor waited, so every test after the first probed editor paint while Tectonic saturated the runner — and the next compile's save-before-compile raced the previous one's hold on `main.tex`, which on Windows fails the atomic replace with `Access is denied. (os error 5)`. That line is the last frontend log entry before every wedge.

The spec states it measures the editor, not the compiler. Now it does: `settleOpenCompile` waits on observable compile-store state before probing.

Also raced the last two unbounded `requestAnimationFrame` waits (`helpers.ts` `fillCommandPalette`, `24-synctex-inverse.spec.ts`) so a paint-stopped webview cannot hang them to the harness's hardcoded 30s cap.

## CI: stop reaching the network on every run

The Rust job failed earlier with `failed to download "msbm10.tfm"` after three retries, which skipped the actual test and clippy steps.

Two jobs run `smoke-markdown.sh` and both hit the network unconditionally: it downloaded Pandoc into a `mktemp` dir (uncacheable by construction), then invoked Tectonic, pulling TeX packages from the bundle CDN. The three E2E jobs already cache the Tectonic package dir; the Rust job and `markdown-platform-smoke` did not, and the latter did not even cache the Tectonic sidecar.

Now: Pandoc lands in the same checksum-verified `CACHE_DIR` the other fetch scripts use, and both jobs cache it plus the package dir. The package cache uses its own `tectonic-pkgs-md-v1-` namespace — cache keys are write-once, so sharing the E2E jobs' key would let a Markdown-only cache win the race and starve them.

## Known, not fixed here

Saving while a compile runs can still fail on Windows with `Access is denied`. `replace_file` already retries those error codes for ~2.2s, but a compile holds the file for far longer. The real fix is serialising the pre-compile save with the compile lock, or compiling from a snapshot — a concurrency change that deserves its own PR rather than being rushed into this one.