### PR TITLE
ci: bound every network wait and job runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
   markdown-platform-smoke:
     name: Markdown smoke (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         include:
@@ -83,6 +84,7 @@ jobs:
   frontend:
     name: Frontend (typecheck + build)
     runs-on: ubuntu-22.04
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
 
@@ -146,6 +148,7 @@ jobs:
   rust:
     name: Rust (test + clippy)
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -278,6 +281,7 @@ jobs:
   rust-windows:
     name: Rust tests (Windows Job Objects)
     runs-on: windows-2022
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
 
@@ -316,6 +320,7 @@ jobs:
     # compiled into the shipped binary. Policy lives in src-tauri/deny.toml.
     name: Rust (cargo-deny audit)
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -333,6 +338,7 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/scripts/fetch-biber.sh
+++ b/scripts/fetch-biber.sh
@@ -118,7 +118,9 @@ fetch() {
   if [[ "$actual_sha" != "$expected_sha" ]]; then
     rm -f "$archive"
     echo "→ fetching $target ($asset)"
-    if ! curl -fSL --retry 5 --retry-delay 3 --retry-connrefused \
+    if ! curl -fSL --proto '=https' --connect-timeout 30 \
+        --speed-limit 1024 --speed-time 60 \
+        --retry 5 --retry-delay 3 --retry-connrefused \
         -o "$tmp/download" "$url"; then
       echo "failed to download $url" >&2
       exit 1

--- a/scripts/fetch-tectonic.sh
+++ b/scripts/fetch-tectonic.sh
@@ -77,7 +77,9 @@ fetch() {
   if [[ "$actual_sha" != "$expected_sha" ]]; then
     rm -f "$archive"
     echo "→ fetching $target ($asset)"
-    if ! curl -fSL --retry 5 --retry-delay 3 --retry-connrefused \
+    if ! curl -fSL --proto '=https' --connect-timeout 30 \
+        --speed-limit 1024 --speed-time 60 \
+        --retry 5 --retry-delay 3 --retry-connrefused \
         -o "$tmp/download" "$url"; then
       echo "failed to download $url" >&2
       exit 1

--- a/scripts/fetch-typst.sh
+++ b/scripts/fetch-typst.sh
@@ -67,7 +67,9 @@ fetch() {
   if [[ "$actual" != "$expected" ]]; then
     rm -f "$archive"
     echo "fetching Typst $VERSION for $target ($asset)"
-    curl -fSL --retry 5 --retry-delay 3 --retry-connrefused -o "$tmp/download" "$url"
+    curl -fSL --proto '=https' --connect-timeout 30 \
+      --speed-limit 1024 --speed-time 60 \
+      --retry 5 --retry-delay 3 --retry-connrefused -o "$tmp/download" "$url"
     actual="$(checksum "$tmp/download")"
     if [[ "$actual" == "$expected" ]]; then
       mv "$tmp/download" "$archive"

--- a/scripts/smoke-markdown.sh
+++ b/scripts/smoke-markdown.sh
@@ -40,7 +40,9 @@ esac
 ARCHIVE="$CACHE_DIR/$ASSET"
 if [[ ! -f "$ARCHIVE" ]] || [[ "$(checksum "$ARCHIVE")" != "$SHA" ]]; then
   rm -f "$ARCHIVE"
-  curl -fSL --proto '=https' --retry 5 --retry-delay 3 --retry-connrefused \
+  curl -fSL --proto '=https' --connect-timeout 30 \
+    --speed-limit 1024 --speed-time 60 \
+    --retry 5 --retry-delay 3 --retry-connrefused \
     -o "$TMP/download" "https://github.com/jgm/pandoc/releases/download/$VERSION/$ASSET"
   ACTUAL="$(checksum "$TMP/download")"
   if [[ "$ACTUAL" != "$SHA" ]]; then


### PR DESCRIPTION
## Problem

The Markdown smoke step on `main` hung for **51 minutes** and was still running when I cancelled it. That step normally finishes in 0.3 to 4 minutes.

Two independent gaps let a single stalled CDN connection burn an hour:

**1. No transfer timeouts.** All four fetch scripts passed `--retry 5` but no timeout of any kind. `curl --retry` retries a connection that *fails*; it does nothing for one that is accepted and then stops sending bytes. A CDN that opens a socket and stalls blocks the step indefinitely.

**2. No job timeouts.** Only the three E2E jobs declared `timeout-minutes`. `rust`, `frontend`, `markdown-platform-smoke`, `rust-windows`, `cargo-deny` and `sonarqube` all inherited the 360-minute default.

## Fix

`--connect-timeout 30` plus `--speed-limit 1024 --speed-time 60` on all four scripts: abort a transfer that stays under 1 KB/s for a minute.

`--speed-limit` rather than `--max-time` deliberately. A slow but *progressing* download of the 37 MB Pandoc archive on a loaded runner must still succeed; a wall-clock cap would kill it. Stall detection is the property we actually want.

`timeout-minutes` on every remaining job, sized against observed durations so there is 5x or more headroom:

| job | observed | limit |
|---|---|---|
| markdown-platform-smoke | 0.3 min | 20 |
| cargo-deny | 0.5 min | 15 |
| rust-windows | 2.0 min | 25 |
| sonarqube | 2.5 min | 20 |
| frontend | 4.0 min | 25 |
| rust | 4.2 min | 30 |

Also `--proto '=https'` on all four so a redirect cannot downgrade the transport. That clears the four `shell:S6506` findings SonarQube reports against these scripts.

## Verification

`smoke-markdown.sh` still passes cold (6.2s, downloads) and warm (4.2s, cache hit, no network).