### PR TITLE
CLI v0.1.0: install hints, completions, a manual page, and the release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,268 @@
+name: Release CLI
+
+#
+#     git tag cli-v0.1.0 && git push origin cli-v0.1.0
+#
+# or run manually from the Actions tab against any ref.
+#
+# The CLI has its own tag namespace (`cli-v*`) and its own version line. The
+# desktop owns `v*.*.*` and the two products have no reason to move together.
+#
+# This workflow always stops at a DRAFT release. Nothing here publishes to a
+# package registry: crates.io, Homebrew and Scoop are deliberately absent until
+# there is a stable local build and the package name is settled. Publishing a
+# crates.io name cannot be undone, so it does not belong behind a tag push.
+on:
+  push:
+    tags:
+      - "cli-v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to attach the draft release to (e.g. cli-v0.1.0)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # What cargo produces. The desktop package still owns the name `oleafly`
+  # inside this workspace - two packages cannot both build a binary by that
+  # name - so the build artifact keeps the old one until the desktop rename
+  # lands. See the naming record.
+  CARGO_BIN: oleaflyc
+  # What people install and type. The build name is an internal detail of the
+  # workspace and nobody outside it should ever see it: the shipped file, the
+  # archive, the completions, and the manual page all use this.
+  SHIP_NAME: oleafly
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS (Apple Silicon)
+            os: macos-14
+            target: aarch64-apple-darwin
+          - name: macOS (Intel)
+            os: macos-14
+            target: x86_64-apple-darwin
+          - name: Linux (x86_64, gnu)
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - name: Linux (ARM64, gnu)
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          # musl builds are static: they run on Alpine, in scratch containers,
+          # and on distributions whose glibc is older than the build machine's.
+          # That is what "supports Linux" means in practice for a CI tool.
+          - name: Linux (x86_64, musl)
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+          - name: Linux (ARM64, musl)
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+          - name: Windows (x86_64)
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> src-tauri/target
+          key: cli-${{ matrix.target }}
+
+      # The CLI has no C dependencies, so musl needs only the linker.
+      - name: Install the musl toolchain
+        if: endsWith(matrix.target, '-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      # --locked: Cargo.lock is tracked, so a release must build exactly the
+      # dependency set that was reviewed, and fail loudly if the lock is stale
+      # rather than quietly resolving something newer.
+      - name: Build
+        run: cargo build --release --locked -p oleafly-cli --target ${{ matrix.target }}
+
+      # Generated from the parser, so they cannot drift from the flags. Built
+      # on the host for the host: cross-compiled targets cannot be executed
+      # here, so these come from a native build of the same source.
+      - name: Generate completions and the manual page
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/completions dist/man
+          cargo run --release --locked -p oleafly-cli --bin "$CARGO_BIN" -- man > "dist/man/$SHIP_NAME.1"
+          for shell in bash zsh fish powershell elvish; do
+            cargo run --release --locked -p oleafly-cli --bin "$CARGO_BIN" -- completions "$shell" \
+              > "dist/completions/$SHIP_NAME.$shell"
+          done
+
+      # macOS binaries downloaded from the internet are quarantined until they
+      # are signed and notarized. Skips cleanly when the secrets are absent so
+      # a fork still produces working (unsigned) artifacts.
+      - name: Sign and notarize (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          binary="src-tauri/target/${{ matrix.target }}/release/$CARGO_BIN"
+          if [ -z "${APPLE_CERTIFICATE:-}" ] || [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+            echo "::warning::Apple signing secrets absent; shipping an unsigned macOS binary"
+            exit 0
+          fi
+          keychain="$RUNNER_TEMP/cli-signing.keychain-db"
+          password="$(uuidgen)"
+          security create-keychain -p "$password" "$keychain"
+          security set-keychain-settings "$keychain"
+          security unlock-keychain -p "$password" "$keychain"
+          certificate="$RUNNER_TEMP/certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate"
+          security import "$certificate" -k "$keychain" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+          rm -f "$certificate"
+          codesign --force --options runtime --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" "$binary"
+          codesign --verify --strict --verbose=2 "$binary"
+          if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
+            # notarytool takes an archive, not a bare Mach-O.
+            ditto -c -k --keepParent "$binary" "$RUNNER_TEMP/notarize.zip"
+            xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" --wait \
+              --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID"
+            # A bare binary cannot be stapled; Gatekeeper checks it online.
+            # Notarizing still clears the quarantine prompt on first run.
+          else
+            echo "::warning::Notarization credentials absent; binary is signed but not notarized"
+          fi
+
+      - name: Sign (Windows)
+        if: startsWith(matrix.os, 'windows-')
+        shell: bash
+        env:
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          AZURE_SIGNING_PROFILE: ${{ secrets.AZURE_SIGNING_PROFILE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AZURE_SIGNING_ENDPOINT:-}" ]; then
+            echo "::warning::Azure signing secrets absent; shipping an unsigned Windows binary"
+            exit 0
+          fi
+          echo "::warning::Windows Authenticode signing for the CLI is not wired up yet"
+
+      - name: Assemble the archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A manual dispatch against a branch has no version in its ref, and
+          # naming an archive "oleaflyc-main-..." helps nobody. Fall back to a
+          # commit-stamped dry-run version so those artifacts are obviously not
+          # releases.
+          ref="${{ github.event.inputs.tag || github.ref_name }}"
+          case "$ref" in
+            cli-v*) version="${ref#cli-v}" ;;
+            *) version="0.0.0-dev.$(git rev-parse --short HEAD)" ;;
+          esac
+          stem="$SHIP_NAME-$version-${{ matrix.target }}"
+          staging="dist/$stem"
+          mkdir -p "$staging"
+          source="src-tauri/target/${{ matrix.target }}/release/$CARGO_BIN"
+          # Ship it under the name people type, not the name cargo happened
+          # to build it as.
+          if [ -f "$source.exe" ]; then
+            cp "$source.exe" "$staging/$SHIP_NAME.exe"
+          else
+            cp "$source" "$staging/$SHIP_NAME"
+          fi
+          cp LICENSE README.md "$staging/"
+          cp -r dist/completions dist/man "$staging/"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # Archive the directory, not a quoted glob: the shell will not
+            # expand "./dir/*" inside quotes, and mirroring the tar branch
+            # keeps both archives the same shape.
+            (cd dist && 7z a -tzip "$stem.zip" "$stem" >/dev/null)
+            echo "ARCHIVE=dist/$stem.zip" >> "$GITHUB_ENV"
+          else
+            tar -czf "dist/$stem.tar.gz" -C dist "$stem"
+            echo "ARCHIVE=dist/$stem.tar.gz" >> "$GITHUB_ENV"
+          fi
+
+      - name: Attest build provenance
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: ${{ env.ARCHIVE }}
+
+      - name: Upload the archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+          retention-days: 7
+
+  draft:
+    name: Draft release
+    needs: build
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download every archive
+        uses: actions/download-artifact@v7
+        with:
+          path: archives
+          merge-multiple: true
+
+      # One checksum file across every target, so a user can verify a download
+      # without trusting the page they got the link from.
+      - name: Checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd archives
+          ls -1
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create or update the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --draft \
+              --title "Oleafly CLI $TAG" \
+              --notes "Draft. The CLI interface is unstable below 1.0.0: JSON fields may be added, renamed, or removed and exit codes may change. Pin an exact version if you script against it."
+          fi
+          gh release upload "$TAG" archives/* --repo "$GITHUB_REPOSITORY" --clobber
+          echo "Draft release ready. Publishing is a separate, deliberate step."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The command-line tool tells you how to install a missing compiler.** When
+  `doctor` cannot find Tectonic, Typst, Pandoc, or latexmk, it now prints a
+  command you can paste for your platform instead of only reporting that the
+  tool is absent. The CLI does not bundle compilers, so this was the first
+  thing a new user hit.
+- **Shell completions and a manual page.** `oleaflyc completions bash`
+  (also zsh, fish, PowerShell, and elvish) prints a completion script, and
+  `oleaflyc man` prints the manual in roff. Both are generated from the parser
+  itself, so a new flag cannot drift out of them.
+- **`--help` now says the interface is not stable yet.** Every 0.x release may
+  add, rename, or remove JSON fields and change exit codes. Pin an exact
+  version if you script against it. This is stated in the tool because the
+  people most likely to depend on it are automating something.
+
 ## [0.3.7] - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1248e420506b523e97ebd7b610656114abadbe73b04279a86768a12ce1860837"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +512,16 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f98eb8c611cdbd2a8bbfe35408903badf2e7f9d47f756907f1b1434c49b6655"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2558,9 +2577,12 @@ name = "oleafly-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "libc",
  "notify",
  "oleafly-core",
+ "roff",
  "serde",
  "serde_json",
  "sha2",
@@ -3237,6 +3259,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a65c4aa82d26fd949433258cada661b1816175012149f0b8cc3269b2df5913"
 
 [[package]]
 name = "rustc-hash"

--- a/README.md
+++ b/README.md
@@ -453,9 +453,11 @@ setup, production builds, and the source-only command-line workflow.
 
 ### Command line
 
-`oleaflyc` manages Oleafly projects without launching the desktop app. It
-builds from source in this repository and is not published as a standalone
-package yet.
+`oleafly` manages Oleafly projects without launching the desktop app. It builds
+from source in this repository and is not published as a standalone package
+yet. Built from source the file is called `oleaflyc`, because the desktop
+package currently owns the name `oleafly` inside the Cargo workspace; released
+builds ship it as `oleafly`, which is what the tool calls itself everywhere.
 
 ```bash
 cargo run -p oleafly-cli --bin oleaflyc -- init
@@ -466,7 +468,17 @@ cargo run -p oleafly-cli --bin oleaflyc -- project info --json
 ```
 
 Commands run against the current directory. Pass `-C <path>` to point at
-another project. Run `oleaflyc --help` for the full command list.
+another project. Run `oleafly --help` for the full command list.
+
+It does not bundle compilers. `doctor` checks for the ones your project needs
+and prints an install command for your platform when one is missing.
+
+`oleafly completions <shell>` prints a completion script for bash, zsh, fish,
+PowerShell, or elvish, and `oleafly man` prints the manual page in roff.
+
+**The interface is not stable yet.** Any release before 1.0.0 may add, rename,
+or remove JSON fields and change exit codes. Pin an exact version if you build
+a pipeline on it.
 
 ## Documentation
 

--- a/crates/oleafly-cli/Cargo.toml
+++ b/crates/oleafly-cli/Cargo.toml
@@ -13,6 +13,17 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "=4.5.50", features = ["derive"] }
+# Pinned for the same reason clap is: the Rust 1.77 MSRV. clap_complete 4.5.67
+# and clap_mangen 0.2.32 are the newest that still declare 1.74; the next
+# clap_mangen (0.2.33) jumps to 1.85.
+clap_complete = "=4.5.67"
+clap_mangen = "=0.2.32"
+# Not used directly - this constrains clap_mangen's own dependency. roff 1.1.x
+# is edition 2024, which Cargo 1.77 refuses to parse at all, so the MSRV job
+# fails while resolving rather than compiling. 1.0.0 is edition 2021.
+# Cargo.lock is not committed, so CI resolves fresh and this has to live here
+# rather than in the lock.
+roff = "=1.0.0"
 notify = "8.2"
 oleafly-core = { path = "../oleafly-core" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/oleafly-cli/src/lib.rs
+++ b/crates/oleafly-cli/src/lib.rs
@@ -31,11 +31,35 @@ const EXIT_BUILD: u8 = 5;
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(300);
 const DEFAULT_TIMEOUT_SECONDS: u64 = 300;
 
+/// Shown at the bottom of `--help`.
+///
+/// The audience for this CLI is automation, so someone is going to wire the
+/// JSON output and the exit codes into a build pipeline. Below 1.0 none of
+/// that is a contract, and they should learn it here rather than from a
+/// pipeline that breaks quietly three months from now.
+const UNSTABLE_NOTICE: &str = "\
+This is a 0.x release and nothing about its interface is stable yet. JSON
+fields may be added, renamed, or removed and exit codes may change in any
+release before 1.0.0. Pin an exact version if you script against it.";
+
 #[derive(Debug, Parser)]
 #[command(
-    name = "oleaflyc",
+    // What users type, which is not the same thing as what cargo builds. The
+    // desktop package still owns the name `oleafly` inside this workspace, so
+    // the build artifact stays `oleaflyc` until that is resolved - but that is
+    // an implementation detail of the workspace, and nobody should have to see
+    // it. This name is what --help, the usage strings, the generated
+    // completions, and the manual page all carry, and the release workflow
+    // ships the file under it.
+    name = "oleafly",
+    // Without this clap takes the usage line from argv[0], which is whatever
+    // the file on disk happens to be called - so `Usage:` would read
+    // `oleaflyc` while the completions and the manual said `oleafly`.
+    bin_name = "oleafly",
     version,
-    about = "Build and manage Oleafly projects"
+    about = "Build and manage Oleafly projects",
+    after_help = UNSTABLE_NOTICE,
+    after_long_help = UNSTABLE_NOTICE
 )]
 pub struct Cli {
     #[arg(
@@ -70,6 +94,19 @@ pub enum Command {
         #[command(subcommand)]
         command: ProjectCommand,
     },
+    // Packagers expect both of these, and generating them from the parser
+    // keeps them correct for free: a new flag cannot drift out of the
+    // completions or the manual the way a hand-maintained copy would.
+    // Homebrew reads completions straight out of the built binary
+    // (generate_completions_from_executable), and the release job redirects
+    // `man` into oleafly.1.
+    #[command(about = "Print a shell completion script")]
+    Completions {
+        #[arg(value_enum, help = "Shell to generate a completion script for")]
+        shell: clap_complete::Shell,
+    },
+    #[command(about = "Print the manual page in roff format")]
+    Man,
 }
 
 #[derive(Debug, Args)]
@@ -214,6 +251,8 @@ pub async fn run(cli: Cli) -> u8 {
         Command::Project {
             command: ProjectCommand::Info,
         } => run_project_info(&cli.project, reporter),
+        Command::Completions { shell } => run_completions(shell),
+        Command::Man => run_man(),
     };
     match result {
         Ok(code) => code,
@@ -232,7 +271,24 @@ fn command_name(command: &Command) -> &'static str {
         Command::Clean => "clean",
         Command::Doctor => "doctor",
         Command::Project { .. } => "project info",
+        Command::Completions { .. } => "completions",
+        Command::Man => "man",
     }
+}
+
+/// Write a shell completion script for `shell` to stdout.
+fn run_completions(shell: clap_complete::Shell) -> Result<u8, Error> {
+    let mut command = <Cli as clap::CommandFactory>::command();
+    let name = command.get_name().to_string();
+    clap_complete::generate(shell, &mut command, name, &mut std::io::stdout());
+    Ok(EXIT_SUCCESS)
+}
+
+/// Write the manual page, in roff, to stdout.
+fn run_man() -> Result<u8, Error> {
+    let command = <Cli as clap::CommandFactory>::command();
+    clap_mangen::Man::new(command).render(&mut std::io::stdout())?;
+    Ok(EXIT_SUCCESS)
 }
 
 fn run_init(path: &Path, command: InitCommand, reporter: Reporter) -> Result<u8, Error> {
@@ -308,6 +364,54 @@ fn run_clean(path: &Path, reporter: Reporter) -> Result<u8, Error> {
     Ok(EXIT_SUCCESS)
 }
 
+/// A platform-appropriate way to install a compiler `doctor` could not find.
+///
+/// The CLI does not bundle compilers, so on a fresh machine the first thing a
+/// new user does fails. Reporting "tectonic was not found" and stopping there
+/// leaves them to go and search for it. Where a package manager reliably
+/// carries the tool this is a command they can paste; where it does not, it is
+/// the project's own install page rather than an invented package name.
+fn install_hint(tool: &str) -> Option<String> {
+    let (macos, linux, windows, home) = match tool {
+        "tectonic" => (
+            Some("brew install tectonic"),
+            Some("cargo install tectonic"),
+            None,
+            "https://tectonic-typesetting.github.io/en-US/install.html",
+        ),
+        "typst" => (
+            Some("brew install typst"),
+            Some("cargo install typst-cli"),
+            None,
+            "https://github.com/typst/typst/releases",
+        ),
+        "pandoc" => (
+            Some("brew install pandoc"),
+            Some("sudo apt install pandoc"),
+            None,
+            "https://pandoc.org/installing.html",
+        ),
+        "latexmk" => (
+            Some("brew install texlive"),
+            Some("sudo apt install latexmk"),
+            None,
+            "https://www.tug.org/texlive/acquire.html",
+        ),
+        _ => return None,
+    };
+    let command = if cfg!(target_os = "macos") {
+        macos
+    } else if cfg!(target_os = "windows") {
+        windows
+    } else {
+        linux
+    };
+    Some(match command {
+        Some(command) => format!("Install it with `{command}`, or see {home}"),
+        None => format!("See {home}"),
+    })
+}
+
 fn run_doctor(path: &Path, reporter: Reporter) -> Result<u8, Error> {
     let workspace = Workspace::open(path)?;
     let tools = BuildTools::discover(workspace.root());
@@ -337,7 +441,10 @@ fn run_doctor(path: &Path, reporter: Reporter) -> Result<u8, Error> {
             (None, None) => DoctorCheck {
                 name: format!("compiler_{name}"),
                 status: DoctorStatus::Fail,
-                message: format!("{name} was not found"),
+                message: match install_hint(name) {
+                    Some(hint) => format!("{name} was not found. {hint}"),
+                    None => format!("{name} was not found"),
+                },
             },
         });
     }
@@ -692,6 +799,21 @@ mod tests {
         let json = json_output_error(serde_error);
         assert_eq!(json.kind(), ErrorKind::Io);
         assert!(json.message().contains("failed to serialize output"));
+    }
+
+    #[test]
+    fn every_engine_tool_has_an_install_hint() {
+        // These are exactly the names BuildTools::required_for_engine can ask
+        // about. A new engine tool without a hint would silently regress a
+        // fresh machine back to "not found" with nowhere to go.
+        for tool in ["tectonic", "latexmk", "typst", "pandoc"] {
+            let hint = install_hint(tool).unwrap_or_else(|| panic!("no install hint for {tool}"));
+            assert!(
+                hint.contains("https://"),
+                "the {tool} hint must name a source: {hint}"
+            );
+        }
+        assert!(install_hint("not-a-compiler").is_none());
     }
 
     #[test]

--- a/crates/oleafly-cli/tests/cli.rs
+++ b/crates/oleafly-cli/tests/cli.rs
@@ -323,3 +323,88 @@ fn watch_recovers_from_environment_errors_and_reloads_the_manifest() {
     });
     assert_eq!(finished["build"]["engine"], "latexmk");
 }
+
+#[test]
+fn completions_and_the_manual_are_generated_from_the_parser() {
+    // Packagers install both straight out of the binary - Homebrew calls
+    // generate_completions_from_executable, and the release job redirects the
+    // manual into oleafly.1 - so a silent regression here breaks packaging
+    // rather than anything a normal run would notice.
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let output = run(&["completions", shell], None);
+        assert!(
+            output.status.success(),
+            "completions {shell} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let script = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            script.contains("oleafly"),
+            "the {shell} completion script must name the command: {script:.120}"
+        );
+        // Every subcommand has to appear, or completion silently stops
+        // offering whichever one drifted out.
+        for command in ["init", "build", "watch", "clean", "doctor", "project"] {
+            assert!(
+                script.contains(command),
+                "the {shell} completion script is missing `{command}`"
+            );
+        }
+    }
+
+    let output = run(&["man"], None);
+    assert!(output.status.success());
+    let page = String::from_utf8(output.stdout).unwrap();
+    assert!(page.starts_with(".ie"), "expected roff output: {page:.60}");
+    assert!(page.contains(".SH NAME"), "the manual needs a NAME section");
+    assert!(page.contains("oleafly"), "the manual must name the command");
+}
+
+#[test]
+fn help_states_that_the_interface_is_unstable_before_1_0() {
+    // The audience is automation. Someone wiring the JSON output or the exit
+    // codes into a pipeline has to learn from the CLI that neither is a
+    // contract yet.
+    let output = run(&["--help"], None);
+    assert!(output.status.success());
+    let help = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        help.contains("0.x") && help.contains("1.0.0"),
+        "--help must say the interface is unstable before 1.0: {help}"
+    );
+}
+
+#[test]
+fn the_public_name_is_oleafly_everywhere_a_user_can_see_it() {
+    // The file cargo builds is still `oleaflyc`, because the desktop package
+    // owns `oleafly` inside this workspace. That is an internal detail and it
+    // must not leak: clap takes its usage line from argv[0] unless bin_name
+    // says otherwise, which is exactly how it would leak.
+    for arguments in [vec!["--help"], vec!["build", "--help"], vec!["--version"]] {
+        let output = run(&arguments, None);
+        let text = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            text.contains("oleafly") && !text.contains("oleaflyc"),
+            "`{}` shows the build name instead of the public one:\n{text}",
+            arguments.join(" ")
+        );
+    }
+
+    let manual = String::from_utf8(run(&["man"], None).stdout).unwrap();
+    assert!(
+        manual.contains(".TH oleafly"),
+        "the manual names the wrong command"
+    );
+    assert!(
+        !manual.contains("oleaflyc"),
+        "the manual leaks the build name"
+    );
+
+    for shell in ["bash", "zsh", "fish"] {
+        let script = String::from_utf8(run(&["completions", shell], None).stdout).unwrap();
+        assert!(
+            !script.contains("oleaflyc"),
+            "the {shell} completion script leaks the build name"
+        );
+    }
+}

--- a/crates/oleafly-core/src/workspace.rs
+++ b/crates/oleafly-core/src/workspace.rs
@@ -63,7 +63,7 @@ impl Workspace {
             return Err(Error::new(
                 ErrorKind::NotInitialized,
                 format!(
-                    "{} is not an Oleafly project. Run `oleaflyc init` first",
+                    "{} is not an Oleafly project. Run `oleafly init` first",
                     root.display()
                 ),
             ));

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ What you need to work on Oleafly. The app is a [Tauri 2](https://tauri.app) proj
 oleafly-desktop/
 ├── crates/
 │   ├── oleafly-core/       shared Rust project, path, and build-directory policy
-│   ├── oleafly-cli/        oleaflyc commands and native compiler adapter
+│   ├── oleafly-cli/        oleafly commands and native compiler adapter
 │   └── oleafly-agent/      provider-neutral agent runtime
 ├── src/                    React app shell (stores, Tauri client, UI kit, port adapters)
 │   ├── components/         ui (shadcn-style), layout, editor glue, preview panes, ai
@@ -76,7 +76,10 @@ pnpm build              # typecheck + build the frontend (tsc -b && vite build)
 pnpm tauri build        # produce a distributable bundle
 ```
 
-The command-line adapter is source-only for now. Run it from the workspace:
+The command-line adapter is source-only for now. Run it from the workspace.
+The built file is `oleaflyc` because the desktop package owns the name
+`oleafly` in this Cargo workspace; the tool calls itself `oleafly` in help,
+completions, and the manual, and release builds ship it under that name:
 
 ```bash
 cargo run -p oleafly-cli --bin oleaflyc -- --help
@@ -85,13 +88,26 @@ cargo run -p oleafly-cli --bin oleaflyc -- build
 cargo run -p oleafly-cli --bin oleaflyc -- project info --json
 ```
 
-`oleaflyc` works on the current directory unless you pass `-C <path>`. It also
+`oleafly` works on the current directory unless you pass `-C <path>`. It also
 has `watch`, `clean`, and `doctor`. Output is human-readable by default.
 `--json` switches to structured output, and watch mode prints newline-delimited
 JSON events. Build and watch kill a compiler after 300 seconds unless you pass
 `--timeout <seconds>`. The CLI never turns on TeX shell escape. Only the
 desktop can, and only through its device-local trust prompt for the system TeX
 engine.
+
+Compilers are not bundled with the CLI. `doctor` reports which ones the
+project's engine needs and, when one is missing, prints an install command for
+the current platform. Add a hint alongside the others in `install_hint` if a
+new engine tool is introduced; a test fails if one is missing.
+
+`completions <shell>` and `man` generate a shell completion script and a roff
+manual page from the clap parser, so both stay correct as flags change.
+Packagers consume them directly from the built binary.
+
+The interface is unstable below 1.0.0: JSON fields may be added, renamed, or
+removed and exit codes may change in any release. `--help` says so, because
+the people most likely to depend on the output are scripting against it.
 
 ### Checks before opening a PR
 
@@ -122,7 +138,7 @@ pnpm test:e2e:app                         # builds + launches the app, runs Play
 
 1. The frontend loads the backend `project_engine` descriptor and its capability flags, then calls `compileProject(projectId, mainDoc, offline)` through Tauri IPC.
 2. `oleafly-core` validates the workspace, resolves the source inside the project root, and prepares the isolated build directory.
-3. The desktop adapter dispatches through `DocumentEngine`. UI code must not infer engine behavior from a filename. The `oleaflyc` adapter invokes its native compiler runner through the same shared workspace policy.
+3. The desktop adapter dispatches through `DocumentEngine`. UI code must not infer engine behavior from a filename. The `oleafly` adapter invokes its native compiler runner through the same shared workspace policy.
 4. The desktop LaTeX adapter writes `_oleafly_entry.tex` and invokes Tectonic with `--synctex --keep-logs --print` and, when requested, `--only-cached`. The CLI invokes the selected source directly and normalizes its PDF output to `_oleafly_entry.pdf`.
 5. Typst invokes the pinned Typst CLI directly against the selected `.typ` main document with short diagnostics and an explicit PDF output path.
 6. Markdown invokes Pandoc directly against `.md`/`.markdown`, with an explicit


### PR DESCRIPTION
Stage A and B of the CLI launch. **Nothing here publishes anything** — the release workflow stops at a draft and touches no package registry. crates.io, Homebrew, and Scoop stay out until there is a stable local build and the package name is settled, because a crates.io name cannot be released once claimed.

## What changes

**`doctor` tells you how to fix a missing compiler.** The CLI does not bundle Tectonic, Typst, Pandoc, or latexmk, so on a fresh machine the first thing a new user does fails, and "tectonic was not found" left them to go searching. Where a package manager reliably carries the tool the hint is a command to paste; where it does not, it is the project's own install page rather than an invented package name. A test fails if an engine tool has no hint.

**Completions and a manual page**, both generated from the clap parser, so neither drifts as flags change. Packagers read them straight out of the binary.

**`--help` says the interface is unstable below 1.0.0.** JSON fields may be added, renamed, or removed and exit codes may change. The audience is automation, so someone will wire this into a pipeline — better they learn it from the tool than from a pipeline that breaks quietly later.

**The tool calls itself `oleafly`.** What cargo builds, what clap prints, and what ships are three separate names, and only the first is constrained: the desktop package still owns `oleafly` inside this workspace, so the build artifact stays `oleaflyc`. `name` sets the displayed command and `bin_name` sets the usage line — without the second, `Usage:` comes from `argv[0]` and the build name leaks. The release workflow separates `CARGO_BIN` from `SHIP_NAME`. A test asserts the build name cannot reach help, usage, `--version`, the manual, or any completion script.

**A release workflow for seven targets**: macOS on Apple Silicon and Intel, Linux gnu and musl on x86_64 and ARM64, and Windows x86_64. The musl pair is what makes this usable on Alpine and in minimal containers. Each archive carries the binary, licence, README, manual, and completions, with one `SHA256SUMS` across every target and per-archive build provenance.

## How it was verified

A dry run built all seven targets, and I ran the artifacts rather than trusting that they compiled:

- The macOS binary runs natively and `codesign` reports it signed with Developer ID and hardened runtime, so signing a bare Mach-O works without the app-bundle path.
- The musl binary runs on Alpine and busybox, neither of which has glibc — the static linking is real.
- A full `init` → `project info --json` → `doctor` cycle inside Alpine, where `doctor` correctly reports the missing Typst with its install hint and exits 4.
- A published checksum recomputed locally and matched.

Gates were run against the CI toolchains rather than local defaults: `cargo +1.98.0 fmt --check` and `clippy -D warnings` clean, `cargo +1.77.0 check` clean, 64 tests passing.

## Known gaps

Windows Authenticode is not wired up. The binary builds and packages, but ships unsigned and will trip SmartScreen. It warns rather than pretending.

The dependency pins carry their reasons in the manifest. `clap_complete` 4.5.67 and `clap_mangen` 0.2.32 are the newest that still declare MSRV 1.74, and `roff` is pinned because `clap_mangen` pulls it and 1.1.x is edition 2024, which Cargo 1.77 refuses to parse at all — the MSRV job fails while resolving, before compiling anything.

## Not in scope

The desktop rename. It is still needed for Linux, where the desktop launcher resolves `oleafly` through `PATH`, but it no longer blocks shipping the CLI under its own name.
