### PR TITLE
fix: send Gemini thought signatures back with function calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# oleafly-desktop agent guide
+
+Workspace-wide rules live in `../AGENTS.md` (git hygiene, security, humanizer,
+CI reproduction). This file adds repo-specific duties.
+
+## AI model catalog maintenance (routine check)
+
+Model lineups rot fast: in mid-2026 alone, Anthropic, DeepSeek, xAI, Groq, and
+Perplexity each retired ids the app was still listing. Whenever you touch the
+AI provider surface, and at least monthly, verify the catalogs against each
+provider's official docs. Never trust training data for model ids or prices.
+
+Four places must stay in sync:
+
+1. `src-tauri/resources/ai-models.json` — an allow-list that
+   `src-tauri/src/ai_model_registry.rs` intersects with each provider's live
+   `/models` listing. A model missing here is hidden from the picker even when
+   the provider serves it. An unknown provider id filters to an empty list,
+   and Ollama and custom providers are filtered like everyone else, so keep
+   the Ollama section stocked with common local pulls.
+2. The CDN copy in `../oleafly-assets/catalogs/ai-models.json`, served from
+   `cdn.oleafly.com/catalogs/ai-models.json`. It overrides the bundled file at
+   runtime. Ship the app change in a release before deploying catalog
+   additions that older builds cannot drive (new wire requirements, new
+   protocols), or released builds will surface models that fail.
+3. `crates/oleafly-agent/src/provider.rs` (`CATALOG` `default_model`) together
+   with `packages/ai-core/src/providers.ts`. The first entry of each
+   provider's `models` array must equal the Rust default;
+   `packages/ai-core/src/catalog-parity.test.ts` enforces it by scraping the
+   Rust source.
+4. `src/lib/ai-pricing.ts` — the per-model rate card the cost estimate uses.
+   Unknown ids fall back to a generic estimate, so add rows for anything the
+   picker recommends.
+
+Check against the providers' own pages, with a search for anything ambiguous:
+Anthropic (platform.claude.com pricing and model-deprecations), OpenAI
+(developers.openai.com pricing and deprecations), Google
+(ai.google.dev/gemini-api/docs/models), xAI (docs.x.ai/docs/models), Groq
+(console.groq.com/docs/models and docs/deprecations), DeepSeek
+(api-docs.deepseek.com/quick_start/pricing), Mistral (docs.mistral.ai models
+overview), Perplexity (docs.perplexity.ai models), Z.AI release notes.
+
+Gemini has one wire-level requirement the others do not: Gemini 3 models
+return a part-level `thoughtSignature` beside `functionCall`, and the request
+that replays history must echo it or the API returns a 400. The handling
+lives in `crates/oleafly-agent` (`ToolCall::thought_signature`, the Google
+translator, and `google_part`). Keep it intact when touching the Google wire.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,15 @@ Anthropic (platform.claude.com pricing and model-deprecations), OpenAI
 (api-docs.deepseek.com/quick_start/pricing), Mistral (docs.mistral.ai models
 overview), Perplexity (docs.perplexity.ai models), Z.AI release notes.
 
+Do not stop at the docs. Provider lifecycle pages can lag or contradict
+production: in August 2026, `gemini-2.5-pro` returned 404 "no longer
+available to new users" while Google's lifecycle page still promised it until
+October 2026. After a docs sweep, test the recommended models against a real
+key (a fresh key if possible, since gating often hits new accounts first),
+and search community forums for "\<model\> no longer available" before
+keeping an older model in the recommended picker. When a provider's error
+message names a replacement model, believe the error, not the docs.
+
 Gemini has one wire-level requirement the others do not: Gemini 3 models
 return a part-level `thoughtSignature` beside `functionCall`, and the request
 that replays history must echo it or the API returns a 400. The handling

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Deutsch](docs/readme-translations/README.de.md) | **English** | [Español](docs/readme-translations/README.es.md) | [Français](docs/readme-translations/README.fr.md) | [日本語](docs/readme-translations/README.ja.md) | [한국어](docs/readme-translations/README.ko.md) | [Português](docs/readme-translations/README.pt.md) | [Русский](docs/readme-translations/README.ru.md) | [中文](docs/readme-translations/README.zh.md)
 
-**A complete research harness, re-engineered for the AI era.**
+<h2>A complete research harness, re-engineered for the AI era.</h2>
 
 Write, compile, proofread, search literature, manage citations, build figures,
 review PDFs, and trace changes in Git. Use hosted AI, a custom endpoint, local

--- a/crates/oleafly-agent/src/complete.rs
+++ b/crates/oleafly-agent/src/complete.rs
@@ -147,6 +147,7 @@ pub(crate) fn parse_google(body: &Value) -> Result<(String, Usage)> {
         .ok_or_else(|| AgentError::Decode("response carried no candidates".into()))?;
     let text = parts
         .iter()
+        .filter(|p| p.get("thought").and_then(|t| t.as_bool()) != Some(true))
         .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
         .collect::<Vec<_>>()
         .join("");
@@ -430,9 +431,13 @@ mod tests {
     }
 
     #[test]
-    fn google_joins_candidate_parts() {
+    fn google_joins_visible_candidate_parts_and_skips_thoughts() {
         let body = json!({
-            "candidates": [{ "content": { "parts": [{ "text": "a" }, { "text": "b" }] } }],
+            "candidates": [{ "content": { "parts": [
+                { "text": "private reasoning", "thought": true },
+                { "text": "a" },
+                { "text": "b" }
+            ] } }],
             "usageMetadata": { "promptTokenCount": 9, "candidatesTokenCount": 2 }
         });
         let (text, usage) = parse_google(&body).unwrap();

--- a/crates/oleafly-agent/src/message.rs
+++ b/crates/oleafly-agent/src/message.rs
@@ -16,6 +16,12 @@ pub enum ContentPart {
         id: String,
         name: String,
         arguments: String,
+        #[serde(
+            rename = "thoughtSignature",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        thought_signature: Option<String>,
     },
     ToolResult {
         id: String,
@@ -95,6 +101,36 @@ mod tests {
         assert_eq!(parse_arguments("   "), serde_json::json!({}));
         assert_eq!(parse_arguments("{\"a\":1}"), serde_json::json!({"a":1}));
         assert_eq!(parse_arguments("{truncated"), serde_json::json!({}));
+    }
+
+    #[test]
+    fn a_tool_use_part_round_trips_its_thought_signature_in_camel_case() {
+        let part = ContentPart::ToolUse {
+            id: "c1".into(),
+            name: "read_file".into(),
+            arguments: "{}".into(),
+            thought_signature: Some("sig".into()),
+        };
+        let json = serde_json::to_value(&part).unwrap();
+        assert_eq!(json["thoughtSignature"], "sig");
+        assert!(json.get("thought_signature").is_none());
+        assert_eq!(serde_json::from_value::<ContentPart>(json).unwrap(), part);
+    }
+
+    #[test]
+    fn a_tool_use_part_without_a_signature_stays_wire_compatible() {
+        let unsigned: ContentPart = serde_json::from_str(
+            r#"{"type":"toolUse","id":"c1","name":"read_file","arguments":"{}"}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            unsigned,
+            ContentPart::ToolUse { ref thought_signature, .. } if thought_signature.is_none()
+        ));
+        assert!(serde_json::to_value(&unsigned)
+            .unwrap()
+            .get("thoughtSignature")
+            .is_none());
     }
 
     #[test]

--- a/crates/oleafly-agent/src/models.rs
+++ b/crates/oleafly-agent/src/models.rs
@@ -178,7 +178,7 @@ mod tests {
         let body = json!({
             "models": [
                 { "name": "models/gemini-2.5-pro", "displayName": "Gemini 2.5 Pro" },
-                { "name": "gemini-2.0-flash" }
+                { "name": "gemini-3.6-flash" }
             ]
         });
         assert_eq!(
@@ -189,8 +189,8 @@ mod tests {
                     name: "Gemini 2.5 Pro".into()
                 },
                 ModelInfo {
-                    id: "gemini-2.0-flash".into(),
-                    name: "gemini-2.0-flash".into()
+                    id: "gemini-3.6-flash".into(),
+                    name: "gemini-3.6-flash".into()
                 },
             ]
         );

--- a/crates/oleafly-agent/src/models.rs
+++ b/crates/oleafly-agent/src/models.rs
@@ -177,7 +177,7 @@ mod tests {
         };
         let body = json!({
             "models": [
-                { "name": "models/gemini-2.5-pro", "displayName": "Gemini 2.5 Pro" },
+                { "name": "models/gemini-3.5-flash-lite", "displayName": "Gemini 3.5 Flash-Lite" },
                 { "name": "gemini-3.6-flash" }
             ]
         });
@@ -185,8 +185,8 @@ mod tests {
             parse_models(&wire, &body).unwrap(),
             vec![
                 ModelInfo {
-                    id: "gemini-2.5-pro".into(),
-                    name: "Gemini 2.5 Pro".into()
+                    id: "gemini-3.5-flash-lite".into(),
+                    name: "Gemini 3.5 Flash-Lite".into()
                 },
                 ModelInfo {
                     id: "gemini-3.6-flash".into(),

--- a/crates/oleafly-agent/src/provider.rs
+++ b/crates/oleafly-agent/src/provider.rs
@@ -35,13 +35,13 @@ pub const CATALOG: &[CatalogEntry] = &[
     CatalogEntry {
         id: "openai",
         base_url: None,
-        default_model: "gpt-4o",
+        default_model: "gpt-5.6-terra",
         is_host: false,
     },
     CatalogEntry {
         id: "anthropic",
         base_url: None,
-        default_model: "claude-sonnet-4-20250514",
+        default_model: "claude-opus-5",
         is_host: false,
     },
     CatalogEntry {
@@ -53,13 +53,13 @@ pub const CATALOG: &[CatalogEntry] = &[
     CatalogEntry {
         id: "zai",
         base_url: Some("https://api.z.ai/api/coding/paas/v4"),
-        default_model: "glm-5.2",
+        default_model: "glm-5.3",
         is_host: false,
     },
     CatalogEntry {
         id: "groq",
         base_url: Some("https://api.groq.com/openai/v1"),
-        default_model: "llama-3.3-70b-versatile",
+        default_model: "openai/gpt-oss-120b",
         is_host: false,
     },
     CatalogEntry {
@@ -71,7 +71,7 @@ pub const CATALOG: &[CatalogEntry] = &[
     CatalogEntry {
         id: "deepseek",
         base_url: Some("https://api.deepseek.com"),
-        default_model: "deepseek-chat",
+        default_model: "deepseek-v4-flash",
         is_host: false,
     },
     CatalogEntry {
@@ -83,7 +83,7 @@ pub const CATALOG: &[CatalogEntry] = &[
     CatalogEntry {
         id: "xai",
         base_url: Some("https://api.x.ai/v1"),
-        default_model: "grok-2",
+        default_model: "grok-4.6",
         is_host: false,
     },
     CatalogEntry {
@@ -647,7 +647,7 @@ mod tests {
 
         cfg.enabled_models.remove("openai");
         cfg.provider = "anthropic".into();
-        assert_eq!(pick_provider(&cfg).1, "gpt-4o");
+        assert_eq!(pick_provider(&cfg).1, "gpt-5.6-terra");
     }
 
     #[test]

--- a/crates/oleafly-agent/src/provider.rs
+++ b/crates/oleafly-agent/src/provider.rs
@@ -47,7 +47,7 @@ pub const CATALOG: &[CatalogEntry] = &[
     CatalogEntry {
         id: "google",
         base_url: None,
-        default_model: "gemini-2.5-pro",
+        default_model: "gemini-3.7-flash",
         is_host: false,
     },
     CatalogEntry {

--- a/crates/oleafly-agent/src/provider.rs
+++ b/crates/oleafly-agent/src/provider.rs
@@ -19,6 +19,17 @@ pub enum Wire {
     },
 }
 
+impl Wire {
+    fn base_url(&self) -> &str {
+        match self {
+            Self::OpenAiResponses { base_url }
+            | Self::OpenAiChat { base_url, .. }
+            | Self::Anthropic { base_url }
+            | Self::Google { base_url } => base_url,
+        }
+    }
+}
+
 pub const OPENAI_BASE: &str = "https://api.openai.com/v1";
 pub const ANTHROPIC_BASE: &str = "https://api.anthropic.com/v1";
 pub const GOOGLE_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -141,6 +152,35 @@ pub struct Resolved {
     pub credential: String,
     pub auth: Option<String>,
     pub wire: Wire,
+}
+
+impl Resolved {
+    pub(crate) fn is_local_endpoint(&self) -> bool {
+        if self.provider_id == "ollama" {
+            return true;
+        }
+        let Ok(url) = reqwest::Url::parse(self.wire.base_url()) else {
+            return false;
+        };
+        let Some(host) = url.host_str() else {
+            return false;
+        };
+        if host.eq_ignore_ascii_case("localhost") || host.ends_with(".localhost") {
+            return true;
+        }
+        match host.parse::<std::net::IpAddr>() {
+            Ok(std::net::IpAddr::V4(ip)) => {
+                ip.is_loopback() || ip.is_private() || ip.is_link_local()
+            }
+            Ok(std::net::IpAddr::V6(ip)) => {
+                let octets = ip.octets();
+                ip.is_loopback()
+                    || octets[0] & 0xfe == 0xfc
+                    || (octets[0] == 0xfe && octets[1] & 0xc0 == 0x80)
+            }
+            Err(_) => false,
+        }
+    }
 }
 
 pub fn pick_provider(cfg: &ProviderConfig) -> (String, String, String) {
@@ -435,7 +475,7 @@ mod tests {
     fn google_model_ids_cannot_escape_the_models_path_segment() {
         let cfg = cfg_with(&[("google", "google-key")]);
 
-        assert!(resolve_specific(&cfg, "google", "gemini-2.5-pro").is_ok());
+        assert!(resolve_specific(&cfg, "google", "gemini-3.5-flash-lite").is_ok());
         for model in ["../other", "gemini?key=attacker", "gemini#fragment", "a/b"] {
             assert!(
                 resolve_specific(&cfg, "google", model).is_err(),

--- a/crates/oleafly-agent/src/run.rs
+++ b/crates/oleafly-agent/src/run.rs
@@ -255,6 +255,7 @@ fn part_context_chars(part: &ContentPart) -> Result<usize> {
             id,
             name,
             arguments,
+            ..
         } => checked_context_fields([id.as_str(), name.as_str(), arguments.as_str()]),
         ContentPart::ToolResult { id, name, output } => {
             checked_context_fields([id.as_str(), name.as_str(), output.as_str()])
@@ -315,6 +316,7 @@ fn assistant_turn(outcome: &StreamOutcome) -> Message {
             id: call.id.clone(),
             name: call.name.clone(),
             arguments: call.arguments.clone(),
+            thought_signature: call.thought_signature.clone(),
         });
     }
     Message {
@@ -724,11 +726,13 @@ mod tests {
                     id: "a".into(),
                     name: "read_file".into(),
                     arguments: "{}".into(),
+                    thought_signature: Some("sig-a".into()),
                 },
                 ToolCall {
                     id: "b".into(),
                     name: "list_files".into(),
                     arguments: "{}".into(),
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -738,11 +742,13 @@ mod tests {
         assert!(matches!(message.content[0], ContentPart::Text { .. }));
         assert!(matches!(
             message.content[1],
-            ContentPart::ToolUse { ref id, .. } if id == "a"
+            ContentPart::ToolUse { ref id, ref thought_signature, .. }
+                if id == "a" && thought_signature.as_deref() == Some("sig-a")
         ));
         assert!(matches!(
             message.content[2],
-            ContentPart::ToolUse { ref id, .. } if id == "b"
+            ContentPart::ToolUse { ref id, ref thought_signature, .. }
+                if id == "b" && thought_signature.is_none()
         ));
     }
 
@@ -770,6 +776,7 @@ mod tests {
                     id: call_id.clone(),
                     name: "literature_search".into(),
                     arguments: r#"{"query":"wildfire detection"}"#.into(),
+                    ..Default::default()
                 }],
                 response_items: vec![json!({
                     "type": "function_call",
@@ -815,6 +822,7 @@ mod tests {
                 id: "call_1".into(),
                 name: "read_file".into(),
                 arguments: "{}".into(),
+                ..Default::default()
             }],
             response_items: vec![
                 json!({
@@ -866,6 +874,7 @@ mod tests {
                 id: "a".into(),
                 name: "n".into(),
                 arguments: "{}".into(),
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -882,6 +891,7 @@ mod tests {
                     id: "a".into(),
                     name: "verify_pdf_pages".into(),
                     arguments: "{}".into(),
+                    ..Default::default()
                 },
                 ToolOutput {
                     output: "checked".into(),
@@ -893,6 +903,7 @@ mod tests {
                     id: "b".into(),
                     name: "read_file".into(),
                     arguments: "{}".into(),
+                    ..Default::default()
                 },
                 ToolOutput::text("body"),
             ),

--- a/crates/oleafly-agent/src/stream/mod.rs
+++ b/crates/oleafly-agent/src/stream/mod.rs
@@ -13,6 +13,7 @@ use crate::provider::{catalog_entry, Resolved, Wire};
 use crate::sse::{SseDecoder, SseEvent};
 
 const DEFAULT_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+const LOCAL_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(360);
 const MAX_STREAM_DURATION: Duration = Duration::from_secs(10 * 60);
 const MAX_STREAM_BYTES: usize = 32 * 1024 * 1024;
 const MAX_TOOL_ARGUMENT_BYTES: usize = 8 * 1024 * 1024;
@@ -153,6 +154,14 @@ impl StreamBudget {
     }
 }
 
+fn default_idle_timeout(resolved: &Resolved) -> Duration {
+    if resolved.auth.is_none() {
+        LOCAL_STREAM_IDLE_TIMEOUT
+    } else {
+        DEFAULT_STREAM_IDLE_TIMEOUT
+    }
+}
+
 fn stream_deadline(req: &CompletionRequest) -> Duration {
     req.timeout_ms
         .map(Duration::from_millis)
@@ -214,7 +223,7 @@ where
     let idle = req
         .idle_timeout_ms
         .map(Duration::from_millis)
-        .unwrap_or(DEFAULT_STREAM_IDLE_TIMEOUT);
+        .unwrap_or_else(|| default_idle_timeout(resolved));
     let response = open_stream(client, resolved, req).await?;
     let mut state = StreamState::new(WireKind::from(&resolved.wire));
     consume_response(response, idle, &mut state, &mut on_event).await?;

--- a/crates/oleafly-agent/src/stream/mod.rs
+++ b/crates/oleafly-agent/src/stream/mod.rs
@@ -155,7 +155,7 @@ impl StreamBudget {
 }
 
 fn default_idle_timeout(resolved: &Resolved) -> Duration {
-    if resolved.auth.is_none() {
+    if resolved.is_local_endpoint() {
         LOCAL_STREAM_IDLE_TIMEOUT
     } else {
         DEFAULT_STREAM_IDLE_TIMEOUT

--- a/crates/oleafly-agent/src/stream/mod.rs
+++ b/crates/oleafly-agent/src/stream/mod.rs
@@ -180,7 +180,7 @@ fn stream_body(resolved: &Resolved, req: &CompletionRequest) -> Result<Value> {
             body["stream"] = Value::Bool(true);
             Ok(body)
         }
-        Wire::Google { .. } => google_body(req),
+        Wire::Google { .. } => google_body(resolved, req),
     }
 }
 

--- a/crates/oleafly-agent/src/stream/mod.rs
+++ b/crates/oleafly-agent/src/stream/mod.rs
@@ -27,6 +27,7 @@ pub struct ToolCall {
     pub id: String,
     pub name: String,
     pub arguments: String,
+    pub thought_signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/crates/oleafly-agent/src/stream/tests.rs
+++ b/crates/oleafly-agent/src/stream/tests.rs
@@ -656,3 +656,24 @@ fn google_stream_body_carries_no_stream_flag() {
     assert!(body.get("stream").is_none());
     assert!(body.get("contents").is_some());
 }
+
+#[test]
+fn local_hosts_get_a_longer_default_idle_timeout_than_cloud_apis() {
+    let local = Resolved {
+        provider_id: "ollama".into(),
+        model_id: "llama3.2".into(),
+        credential: String::new(),
+        auth: None,
+        wire: Wire::OpenAiChat {
+            base_url: "http://localhost:11434/v1".into(),
+            reasoning_content: false,
+        },
+    };
+    let cloud = Resolved {
+        auth: Some("sk".into()),
+        ..local.clone()
+    };
+
+    assert_eq!(default_idle_timeout(&local), Duration::from_secs(360));
+    assert_eq!(default_idle_timeout(&cloud), Duration::from_secs(120));
+}

--- a/crates/oleafly-agent/src/stream/tests.rs
+++ b/crates/oleafly-agent/src/stream/tests.rs
@@ -536,6 +536,20 @@ fn google_function_calls_arrive_whole() {
 }
 
 #[test]
+fn google_thought_parts_stream_as_reasoning_not_answer_text() {
+    let raw = concat!(
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"planning the search\",\"thought\":true}]}}]}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Here are the papers.\"}]},\"finishReason\":\"STOP\"}]}\n\n"
+    );
+    let (events, _) = run(WireKind::Google, raw);
+    assert_eq!(text_of(&events), "Here are the papers.");
+    assert!(events.iter().any(|e| matches!(
+        e,
+        AgentEvent::ReasoningDelta { text } if text == "planning the search"
+    )));
+}
+
+#[test]
 fn a_google_function_call_keeps_its_part_level_thought_signature() {
     let raw = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{}},\"thoughtSignature\":\"sig-1\"}]}}]}\n\n";
     let (_, translator) = run(WireKind::Google, raw);

--- a/crates/oleafly-agent/src/stream/tests.rs
+++ b/crates/oleafly-agent/src/stream/tests.rs
@@ -559,6 +559,40 @@ fn a_google_function_call_keeps_its_part_level_thought_signature() {
 }
 
 #[test]
+fn a_signature_on_a_thought_part_reaches_the_following_call() {
+    let raw = concat!(
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"planning\",\"thought\":true,\"thoughtSignature\":\"sig-t\"}]}}]}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{}}}]}}]}\n\n"
+    );
+    let (_, translator) = run(WireKind::Google, raw);
+    let calls = translator.tool_calls();
+    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-t"));
+}
+
+#[test]
+fn a_trailing_signature_only_part_backfills_an_unsigned_call() {
+    let raw = concat!(
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{}}}]}}]}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\",\"thoughtSignature\":\"sig-late\"}]}}]}\n\n"
+    );
+    let (_, translator) = run(WireKind::Google, raw);
+    let calls = translator.tool_calls();
+    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-late"));
+}
+
+#[test]
+fn a_signed_call_is_never_overwritten_by_a_stray_signature() {
+    let raw = concat!(
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"f\",\"args\":{}},\"thoughtSignature\":\"sig-own\"},{\"functionCall\":{\"name\":\"f\",\"args\":{}}}]}}]}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\",\"thoughtSignature\":\"sig-stray\"}]}}]}\n\n"
+    );
+    let (_, translator) = run(WireKind::Google, raw);
+    let calls = translator.tool_calls();
+    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-own"));
+    assert_eq!(calls[1].thought_signature, None);
+}
+
+#[test]
 fn parallel_google_calls_keep_the_signature_only_where_it_arrived() {
     let raw = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"f\",\"args\":{}},\"thoughtSignature\":\"sig-first\"},{\"functionCall\":{\"name\":\"f\",\"args\":{}}}]}}]}\n\n";
     let (_, translator) = run(WireKind::Google, raw);

--- a/crates/oleafly-agent/src/stream/tests.rs
+++ b/crates/oleafly-agent/src/stream/tests.rs
@@ -342,6 +342,7 @@ fn openai_tool_call_fragments_reassemble_into_one_document() {
             id: "call_a".into(),
             name: "read_file".into(),
             arguments: "{\"path\":\"main.tex\"}".into(),
+            ..Default::default()
         }]
     );
     assert!(events.iter().any(|e| matches!(
@@ -440,6 +441,7 @@ fn anthropic_tool_use_blocks_reassemble() {
             id: "toolu_1".into(),
             name: "write_file".into(),
             arguments: "{\"path\":\"a.tex\"}".into(),
+            ..Default::default()
         }]
     );
 }
@@ -530,6 +532,26 @@ fn google_function_calls_arrive_whole() {
         serde_json::from_str::<Value>(&calls[0].arguments).unwrap()["path"],
         "main.tex"
     );
+    assert_eq!(calls[0].thought_signature, None);
+}
+
+#[test]
+fn a_google_function_call_keeps_its_part_level_thought_signature() {
+    let raw = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{}},\"thoughtSignature\":\"sig-1\"}]}}]}\n\n";
+    let (_, translator) = run(WireKind::Google, raw);
+    let calls = translator.tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-1"));
+}
+
+#[test]
+fn parallel_google_calls_keep_the_signature_only_where_it_arrived() {
+    let raw = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"f\",\"args\":{}},\"thoughtSignature\":\"sig-first\"},{\"functionCall\":{\"name\":\"f\",\"args\":{}}}]}}]}\n\n";
+    let (_, translator) = run(WireKind::Google, raw);
+    let calls = translator.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-first"));
+    assert_eq!(calls[1].thought_signature, None);
 }
 
 #[test]

--- a/crates/oleafly-agent/src/stream/tests.rs
+++ b/crates/oleafly-agent/src/stream/tests.rs
@@ -559,37 +559,39 @@ fn a_google_function_call_keeps_its_part_level_thought_signature() {
 }
 
 #[test]
-fn a_signature_on_a_thought_part_reaches_the_following_call() {
+fn a_signature_on_a_thought_part_is_not_moved_to_a_following_call() {
     let raw = concat!(
         "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"planning\",\"thought\":true,\"thoughtSignature\":\"sig-t\"}]}}]}\n\n",
         "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{}}}]}}]}\n\n"
     );
     let (_, translator) = run(WireKind::Google, raw);
     let calls = translator.tool_calls();
-    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-t"));
+    assert_eq!(calls[0].thought_signature, None);
 }
 
 #[test]
-fn a_trailing_signature_only_part_backfills_an_unsigned_call() {
+fn a_trailing_signature_only_part_does_not_backfill_an_unsigned_call() {
     let raw = concat!(
         "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{}}}]}}]}\n\n",
         "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\",\"thoughtSignature\":\"sig-late\"}]}}]}\n\n"
     );
     let (_, translator) = run(WireKind::Google, raw);
     let calls = translator.tool_calls();
-    assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-late"));
+    assert_eq!(calls[0].thought_signature, None);
 }
 
 #[test]
 fn a_signed_call_is_never_overwritten_by_a_stray_signature() {
     let raw = concat!(
         "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"f\",\"args\":{}},\"thoughtSignature\":\"sig-own\"},{\"functionCall\":{\"name\":\"f\",\"args\":{}}}]}}]}\n\n",
-        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\",\"thoughtSignature\":\"sig-stray\"}]}}]}\n\n"
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\",\"thoughtSignature\":\"sig-stray\"}]}}]}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"later\",\"args\":{}}}]}}]}\n\n"
     );
     let (_, translator) = run(WireKind::Google, raw);
     let calls = translator.tool_calls();
     assert_eq!(calls[0].thought_signature.as_deref(), Some("sig-own"));
     assert_eq!(calls[1].thought_signature, None);
+    assert_eq!(calls[2].thought_signature, None);
 }
 
 #[test]
@@ -679,7 +681,7 @@ fn google_stream_body_carries_no_stream_flag() {
     let req = CompletionRequest::prompt("s", "u");
     let resolved = Resolved {
         provider_id: "google".into(),
-        model_id: "gemini-2.5-pro".into(),
+        model_id: "gemini-3.5-flash-lite".into(),
         credential: "k".into(),
         auth: Some("k".into()),
         wire: Wire::Google {
@@ -692,19 +694,25 @@ fn google_stream_body_carries_no_stream_flag() {
 }
 
 #[test]
-fn local_hosts_get_a_longer_default_idle_timeout_than_cloud_apis() {
+fn endpoint_locality_controls_the_default_idle_timeout_independently_of_auth() {
     let local = Resolved {
-        provider_id: "ollama".into(),
+        provider_id: "private-model-server".into(),
         model_id: "llama3.2".into(),
-        credential: String::new(),
-        auth: None,
+        credential: "local-key".into(),
+        auth: Some("local-key".into()),
         wire: Wire::OpenAiChat {
-            base_url: "http://localhost:11434/v1".into(),
+            base_url: "http://127.0.0.1:11434/v1".into(),
             reasoning_content: false,
         },
     };
     let cloud = Resolved {
-        auth: Some("sk".into()),
+        provider_id: "remote-keyless-server".into(),
+        credential: String::new(),
+        auth: None,
+        wire: Wire::OpenAiChat {
+            base_url: "https://models.example/v1".into(),
+            reasoning_content: false,
+        },
         ..local.clone()
     };
 

--- a/crates/oleafly-agent/src/stream/translate.rs
+++ b/crates/oleafly-agent/src/stream/translate.rs
@@ -126,6 +126,7 @@ impl Translator {
                 id: id.clone(),
                 name: name.clone(),
                 arguments: String::new(),
+                thought_signature: None,
             },
         );
         vec![AgentEvent::ToolCallStart { id, name }]
@@ -510,7 +511,12 @@ impl Translator {
                     out.push(AgentEvent::TextDelta { text });
                 }
                 if let Some(call) = part.get("functionCall") {
-                    out.extend(self.google_function_call(call));
+                    let signature = part
+                        .get("thoughtSignature")
+                        .and_then(|s| s.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+                    out.extend(self.google_function_call(call, signature));
                 }
             }
         }
@@ -524,7 +530,11 @@ impl Translator {
         out
     }
 
-    fn google_function_call(&mut self, call: &Value) -> Vec<AgentEvent> {
+    fn google_function_call(
+        &mut self,
+        call: &Value,
+        thought_signature: Option<String>,
+    ) -> Vec<AgentEvent> {
         let name = call
             .get("name")
             .and_then(|n| n.as_str())
@@ -541,6 +551,9 @@ impl Translator {
             .map(|a| a.to_string())
             .unwrap_or_else(|| "{}".to_string());
         let mut out = self.start_call(index, id, name);
+        if let Some(open) = self.open.get_mut(&index) {
+            open.thought_signature = thought_signature;
+        }
         out.extend(self.push_args(index, &arguments));
         out.extend(self.close_call(index));
         out

--- a/crates/oleafly-agent/src/stream/translate.rs
+++ b/crates/oleafly-agent/src/stream/translate.rs
@@ -507,8 +507,16 @@ impl Translator {
             .and_then(|p| p.as_array())
         {
             for part in parts {
+                let thought = part
+                    .get("thought")
+                    .and_then(|t| t.as_bool())
+                    .unwrap_or(false);
                 if let Some(text) = nonempty(part.get("text")) {
-                    out.push(AgentEvent::TextDelta { text });
+                    if thought {
+                        out.push(AgentEvent::ReasoningDelta { text });
+                    } else {
+                        out.push(AgentEvent::TextDelta { text });
+                    }
                 }
                 if let Some(call) = part.get("functionCall") {
                     let signature = part

--- a/crates/oleafly-agent/src/stream/translate.rs
+++ b/crates/oleafly-agent/src/stream/translate.rs
@@ -39,6 +39,7 @@ pub struct Translator {
     synthetic: i64,
     error: Option<AgentError>,
     response_items: BTreeMap<i64, Value>,
+    pending_google_signature: Option<String>,
 }
 
 impl Translator {
@@ -54,6 +55,7 @@ impl Translator {
             synthetic: 0,
             error: None,
             response_items: BTreeMap::new(),
+            pending_google_signature: None,
         }
     }
 
@@ -518,13 +520,15 @@ impl Translator {
                         out.push(AgentEvent::TextDelta { text });
                     }
                 }
+                let signature = part
+                    .get("thoughtSignature")
+                    .and_then(|s| s.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
                 if let Some(call) = part.get("functionCall") {
-                    let signature = part
-                        .get("thoughtSignature")
-                        .and_then(|s| s.as_str())
-                        .filter(|s| !s.is_empty())
-                        .map(|s| s.to_string());
                     out.extend(self.google_function_call(call, signature));
+                } else if let Some(signature) = signature {
+                    self.note_google_signature(signature);
                 }
             }
         }
@@ -551,6 +555,7 @@ impl Translator {
         if name.is_empty() {
             return Vec::new();
         }
+        let thought_signature = thought_signature.or_else(|| self.pending_google_signature.take());
         self.synthetic += 1;
         let index = -self.synthetic;
         let id = format!("call_{}_{}", name, self.synthetic);
@@ -565,6 +570,25 @@ impl Translator {
         out.extend(self.push_args(index, &arguments));
         out.extend(self.close_call(index));
         out
+    }
+
+    fn note_google_signature(&mut self, signature: String) {
+        let step_already_signed = self
+            .finished
+            .iter()
+            .any(|call| call.thought_signature.is_some());
+        if step_already_signed {
+            self.pending_google_signature = Some(signature);
+            return;
+        }
+        match self
+            .finished
+            .iter_mut()
+            .find(|call| call.thought_signature.is_none())
+        {
+            Some(call) => call.thought_signature = Some(signature),
+            None => self.pending_google_signature = Some(signature),
+        }
     }
 }
 

--- a/crates/oleafly-agent/src/stream/translate.rs
+++ b/crates/oleafly-agent/src/stream/translate.rs
@@ -39,7 +39,6 @@ pub struct Translator {
     synthetic: i64,
     error: Option<AgentError>,
     response_items: BTreeMap<i64, Value>,
-    pending_google_signature: Option<String>,
 }
 
 impl Translator {
@@ -55,7 +54,6 @@ impl Translator {
             synthetic: 0,
             error: None,
             response_items: BTreeMap::new(),
-            pending_google_signature: None,
         }
     }
 
@@ -527,8 +525,6 @@ impl Translator {
                     .map(|s| s.to_string());
                 if let Some(call) = part.get("functionCall") {
                     out.extend(self.google_function_call(call, signature));
-                } else if let Some(signature) = signature {
-                    self.note_google_signature(signature);
                 }
             }
         }
@@ -555,7 +551,6 @@ impl Translator {
         if name.is_empty() {
             return Vec::new();
         }
-        let thought_signature = thought_signature.or_else(|| self.pending_google_signature.take());
         self.synthetic += 1;
         let index = -self.synthetic;
         let id = format!("call_{}_{}", name, self.synthetic);
@@ -570,25 +565,6 @@ impl Translator {
         out.extend(self.push_args(index, &arguments));
         out.extend(self.close_call(index));
         out
-    }
-
-    fn note_google_signature(&mut self, signature: String) {
-        let step_already_signed = self
-            .finished
-            .iter()
-            .any(|call| call.thought_signature.is_some());
-        if step_already_signed {
-            self.pending_google_signature = Some(signature);
-            return;
-        }
-        match self
-            .finished
-            .iter_mut()
-            .find(|call| call.thought_signature.is_none())
-        {
-            Some(call) => call.thought_signature = Some(signature),
-            None => self.pending_google_signature = Some(signature),
-        }
     }
 }
 

--- a/crates/oleafly-agent/src/wire/mod.rs
+++ b/crates/oleafly-agent/src/wire/mod.rs
@@ -34,6 +34,7 @@ fn openai_tool_calls(rest: &[&ContentPart]) -> Vec<Value> {
                 id,
                 name,
                 arguments,
+                ..
             } => Some(json!({
                 "id": id,
                 "type": "function",
@@ -144,6 +145,7 @@ pub(crate) fn openai_responses_input(messages: &[Message]) -> Result<Vec<Value>>
                     id,
                     name,
                     arguments,
+                    ..
                 } => {
                     if let Some(item) = responses_message(message, &visible)? {
                         input.push(item);
@@ -221,6 +223,7 @@ fn anthropic_part(part: &ContentPart) -> Result<Value> {
             id,
             name,
             arguments,
+            ..
         } => json!({
             "type": "tool_use",
             "id": id,
@@ -275,10 +278,19 @@ fn google_part(part: &ContentPart) -> Result<Value> {
             })
         }
         ContentPart::ToolUse {
-            name, arguments, ..
-        } => json!({
-            "functionCall": { "name": name, "args": parse_arguments(arguments) }
-        }),
+            name,
+            arguments,
+            thought_signature,
+            ..
+        } => {
+            let mut part = json!({
+                "functionCall": { "name": name, "args": parse_arguments(arguments) }
+            });
+            if let Some(signature) = thought_signature {
+                part["thoughtSignature"] = json!(signature);
+            }
+            part
+        }
         ContentPart::ToolResult { name, output, .. } => json!({
             "functionResponse": {
                 "name": name,

--- a/crates/oleafly-agent/src/wire/mod.rs
+++ b/crates/oleafly-agent/src/wire/mod.rs
@@ -300,13 +300,16 @@ fn google_part(part: &ContentPart) -> Result<Value> {
     })
 }
 
-fn google_generation_config(req: &CompletionRequest) -> Option<Value> {
+fn google_generation_config(resolved: &Resolved, req: &CompletionRequest) -> Option<Value> {
     let mut generation = serde_json::Map::new();
     if let Some(t) = req.temperature {
         generation.insert("temperature".into(), json!(t));
     }
     if let Some(m) = req.max_tokens {
         generation.insert("maxOutputTokens".into(), json!(m));
+    }
+    if resolved.model_id.starts_with("gemini-") {
+        generation.insert("thinkingConfig".into(), json!({ "includeThoughts": true }));
     }
     if generation.is_empty() {
         None
@@ -315,7 +318,7 @@ fn google_generation_config(req: &CompletionRequest) -> Option<Value> {
     }
 }
 
-pub(crate) fn google_body(req: &CompletionRequest) -> Result<Value> {
+pub(crate) fn google_body(resolved: &Resolved, req: &CompletionRequest) -> Result<Value> {
     let mut contents: Vec<Value> = Vec::new();
     for message in &req.messages {
         let mut parts = Vec::with_capacity(message.content.len());
@@ -333,7 +336,7 @@ pub(crate) fn google_body(req: &CompletionRequest) -> Result<Value> {
     if let Some(system) = req.system.as_ref().filter(|s| !s.is_empty()) {
         body["systemInstruction"] = json!({ "parts": [{ "text": system }] });
     }
-    if let Some(generation) = google_generation_config(req) {
+    if let Some(generation) = google_generation_config(resolved, req) {
         body["generationConfig"] = generation;
     }
     if !req.tools.is_empty() {
@@ -402,7 +405,7 @@ pub fn wire_body(resolved: &Resolved, req: &CompletionRequest) -> Result<serde_j
         Wire::OpenAiResponses { .. } => openai_responses_body(resolved, req),
         Wire::OpenAiChat { .. } => openai_body(resolved, req),
         Wire::Anthropic { .. } => anthropic_body(resolved, req),
-        Wire::Google { .. } => google_body(req),
+        Wire::Google { .. } => google_body(resolved, req),
     }
 }
 

--- a/crates/oleafly-agent/src/wire/tests.rs
+++ b/crates/oleafly-agent/src/wire/tests.rs
@@ -548,8 +548,8 @@ fn endpoints_are_built_without_double_slashes() {
         format!(
             "{}/models/{}:generateContent",
             GOOGLE_BASE.trim_end_matches('/'),
-            "gemini-2.5-pro"
+            "gemini-3.5-flash-lite"
         ),
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent"
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent"
     );
 }

--- a/crates/oleafly-agent/src/wire/tests.rs
+++ b/crates/oleafly-agent/src/wire/tests.rs
@@ -132,6 +132,7 @@ fn tool_turn() -> CompletionRequest {
                         id: "call_1".into(),
                         name: "read_file".into(),
                         arguments: "{\"path\":\"main.tex\"}".into(),
+                        thought_signature: Some("sig-abc".into()),
                     },
                 ],
             },
@@ -269,6 +270,7 @@ fn an_assistant_turn_of_only_tool_calls_sends_null_content() {
                 id: "c".into(),
                 name: "n".into(),
                 arguments: "{}".into(),
+                thought_signature: None,
             }],
         }],
         ..Default::default()
@@ -315,6 +317,47 @@ fn google_uses_function_call_and_response_parts() {
 }
 
 #[test]
+fn google_echoes_the_thought_signature_beside_its_function_call() {
+    let body = google_body(&tool_turn()).unwrap();
+    assert_eq!(
+        body["contents"][1]["parts"][1]["thoughtSignature"],
+        "sig-abc"
+    );
+}
+
+#[test]
+fn a_function_call_without_a_signature_omits_the_field_entirely() {
+    let request = CompletionRequest {
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentPart::ToolUse {
+                id: "c".into(),
+                name: "n".into(),
+                arguments: "{}".into(),
+                thought_signature: None,
+            }],
+        }],
+        ..Default::default()
+    };
+    let part = &google_body(&request).unwrap()["contents"][0]["parts"][0];
+    assert!(part.get("thoughtSignature").is_none());
+}
+
+#[test]
+fn thought_signatures_never_leak_into_other_providers_wire_shapes() {
+    let request = tool_turn();
+    let openai_call = &openai_body(&openai(), &request).unwrap()["messages"][2]["tool_calls"][0];
+    assert!(openai_call.get("thoughtSignature").is_none());
+
+    let anthropic_block =
+        &anthropic_body(&openai(), &request).unwrap()["messages"][1]["content"][1];
+    assert!(anthropic_block.get("thoughtSignature").is_none());
+
+    let responses_item = &openai_responses_body(&openai_responses(), &request).unwrap()["input"][2];
+    assert!(responses_item.get("thoughtSignature").is_none());
+}
+
+#[test]
 fn tool_schemas_reach_every_provider_in_its_own_shape() {
     let request = tool_turn();
     assert_eq!(
@@ -354,6 +397,7 @@ fn truncated_tool_arguments_do_not_break_the_request() {
                 id: "c".into(),
                 name: "n".into(),
                 arguments: "{\"path\":".into(),
+                thought_signature: None,
             }],
         }],
         ..Default::default()

--- a/crates/oleafly-agent/src/wire/tests.rs
+++ b/crates/oleafly-agent/src/wire/tests.rs
@@ -19,6 +19,15 @@ fn openai() -> Resolved {
     })
 }
 
+fn google() -> Resolved {
+    Resolved {
+        model_id: "gemini-3.7-flash".into(),
+        ..resolved(Wire::Google {
+            base_url: GOOGLE_BASE.into(),
+        })
+    }
+}
+
 fn openai_responses() -> Resolved {
     resolved(Wire::OpenAiResponses {
         base_url: OPENAI_BASE.into(),
@@ -59,7 +68,7 @@ fn an_empty_system_prompt_is_omitted_everywhere() {
         .unwrap()
         .get("system")
         .is_none());
-    assert!(google_body(&req)
+    assert!(google_body(&google(), &req)
         .unwrap()
         .get("systemInstruction")
         .is_none());
@@ -92,7 +101,7 @@ fn images_take_each_providers_own_shape() {
     );
     assert_eq!(an["messages"][0]["content"][1]["source"]["data"], "AAAB");
 
-    let gg = google_body(&req).unwrap();
+    let gg = google_body(&google(), &req).unwrap();
     assert_eq!(
         gg["contents"][0]["parts"][1]["inlineData"]["mimeType"],
         "image/png"
@@ -116,7 +125,7 @@ fn a_remote_image_url_is_refused_before_any_request_leaves() {
     };
     assert!(openai_body(&openai(), &req).is_err());
     assert!(anthropic_body(&openai(), &req).is_err());
-    assert!(google_body(&req).is_err());
+    assert!(google_body(&google(), &req).is_err());
 }
 
 fn tool_turn() -> CompletionRequest {
@@ -299,7 +308,7 @@ fn anthropic_keeps_tool_blocks_inside_the_turn_and_parses_arguments() {
 
 #[test]
 fn google_uses_function_call_and_response_parts() {
-    let body = google_body(&tool_turn()).unwrap();
+    let body = google_body(&google(), &tool_turn()).unwrap();
     let contents = body["contents"].as_array().unwrap();
 
     assert_eq!(contents[1]["role"], "model");
@@ -318,7 +327,7 @@ fn google_uses_function_call_and_response_parts() {
 
 #[test]
 fn google_echoes_the_thought_signature_beside_its_function_call() {
-    let body = google_body(&tool_turn()).unwrap();
+    let body = google_body(&google(), &tool_turn()).unwrap();
     assert_eq!(
         body["contents"][1]["parts"][1]["thoughtSignature"],
         "sig-abc"
@@ -339,7 +348,7 @@ fn a_function_call_without_a_signature_omits_the_field_entirely() {
         }],
         ..Default::default()
     };
-    let part = &google_body(&request).unwrap()["contents"][0]["parts"][0];
+    let part = &google_body(&google(), &request).unwrap()["contents"][0]["parts"][0];
     assert!(part.get("thoughtSignature").is_none());
 }
 
@@ -369,7 +378,7 @@ fn tool_schemas_reach_every_provider_in_its_own_shape() {
         "read_file"
     );
     assert_eq!(
-        google_body(&request).unwrap()["tools"][0]["functionDeclarations"][0]["name"],
+        google_body(&google(), &request).unwrap()["tools"][0]["functionDeclarations"][0]["name"],
         "read_file"
     );
 }
@@ -385,7 +394,10 @@ fn a_request_without_tools_sends_no_tools_field() {
         .unwrap()
         .get("tools")
         .is_none());
-    assert!(google_body(&request).unwrap().get("tools").is_none());
+    assert!(google_body(&google(), &request)
+        .unwrap()
+        .get("tools")
+        .is_none());
 }
 
 #[test]
@@ -438,15 +450,34 @@ fn google_renames_the_assistant_turn() {
         ],
         ..Default::default()
     };
-    let body = google_body(&req).unwrap();
+    let body = google_body(&google(), &req).unwrap();
     assert_eq!(body["contents"][0]["role"], "user");
     assert_eq!(body["contents"][1]["role"], "model");
 }
 
 #[test]
-fn generation_config_is_omitted_when_nothing_was_asked_for() {
+fn gemini_models_always_ask_for_streamed_thought_summaries() {
     let req = CompletionRequest::prompt("s", "u");
-    assert!(google_body(&req).unwrap().get("generationConfig").is_none());
+    let body = google_body(&google(), &req).unwrap();
+    assert_eq!(
+        body["generationConfig"]["thinkingConfig"]["includeThoughts"],
+        true
+    );
+}
+
+#[test]
+fn non_gemini_google_models_get_no_generation_config_by_default() {
+    let req = CompletionRequest::prompt("s", "u");
+    let other = Resolved {
+        model_id: "gemma-3-27b-it".into(),
+        ..resolved(Wire::Google {
+            base_url: GOOGLE_BASE.into(),
+        })
+    };
+    assert!(google_body(&other, &req)
+        .unwrap()
+        .get("generationConfig")
+        .is_none());
 }
 
 fn header_names(resolved: &Resolved) -> Vec<String> {

--- a/docs/readme-translations/README.de.md
+++ b/docs/readme-translations/README.de.md
@@ -6,43 +6,30 @@
 
 [English](../../README.md) | **Deutsch** | [Español](README.es.md) | [Français](README.fr.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Português](README.pt.md) | [Русский](README.ru.md) | [中文](README.zh.md)
 
-**Schreibe, kompiliere und veröffentliche Forschung mit einem KI-Arbeitsbereich, der dir gehört.**
+<h2>Eine vollständige Forschungsumgebung, neu entwickelt für das KI-Zeitalter.</h2>
 
-Schreibe in LaTeX, Typst oder Markdown. Kompiliere direkt neben deinem
-Quelltext. Behalte jede Revision in Git. Nutze KI zu deinen Bedingungen.
+Schreibe, kompiliere und korrigiere Texte, durchsuche Fachliteratur, verwalte
+Quellen, erstelle Abbildungen, prüfe PDFs und verfolge jede Änderung in Git.
+Nutze gehostete KI, einen eigenen Endpunkt, lokales Ollama oder gar keine KI.
+Oleafly speichert deine Projekte als normale Ordner auf deinem Computer.
 
-Oleafly ist eine kostenlose, zu 100 % quelloffene Desktop-App für macOS,
-Windows und Linux. Sie ist Local-First, funktioniert ohne Konto und speichert
-einfache Projektdateien auf deinem Rechner.
-
+[![Offene Issues](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Oleafly herunterladen](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[Engineering-Dokumentation lesen](../README.md) ·
+[Produktdokumentation lesen](https://oleafly.com/docs/overview/) ·
 [Aus dem Quellcode bauen](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="Oleafly mit einem LaTeX-Editor und dem kompilierten PDF nebeneinander (helles Theme)" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="Oleafly mit einem LaTeX-Editor und dem kompilierten PDF nebeneinander (dunkles Theme)" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="Die Oleafly-Bibliothek zeigt Projekte als farbige Bücher mit Angaben zu Engine, Art und letzter Änderung (dunkles Theme)" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="Die Oleafly-Bibliothek zeigt Projekte als farbige Bücher mit Angaben zu Engine, Art und letzter Änderung (helles Theme)" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="Oleafly bearbeitet das LLaMA-Forschungspapier in LaTeX. Quellbaum, Dokumentgliederung und kompiliertes PDF sind gleichzeitig geöffnet." width="100%" />
 </div>
 
 <!--
@@ -50,14 +37,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly ist bereit für den täglichen Einsatz, aber das Projekt entwickelt
-> sich noch schnell weiter. Erweiterte Paketkompatibilität und einige
-> Plattformintegrationen werden noch stabilisiert. macOS-Builds sind signiert
-> und notarisiert; Windows-Builds sind noch nicht signiert. Lade nur von der
-> offiziellen Releases-Seite herunter und lies die Release-Notes,
-> bevor du einen unsignierten Preview-Build installierst.
 
 ## Forschung hat ohnehin schon genug bewegliche Teile
 
@@ -175,10 +154,6 @@ Leser tatsächlich sieht.
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="Eine kompilierte Seite mit Plots, einer farbkodierten Fehleroberfläche und einer Ergebnistabelle neben dem LaTeX-Quelltext" width="88%" />
 </div>
 
 Zoome heraus, und das ganze Dokument ist auf einmal auf dem Bildschirm – meist
@@ -427,6 +402,28 @@ bleiben auf deinem Rechner.
 API-Schlüssel werden lokal gespeichert. Die einfachen Dokumentdateien bleiben
 nutzbar, selbst wenn du Oleafly nicht mehr verwendest.
 
+## Demnächst
+
+Die Roadmap hält Oleafly offen, Local-First und für den gesamten
+Forschungsablauf nützlich.
+
+- **Lokalisierung der App.** Nutze Oleafly in weiteren Sprachen und arbeite in
+  der Oberfläche, die sich für dich am natürlichsten anfühlt.
+- **Agenten-Skills und Plugins.** Ergänze gezielte, wiederverwendbare
+  KI-Abläufe, die weniger Kontext erneut senden und weniger Tokens verbrauchen.
+- **Autonome Forschungsagenten.** Verwandle eine Forschungsfrage und eine
+  Quellensammlung in einen strukturierten ersten Entwurf.
+- **Echtzeit-Zusammenarbeit und Kommentare.** Arbeite mit unbegrenzter,
+  selbst gehosteter Zusammenarbeit im Forschungsteam.
+- **Oleafly CLI.** Nutze ein schlankes, installierbares Kommandozeilenpaket für
+  Forschungsabläufe, die keine grafische Oberfläche benötigen.
+- **Bessere Typst- und Markdown-Unterstützung.** Nutze mehr Funktionen für
+  Bearbeitung, Vorschau und Veröffentlichung in beiden Formaten.
+- **Weitere Forschungsintegrationen.** Verbinde Mendeley und zusätzliche
+  Literatur-, Bibliotheks- und Forschungsdienste.
+- **Selbst gehostete Cloud-Synchronisierung.** Synchronisiere Projekte zwischen
+  Geräten und nutze auf Wunsch eine bessere automatische GitHub-Synchronisierung.
+
 ## Installation
 
 Lade den neuesten Build von
@@ -447,20 +444,49 @@ So startest du aus dem Quellcode:
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 Voraussetzungen, Plattform-Setup und Produktions-Builds findest du im
 [Entwicklungsleitfaden](../development.md).
 
-## Dokumentation
+Diese Skripte laden die mit Prüfsummen festgelegten Compiler-Sidecars für deine
+aktuelle Plattform nach `src-tauri/binaries`. Das Argument `all` ist für CI und
+Release-Pakete vorgesehen, bei denen jede unterstützte Plattform vorbereitet
+werden muss.
 
-Das Repository hält die öffentlichen Engineering- und Produktreferenzen nah am
-Code. Aufgabenorientierte Anleitungen für Endnutzer werden getrennt von diesem
-öffentlichen Index gepflegt.
+Editorfunktionen über TexLab und Tinymist sind für einen lokalen Start optional.
+Lade diese Language Server mit `pnpm language-servers:fetch` herunter. Angaben
+zu Integrität, Lizenzen und Verteilung findest du in der
+[Language-Server-Toolchain](../language-server-toolchain.md).
+
+### Kommandozeile
+
+`oleaflyc` verwaltet Oleafly-Projekte, ohne die Desktop-App zu starten. Das
+Programm wird in diesem Repository aus dem Quellcode gebaut und noch nicht als
+eigenständiges Paket veröffentlicht.
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+Die Befehle arbeiten im aktuellen Verzeichnis. Mit `-C <path>` wählst du ein
+anderes Projekt. `oleaflyc --help` zeigt die vollständige Befehlsliste.
+
+## Entwicklerdokumentation
+
+Benutzerhandbücher findest du in der
+[Oleafly-Produktdokumentation](https://oleafly.com/docs/overview/). Die folgenden
+Referenzen richten sich an Mitwirkende, Integratoren und Release-Verantwortliche.
 
 | Referenz | Inhalt |
 | --- | --- |
@@ -477,10 +503,12 @@ Code. Aufgabenorientierte Anleitungen für Endnutzer werden getrennt von diesem
 
 ## Mitwirken
 
-Oleafly wird offen entwickelt, von
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) und
-Mitwirkenden. Fehlerberichte, Fixes, Vorlagen, Dokumentation und durchdachtes
-Produktfeedback sind willkommen.
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="Der Oleafly Club: eine offene Forschungsgemeinschaft, die Entwürfe, Überarbeitungen, Tests und erfolgreiche Einreichungen feiert" width="100%" /></td>
+    <td width="62%" valign="top"><h3>Forschende verdienen Werkzeuge, die sie prüfen, erweitern und denen sie vertrauen können.</h3><p>Oleafly wird von <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> und Mitwirkenden offen entwickelt. Fehlerberichte, Fixes, Vorlagen, Dokumentation und durchdachtes Produktfeedback sind willkommen.</p></td>
+  </tr>
+</table>
 
 1. Lies [CONTRIBUTING.md](../../CONTRIBUTING.md).
 2. Eröffne vor einer großen Änderung ein Issue; kleine, fokussierte Fixes
@@ -496,6 +524,25 @@ Produktfeedback sind willkommen.
 Bitte melde Sicherheitsprobleme vertraulich, wie in
 [SECURITY.md](../../SECURITY.md) beschrieben. Für die Teilnahme gilt der
 [Verhaltenskodex](../../CODE_OF_CONDUCT.md).
+
+## Community und Support
+
+- Stelle Fragen und teile Ideen in den [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions).
+- Melde Fehler und wünsche dir Funktionen in den [GitHub Issues](https://github.com/Oleafly/Oleafly/issues).
+- 🔔 Folge [@OleaflyHQ auf X](https://x.com/OleaflyHQ) für Produkt- und Release-Updates.
+
+⭐ Wenn Oleafly dir hilft, gib dem [Repository einen Stern](https://github.com/Oleafly/Oleafly).
+So finden mehr Forschende das Projekt, und du unterstützt die weitere Entwicklung.
+
+## Sterneverlauf
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="Verlauf der GitHub-Sterne" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## Danksagungen
 

--- a/docs/readme-translations/README.es.md
+++ b/docs/readme-translations/README.es.md
@@ -6,43 +6,30 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | **Español** | [Français](README.fr.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Português](README.pt.md) | [Русский](README.ru.md) | [中文](README.zh.md)
 
-**Escribe, compila y publica tu investigación con un espacio de trabajo con IA que te pertenece.**
+<h2>Un entorno de investigación completo, rediseñado para la era de la IA.</h2>
 
-Escribe en LaTeX, Typst o Markdown. Compila junto a tu código fuente. Conserva
-cada revisión en Git. Usa la IA en tus propios términos.
+Escribe, compila y corrige textos, busca bibliografía, gestiona citas, crea
+figuras, revisa archivos PDF y sigue cada cambio en Git. Usa una IA alojada,
+un endpoint propio, Ollama en local o ninguna IA. Oleafly guarda tus proyectos
+en carpetas normales de tu equipo.
 
-Oleafly es una aplicación de escritorio gratuita y 100 % de código abierto para
-macOS, Windows y Linux. Funciona primero en local, no requiere cuenta y guarda
-los archivos del proyecto en texto plano en tu equipo.
-
+[![Issues abiertos](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Descargar Oleafly](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[Leer la documentación de ingeniería](../README.md) ·
+[Leer la documentación del producto](https://oleafly.com/docs/overview/) ·
 [Compilar desde el código fuente](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="Oleafly con un editor de LaTeX y el PDF compilado abiertos lado a lado (tema claro)" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="Oleafly con un editor de LaTeX y el PDF compilado abiertos lado a lado (tema oscuro)" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="La biblioteca de Oleafly mostrando los proyectos como libros de colores con etiquetas de motor, tipo y última modificación (tema oscuro)" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="La biblioteca de Oleafly mostrando los proyectos como libros de colores con etiquetas de motor, tipo y última modificación (tema claro)" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="Oleafly editando el artículo de investigación de LLaMA en LaTeX, con el árbol de archivos, el esquema del documento y el PDF compilado abiertos a la vez" width="100%" />
 </div>
 
 <!--
@@ -50,14 +37,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly está listo para documentos del día a día, pero el proyecto todavía
-> avanza deprisa. La compatibilidad con paquetes avanzados y algunas
-> integraciones de plataforma aún se están consolidando. Las compilaciones para
-> macOS están firmadas y notarizadas; las de Windows todavía no. Descarga solo
-> desde la página oficial de versiones y revisa las notas de la versión
-> antes de instalar una compilación preliminar sin firmar.
 
 ## La investigación ya tiene suficientes piezas en movimiento
 
@@ -177,10 +156,6 @@ que ve el lector.
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="Una página compilada con gráficas, una superficie de error con mapa de color y una tabla de resultados junto al código LaTeX" width="88%" />
 </div>
 
 Aleja el zoom y tendrás el documento completo en pantalla de una vez, que suele
@@ -428,6 +403,28 @@ permanecen en tu máquina.
 Las claves de API se guardan en local. Los archivos de documento en texto
 plano siguen siendo utilizables aunque dejes de usar Oleafly.
 
+## Próximamente
+
+La hoja de ruta mantiene Oleafly abierto, local primero y útil durante todo el
+flujo de investigación.
+
+- **Localización de la aplicación.** Usa Oleafly en más idiomas y trabaja con
+  la interfaz que te resulte más natural.
+- **Habilidades y plugins para agentes.** Añade flujos de IA específicos y
+  reutilizables que repiten menos contexto y consumen menos tokens.
+- **Agentes de investigación autónomos.** Convierte una pregunta de
+  investigación y un conjunto de fuentes en un primer borrador estructurado.
+- **Colaboración en tiempo real y comentarios.** Trabaja en equipo con
+  colaboración ilimitada y autoalojada.
+- **Oleafly CLI.** Usa un paquete ligero e instalable para flujos de
+  investigación que no necesitan una interfaz gráfica.
+- **Mejor compatibilidad con Typst y Markdown.** Lleva más funciones de edición,
+  vista previa y publicación de Oleafly a ambos formatos.
+- **Más integraciones de investigación.** Conecta Mendeley y otros servicios de
+  referencias, bibliotecas e investigación.
+- **Sincronización autoalojada en la nube.** Sincroniza proyectos entre
+  dispositivos, con una mejor sincronización automática de GitHub cuando la quieras.
+
 ## Instalación
 
 Descarga la última versión desde
@@ -448,20 +445,50 @@ Para ejecutar desde el código fuente:
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 Consulta la [guía de desarrollo](../development.md) para conocer los
 requisitos, la configuración por plataforma y las compilaciones de producción.
 
-## Documentación
+Estos scripts descargan en `src-tauri/binaries` los ejecutables auxiliares del
+compilador, fijados mediante suma de comprobación, para tu plataforma actual.
+El argumento `all` está pensado para CI y los paquetes de lanzamiento, donde
+deben prepararse todas las plataformas compatibles.
 
-El repositorio mantiene las referencias públicas de ingeniería y de producto
-cerca del código. Las guías de tareas para el usuario final se mantienen aparte
-de este índice público.
+La inteligencia del editor mediante TexLab y Tinymist es opcional para una
+ejecución local. Descarga esos servidores de lenguaje con
+`pnpm language-servers:fetch`. Consulta la
+[cadena de herramientas de servidores de lenguaje](../language-server-toolchain.md)
+para conocer su integridad, licencias y política de distribución.
+
+### Línea de comandos
+
+`oleaflyc` administra proyectos de Oleafly sin abrir la aplicación de
+escritorio. Se compila desde el código fuente de este repositorio y todavía no
+se publica como paquete independiente.
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+Los comandos se ejecutan sobre el directorio actual. Usa `-C <path>` para
+señalar otro proyecto. Ejecuta `oleaflyc --help` para ver la lista completa.
+
+## Documentación para desarrolladores
+
+Las guías de usuario están en la
+[documentación del producto Oleafly](https://oleafly.com/docs/overview/). Las
+referencias siguientes son para colaboradores, integradores y responsables de versiones.
 
 | Referencia | Cubre |
 | --- | --- |
@@ -478,10 +505,12 @@ de este índice público.
 
 ## Cómo contribuir
 
-Oleafly se desarrolla en abierto por
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) y sus
-colaboradores. Los informes de errores, las correcciones, las plantillas, la
-documentación y los comentarios cuidadosos sobre el producto son bienvenidos.
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="El Club Oleafly: una comunidad de investigación abierta que celebra borradores, revisiones, pruebas y publicaciones aceptadas" width="100%" /></td>
+    <td width="62%" valign="top"><h3>Quienes investigan merecen herramientas que puedan inspeccionar, ampliar y en las que puedan confiar.</h3><p>Oleafly se desarrolla en abierto gracias a <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> y sus colaboradores. Los informes de errores, las correcciones, las plantillas, la documentación y los comentarios cuidadosos sobre el producto son bienvenidos.</p></td>
+  </tr>
+</table>
 
 1. Lee [CONTRIBUTING.md](../../CONTRIBUTING.md).
 2. Abre un issue antes de un cambio grande; las correcciones pequeñas y
@@ -497,6 +526,25 @@ documentación y los comentarios cuidadosos sobre el producto son bienvenidos.
 Informa de los problemas de seguridad en privado tal como se describe en
 [SECURITY.md](../../SECURITY.md). La participación se rige por el
 [Código de conducta](../../CODE_OF_CONDUCT.md).
+
+## Comunidad y soporte
+
+- Haz preguntas y comparte ideas en [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions).
+- Informa de errores y solicita funciones en [GitHub Issues](https://github.com/Oleafly/Oleafly/issues).
+- 🔔 Sigue a [@OleaflyHQ en X](https://x.com/OleaflyHQ) para conocer las novedades del producto y de las versiones.
+
+⭐ Si Oleafly te ayuda, considera [dar una estrella al repositorio](https://github.com/Oleafly/Oleafly).
+Ese pequeño gesto ayuda a que más investigadores encuentren el proyecto y apoya su desarrollo.
+
+## Historial de estrellas
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="Gráfico del historial de estrellas" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## Créditos
 

--- a/docs/readme-translations/README.fr.md
+++ b/docs/readme-translations/README.fr.md
@@ -6,43 +6,31 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | [Español](README.es.md) | **Français** | [日本語](README.ja.md) | [한국어](README.ko.md) | [Português](README.pt.md) | [Русский](README.ru.md) | [中文](README.zh.md)
 
-**Rédigez, compilez et publiez vos travaux de recherche dans un espace de travail IA qui vous appartient.**
+<h2>Un environnement de recherche complet, repensé pour l'ère de l'IA.</h2>
 
-Écrivez en LaTeX, Typst ou Markdown. Compilez à côté de votre source. Conservez
-chaque révision dans Git. Utilisez l'IA à vos conditions.
+Rédigez, compilez et relisez vos textes, recherchez des publications, gérez
+vos références, créez des figures, examinez vos PDF et suivez chaque
+modification dans Git. Utilisez une IA hébergée, un point de terminaison
+personnalisé, Ollama en local ou aucune IA. Oleafly conserve vos projets dans
+des dossiers ordinaires sur votre ordinateur.
 
-Oleafly est une application de bureau gratuite et 100 % open source pour macOS,
-Windows et Linux. Elle privilégie le local, fonctionne sans compte et conserve
-vos projets sous forme de fichiers ordinaires sur votre ordinateur.
-
+[![Issues ouvertes](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Télécharger Oleafly](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[Lire la documentation technique](../README.md) ·
+[Lire la documentation du produit](https://oleafly.com/docs/overview/) ·
 [Compiler depuis les sources](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="Oleafly avec un éditeur LaTeX et le PDF compilé ouverts côte à côte (thème clair)" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="Oleafly avec un éditeur LaTeX et le PDF compilé ouverts côte à côte (thème sombre)" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="La bibliothèque Oleafly présentant les projets sous forme de livres colorés avec le moteur, le type et la date de dernière modification (thème sombre)" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="La bibliothèque Oleafly présentant les projets sous forme de livres colorés avec le moteur, le type et la date de dernière modification (thème clair)" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="Oleafly modifiant l'article de recherche LLaMA en LaTeX, avec l'arborescence des sources, le plan du document et le PDF compilé ouverts ensemble" width="100%" />
 </div>
 
 <!--
@@ -50,15 +38,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly est prêt pour vos documents du quotidien, mais le projet évolue
-> encore rapidement. La compatibilité avec les packages avancés et quelques
-> intégrations spécifiques aux plateformes sont encore en cours de
-> consolidation. Les builds macOS sont signés et notarisés ; les builds Windows
-> ne sont pas encore signés. Téléchargez uniquement depuis la page officielle
-> des versions et consultez les notes de version avant d'installer une version
-> préliminaire non signée.
 
 ## La recherche a déjà bien assez de pièces mobiles
 
@@ -179,10 +158,6 @@ que voit le lecteur.
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="Une page compilée montrant des graphiques, une surface d'erreur en couleurs et un tableau de résultats à côté de la source LaTeX" width="88%" />
 </div>
 
 Dézoomez et le document entier tient à l'écran d'un seul coup, ce qui est
@@ -434,6 +409,28 @@ projet restent sur votre machine.
 Les clés API sont stockées localement. Vos fichiers de document ordinaires
 restent utilisables même si vous cessez d'utiliser Oleafly.
 
+## Bientôt disponible
+
+La feuille de route maintient Oleafly ouvert, local-first et utile tout au long
+du travail de recherche.
+
+- **Localisation de l'application.** Utilisez Oleafly dans davantage de langues
+  et travaillez dans l'interface qui vous semble la plus naturelle.
+- **Compétences et plugins pour agents.** Ajoutez des flux d'IA ciblés et
+  réutilisables qui renvoient moins de contexte et utilisent moins de tokens.
+- **Agents de recherche autonomes.** Transformez une question de recherche et
+  un ensemble de sources en un premier brouillon structuré.
+- **Collaboration en temps réel et commentaires.** Travaillez en équipe avec
+  une collaboration illimitée et auto-hébergée.
+- **Oleafly CLI.** Utilisez un paquet en ligne de commande léger et installable
+  pour les flux de recherche qui n'ont pas besoin d'interface graphique.
+- **Meilleure prise en charge de Typst et Markdown.** Retrouvez davantage de
+  fonctions d'édition, d'aperçu et de publication dans les deux formats.
+- **Plus d'intégrations de recherche.** Connectez Mendeley et d'autres services
+  de références, de bibliothèque et de recherche.
+- **Synchronisation cloud auto-hébergée.** Synchronisez les projets entre vos
+  appareils et profitez d'une meilleure synchronisation GitHub automatique.
+
 ## Installation
 
 Téléchargez la dernière version depuis
@@ -454,20 +451,50 @@ Pour lancer depuis les sources :
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 Consultez le [guide de développement](../development.md) pour les
 prérequis, la configuration par plateforme et les builds de production.
 
-## Documentation
+Ces scripts téléchargent dans `src-tauri/binaries` les exécutables auxiliaires
+du compilateur, verrouillés par somme de contrôle, pour votre plateforme. Le
+paramètre `all` sert à la CI et aux paquets de publication, qui doivent préparer
+toutes les plateformes prises en charge.
 
-Le dépôt garde les références publiques d'ingénierie et de produit au plus près
-du code. Les guides destinés aux utilisateurs finaux sont maintenus séparément
-de cet index public.
+L'intelligence de l'éditeur fournie par TexLab et Tinymist reste facultative en
+développement local. Téléchargez ces serveurs de langage avec
+`pnpm language-servers:fetch`. Consultez la
+[chaîne d'outils des serveurs de langage](../language-server-toolchain.md) pour
+les règles d'intégrité, de licence et de distribution.
+
+### Ligne de commande
+
+`oleaflyc` gère les projets Oleafly sans lancer l'application de bureau. Il est
+compilé depuis les sources de ce dépôt et n'est pas encore publié sous forme de
+paquet autonome.
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+Les commandes utilisent le répertoire courant. Passez `-C <path>` pour choisir
+un autre projet. Exécutez `oleaflyc --help` pour obtenir la liste complète.
+
+## Documentation pour les développeurs
+
+Les guides utilisateur se trouvent dans la
+[documentation produit d'Oleafly](https://oleafly.com/docs/overview/). Les
+références ci-dessous s'adressent aux contributeurs, intégrateurs et responsables des versions.
 
 | Référence | Contenu |
 | --- | --- |
@@ -484,10 +511,12 @@ de cet index public.
 
 ## Contribuer
 
-Oleafly est développé au grand jour par
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) et les
-contributeurs. Rapports de bugs, correctifs, modèles, documentation et retours
-produit réfléchis sont les bienvenus.
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="Le Club Oleafly : une communauté de recherche ouverte qui célèbre les brouillons, les révisions, les tests et les soumissions réussies" width="100%" /></td>
+    <td width="62%" valign="top"><h3>Les chercheurs méritent des outils qu'ils peuvent examiner, étendre et utiliser en toute confiance.</h3><p>Oleafly est développé au grand jour par <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> et ses contributeurs. Rapports de bugs, correctifs, modèles, documentation et retours produit réfléchis sont les bienvenus.</p></td>
+  </tr>
+</table>
 
 1. Lisez [CONTRIBUTING.md](../../CONTRIBUTING.md).
 2. Ouvrez une issue avant tout changement d'ampleur ; les correctifs petits et
@@ -503,6 +532,25 @@ produit réfléchis sont les bienvenus.
 Merci de signaler les problèmes de sécurité en privé, comme décrit dans
 [SECURITY.md](../../SECURITY.md). La participation est régie par le
 [code de conduite](../../CODE_OF_CONDUCT.md).
+
+## Communauté et assistance
+
+- Posez vos questions et partagez vos idées dans [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions).
+- Signalez les bugs et proposez des fonctionnalités dans [GitHub Issues](https://github.com/Oleafly/Oleafly/issues).
+- 🔔 Suivez [@OleaflyHQ sur X](https://x.com/OleaflyHQ) pour les actualités du produit et des versions.
+
+⭐ Si Oleafly vous aide, pensez à [ajouter une étoile au dépôt](https://github.com/Oleafly/Oleafly).
+Ce petit geste aide d'autres chercheurs à découvrir le projet et soutient son développement.
+
+## Historique des étoiles
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="Graphique de l'historique des étoiles" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## Crédits
 

--- a/docs/readme-translations/README.ja.md
+++ b/docs/readme-translations/README.ja.md
@@ -6,43 +6,30 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | [Español](README.es.md) | [Français](README.fr.md) | **日本語** | [한국어](README.ko.md) | [Português](README.pt.md) | [Русский](README.ru.md) | [中文](README.zh.md)
 
-**自分の手元にある AI ワークスペースで、研究を執筆・コンパイル・公開する。**
+<h2>AI 時代のために再設計された、研究のための統合環境。</h2>
 
-LaTeX、Typst、Markdown で執筆できます。ソースのすぐ隣でコンパイルできます。
-すべての変更履歴を Git に残せます。AI は自分の条件で使えます。
+執筆、コンパイル、校正、文献検索、引用管理、図の作成、PDF の確認、Git
+による全変更の追跡を一つの場所で行えます。ホスト型 AI、独自エンドポイント、
+ローカルの Ollama、または AI なしを選べます。Oleafly はプロジェクトを
+コンピュータ上の通常のフォルダに保存します。
 
-Oleafly は macOS、Windows、Linux 向けの無料かつ 100% オープンソースの
-デスクトップアプリです。ローカルファーストで、アカウント不要で動作し、
-プレーンなプロジェクトファイルをあなたのコンピュータ上に保持します。
-
+[![未解決の Issue](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Oleafly をダウンロード](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[エンジニアリングドキュメントを読む](../README.md) ·
+[製品ドキュメントを読む](https://oleafly.com/docs/overview/) ·
 [ソースからビルドする](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="LaTeX エディタとコンパイル済み PDF を並べて開いた Oleafly（ライトテーマ）" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="LaTeX エディタとコンパイル済み PDF を並べて開いた Oleafly（ダークテーマ）" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="プロジェクトを色分けされた本として表示し、エンジン・種類・最終更新のラベルを付けた Oleafly のライブラリ（ダークテーマ）" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="プロジェクトを色分けされた本として表示し、エンジン・種類・最終更新のラベルを付けた Oleafly のライブラリ（ライトテーマ）" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="LLaMA 研究論文を LaTeX で編集し、ソースツリー、文書アウトライン、コンパイル済み PDF を同時に表示する Oleafly" width="100%" />
 </div>
 
 <!--
@@ -50,14 +37,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly は日常的なドキュメント作成にすぐ使える状態ですが、プロジェクトは
-> まだ急速に発展しています。高度なパッケージ互換性や一部のプラットフォーム
-> 連携は現在も強化中です。macOS ビルドは署名・公証済みですが、Windows
-> ビルドはまだ署名されていません。ダウンロードは必ず公式リリースページ
-> からのみ行い、未署名のプレビュービルドをインストールする前には
-> リリースノートをご確認ください。
 
 ## 研究には、ただでさえ考えることが多すぎる
 
@@ -172,10 +151,6 @@ LaTeX を理解する単語カウントは、マークアップを無視して�
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="プロット、カラーマップされた誤差曲面、結果の表を LaTeX ソースの隣に表示したコンパイル済みページ" width="88%" />
 </div>
 
 ズームアウトすれば文書全体が一画面に収まります。フロート、図、表が
@@ -414,6 +389,28 @@ Oleafly はプロジェクトツールを Claude Desktop、Claude Code、Cursor�
 API キーはローカルに保存されます。プレーンなドキュメントファイルは、
 Oleafly の利用をやめても引き続き使えます。
 
+## 近日公開
+
+これからも Oleafly はオープンかつローカルファーストで、研究の全工程に
+役立つワークスペースを目指します。
+
+- **アプリの多言語化。** Oleafly をより多くの言語で使えるようにし、研究者が
+  使いやすい表示言語を選べるようにします。
+- **エージェントスキルとプラグイン。** 再利用できる AI ワークフローを追加し、
+  同じコンテキストの再送とトークン使用量を減らします。
+- **自律型リサーチエージェント。** 研究課題と参考文献から、構造化された初稿を
+  作成します。
+- **リアルタイム共同編集とコメント。** セルフホスト環境で、研究チームが
+  人数制限なく共同作業できるようにします。
+- **Oleafly CLI。** GUI が必要ない研究ワークフロー向けに、軽量でインストール
+  可能なコマンドラインパッケージを提供します。
+- **Typst と Markdown の対応強化。** 編集、プレビュー、公開の機能を両方の
+  形式でさらに利用できるようにします。
+- **研究サービス連携の拡充。** Mendeley と、その他の文献管理、ライブラリ、
+  研究サービスを接続します。
+- **セルフホスト式クラウド同期。** デバイス間でプロジェクトを同期し、GitHub の
+  自動同期も改善します。
+
 ## インストール
 
 最新ビルドは
@@ -435,20 +432,48 @@ Oleafly の利用をやめても引き続き使えます。
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 前提条件、プラットフォームごとのセットアップ、プロダクションビルドに
 ついては[開発ガイド](../development.md)をご覧ください。
 
-## ドキュメント
+これらのスクリプトは、現在のプラットフォーム用にチェックサムで固定された
+コンパイラのサイドカーを `src-tauri/binaries` にダウンロードします。`all`
+引数は、すべての対応プラットフォームを準備する CI とリリース用です。
 
-このリポジトリでは、公開のエンジニアリング・プロダクトリファレンスを
-コードのすぐそばに置いています。エンドユーザー向けのタスクガイドは、
-この公開インデックスとは別に管理されています。
+TexLab と Tinymist によるエディタ支援は、ローカル実行では任意です。これらの
+Language Server は `pnpm language-servers:fetch` で取得できます。完全性、
+ライセンス、配布方針については
+[Language Server ツールチェーン](../language-server-toolchain.md)をご覧ください。
+
+### コマンドライン
+
+`oleaflyc` を使うと、デスクトップアプリを起動せずに Oleafly プロジェクトを
+管理できます。現在はこのリポジトリのソースからビルドする形式で、独立した
+パッケージとしてはまだ公開していません。
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+各コマンドは現在のディレクトリを対象にします。別のプロジェクトを指定する
+には `-C <path>` を使います。全コマンドは `oleaflyc --help` で確認できます。
+
+## 開発者向けドキュメント
+
+ユーザーガイドは [Oleafly 製品ドキュメント](https://oleafly.com/docs/overview/)
+にあります。以下はコントリビューター、インテグレーター、リリース担当者向けの
+リファレンスです。
 
 | リファレンス | 内容 |
 | --- | --- |
@@ -465,10 +490,12 @@ pnpm tauri dev
 
 ## コントリビューション
 
-Oleafly は
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) と
-コントリビューターによってオープンに開発されています。バグ報告、修正、
-テンプレート、ドキュメント、丁寧なプロダクトフィードバックを歓迎します。
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="Oleafly Club：下書き、改稿、テスト、投稿の成功を祝うオープンな研究コミュニティ" width="100%" /></td>
+    <td width="62%" valign="top"><h3>研究者には、自分で検証し、拡張し、信頼できる道具が必要です。</h3><p>Oleafly は <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> とコントリビューターによってオープンに開発されています。バグ報告、修正、テンプレート、ドキュメント、丁寧なプロダクトフィードバックを歓迎します。</p></td>
+  </tr>
+</table>
 
 1. [CONTRIBUTING.md](../../CONTRIBUTING.md) をお読みください。
 2. 大きな変更の前には Issue を立ててください。小さく焦点の絞られた修正は
@@ -484,6 +511,25 @@ Oleafly は
 セキュリティ上の問題は
 [SECURITY.md](../../SECURITY.md) の記載に従って非公開でご報告ください。
 参加にあたっては[行動規範](../../CODE_OF_CONDUCT.md)が適用されます。
+
+## コミュニティとサポート
+
+- 質問やアイデアは [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions) へ投稿してください。
+- バグ報告や機能要望は [GitHub Issues](https://github.com/Oleafly/Oleafly/issues) へ投稿してください。
+- 🔔 製品とリリースの最新情報は [X の @OleaflyHQ](https://x.com/OleaflyHQ) をフォローしてください。
+
+⭐ Oleafly が役に立ったら、[リポジトリにスター](https://github.com/Oleafly/Oleafly)をお願いします。
+その小さなクリックが、より多くの研究者にプロジェクトを届け、開発の継続を支えます。
+
+## スター数の推移
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="GitHub スター数の推移" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## クレジット
 

--- a/docs/readme-translations/README.ko.md
+++ b/docs/readme-translations/README.ko.md
@@ -6,43 +6,30 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | [Español](README.es.md) | [Français](README.fr.md) | [日本語](README.ja.md) | **한국어** | [Português](README.pt.md) | [Русский](README.ru.md) | [中文](README.zh.md)
 
-**직접 소유하는 AI 워크스페이스에서 연구를 작성하고, 컴파일하고, 출판하세요.**
+<h2>AI 시대에 맞춰 다시 설계한 완전한 연구 환경.</h2>
 
-LaTeX, Typst, Markdown으로 글을 쓰고, 소스 옆에서 바로 컴파일하고, 모든
-수정 이력을 Git에 남기세요. AI는 원하는 방식으로만 사용합니다.
+작성, 컴파일, 교정, 문헌 검색, 인용 관리, 그림 제작, PDF 검토, Git 변경
+추적을 한곳에서 처리하세요. 호스팅 AI, 사용자 지정 엔드포인트, 로컬 Ollama,
+또는 AI 없이 작업할 수 있습니다. Oleafly는 프로젝트를 컴퓨터의 일반 폴더에
+보관합니다.
 
-Oleafly는 macOS, Windows, Linux용 무료 100% 오픈소스 데스크톱 앱입니다.
-로컬 우선(local-first)으로 동작하고, 계정 없이 사용할 수 있으며, 프로젝트
-파일을 평범한 형식 그대로 내 컴퓨터에 보관합니다.
-
+[![열린 이슈](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Oleafly 다운로드](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[엔지니어링 문서 보기](../README.md) ·
+[제품 문서 보기](https://oleafly.com/docs/overview/) ·
 [소스에서 빌드하기](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="LaTeX 편집기와 컴파일된 PDF가 나란히 열려 있는 Oleafly (라이트 테마)" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="LaTeX 편집기와 컴파일된 PDF가 나란히 열려 있는 Oleafly (다크 테마)" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="프로젝트를 엔진, 종류, 최근 수정 라벨이 붙은 색색의 책으로 보여주는 Oleafly 라이브러리 (다크 테마)" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="프로젝트를 엔진, 종류, 최근 수정 라벨이 붙은 색색의 책으로 보여주는 Oleafly 라이브러리 (라이트 테마)" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="LLaMA 연구 논문을 LaTeX로 편집하면서 소스 트리, 문서 개요, 컴파일된 PDF를 함께 보여 주는 Oleafly" width="100%" />
 </div>
 
 <!--
@@ -50,14 +37,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly는 일상적인 문서 작업에 바로 쓸 수 있는 상태이지만, 프로젝트는
-> 아직 빠르게 변화하고 있습니다. 고급 패키지 호환성과 일부 플랫폼 연동은
-> 계속 안정화 중입니다. macOS 빌드는 서명 및 공증이 완료되어 있지만,
-> Windows 빌드는 아직 서명되지 않았습니다. 반드시 공식 릴리스 페이지에서만
-> 다운로드하고, 서명되지 않은 프리뷰 빌드를 설치하기 전에는 릴리스 노트를
-> 먼저 확인하시기 바랍니다.
 
 ## 연구에는 이미 신경 쓸 것이 충분히 많습니다
 
@@ -169,10 +148,6 @@ LaTeX를 이해하는 단어 수 세기는 마크업을 무시하고 독자가 �
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="LaTeX 소스 옆에 플롯, 컬러맵 오차 곡면, 결과 표가 담긴 컴파일된 페이지" width="88%" />
 </div>
 
 축소하면 문서 전체가 한 화면에 들어오므로, 플로트, 그림, 표가 의도한
@@ -406,6 +381,27 @@ Oleafly는 프로젝트 도구를 Claude Desktop, Claude Code, Cursor를 비롯�
 API 키는 로컬에 저장됩니다. 문서 파일은 평범한 형식이므로 Oleafly 사용을
 그만두더라도 계속 쓸 수 있습니다.
 
+## 공개 예정
+
+앞으로도 Oleafly는 개방되고 로컬 우선이며, 전체 연구 워크플로에
+유용한 작업 공간을 목표로 합니다.
+
+- **앱 현지화.** 더 많은 언어로 Oleafly를 사용하고, 연구자에게 가장 편안한
+  인터페이스 언어를 선택할 수 있게 합니다.
+- **에이전트 스킬과 플러그인.** 반복 가능한 AI 워크플로를 추가해 같은 맥락을
+  반복 전송하는 일과 토큰 사용량을 줄입니다.
+- **자율 연구 에이전트.** 연구 질문과 출처 목록을 구조화된 첫 초안으로
+  바꿔 연구의 출발점을 만듭니다.
+- **실시간 협업과 댓글.** 연구팀을 위한 무제한 자체 호스팅 협업을 제공합니다.
+- **Oleafly CLI.** GUI가 필요 없는 연구 워크플로에 가벼운 설치형 명령줄 패키지를
+  제공합니다.
+- **Typst와 Markdown 지원 강화.** 두 형식 모두에 더 많은 편집, 미리 보기,
+  게시 기능을 제공합니다.
+- **연구 연동 확대.** Mendeley와 추가 참고문헌, 라이브러리, 연구 서비스를
+  연결합니다.
+- **자체 호스팅 클라우드 동기화.** 여러 기기에서 프로젝트를 동기화하고,
+  원할 때 GitHub 자동 동기화를 더 나은 방식으로 사용합니다.
+
 ## 설치
 
 최신 빌드는
@@ -427,19 +423,47 @@ Tectonic이 이후 빌드를 위해 패키지를 캐시하며, 오프라인 모�
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 사전 요구 사항, 플랫폼별 설정, 프로덕션 빌드는
 [개발 가이드](../development.md)를 참고하시기 바랍니다.
 
-## 문서
+이 스크립트는 현재 플랫폼용으로 체크섬이 고정된 컴파일러 사이드카를
+`src-tauri/binaries`에 내려받습니다. `all` 인수는 지원하는 모든 플랫폼을
+준비해야 하는 CI와 릴리스 패키징에 사용합니다.
 
-이 저장소는 공개 엔지니어링·제품 레퍼런스를 코드와 가까운 곳에 둡니다.
-최종 사용자용 작업 가이드는 이 공개 인덱스와 별도로 관리됩니다.
+TexLab과 Tinymist가 제공하는 편집기 지능 기능은 로컬 실행에서 선택 사항입니다.
+`pnpm language-servers:fetch`로 이 언어 서버를 받을 수 있습니다. 무결성,
+라이선스, 배포 정책은
+[언어 서버 도구 체인](../language-server-toolchain.md)을 참고하세요.
+
+### 명령줄
+
+`oleaflyc`는 데스크톱 앱을 실행하지 않고 Oleafly 프로젝트를 관리합니다.
+현재는 이 저장소의 소스에서 빌드하며 독립 패키지로는 아직 배포하지 않습니다.
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+명령은 현재 디렉터리를 대상으로 실행됩니다. 다른 프로젝트를 지정하려면
+`-C <path>`를 사용하세요. 전체 명령 목록은 `oleaflyc --help`에서 확인할 수
+있습니다.
+
+## 개발자 문서
+
+사용자 가이드는 [Oleafly 제품 문서](https://oleafly.com/docs/overview/)에서
+확인할 수 있습니다. 아래 자료는 기여자, 통합 개발자, 릴리스 관리자를 위한 것입니다.
 
 | 레퍼런스 | 다루는 내용 |
 | --- | --- |
@@ -456,10 +480,12 @@ pnpm tauri dev
 
 ## 기여하기
 
-Oleafly는
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm)와
-기여자들이 공개적으로 개발하고 있습니다. 버그 리포트, 수정, 템플릿, 문서,
-그리고 신중한 제품 피드백을 환영합니다.
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="Oleafly Club: 초안, 수정, 테스트, 성공적인 투고를 함께 기념하는 공개 연구 커뮤니티" width="100%" /></td>
+    <td width="62%" valign="top"><h3>연구자는 직접 살펴보고, 확장하고, 신뢰할 수 있는 도구를 누릴 자격이 있습니다.</h3><p>Oleafly는 <a href="https://github.com/prajwal-svm">Prajwal Murthy</a>와 기여자들이 공개적으로 개발하고 있습니다. 버그 리포트, 수정, 템플릿, 문서, 그리고 신중한 제품 피드백을 환영합니다.</p></td>
+  </tr>
+</table>
 
 1. [CONTRIBUTING.md](../../CONTRIBUTING.md)를 읽어 주세요.
 2. 큰 변경은 먼저 이슈를 열어 주세요. 작고 집중된 수정은 바로 풀
@@ -475,6 +501,25 @@ Oleafly는
 보안 문제는 [SECURITY.md](../../SECURITY.md)에 안내된 대로 비공개로 제보해
 주시기 바랍니다. 참여에는
 [행동 강령](../../CODE_OF_CONDUCT.md)이 적용됩니다.
+
+## 커뮤니티 및 지원
+
+- 질문과 아이디어는 [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions)에 공유해 주세요.
+- 버그와 기능 요청은 [GitHub Issues](https://github.com/Oleafly/Oleafly/issues)에 등록해 주세요.
+- 🔔 제품 및 릴리스 소식은 [X의 @OleaflyHQ](https://x.com/OleaflyHQ)를 팔로우해 주세요.
+
+⭐ Oleafly가 도움이 된다면 [저장소에 별을 눌러 주세요](https://github.com/Oleafly/Oleafly).
+작은 클릭 하나가 더 많은 연구자에게 프로젝트를 알리고 지속적인 개발을 돕습니다.
+
+## 스타 기록
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="GitHub 스타 기록 차트" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## 크레딧
 

--- a/docs/readme-translations/README.pt.md
+++ b/docs/readme-translations/README.pt.md
@@ -6,43 +6,30 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | [Español](README.es.md) | [Français](README.fr.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | **Português** | [Русский](README.ru.md) | [中文](README.zh.md)
 
-**Escreva, compile e publique pesquisas com um espaço de trabalho de IA que é seu.**
+<h2>Um ambiente de pesquisa completo, reprojetado para a era da IA.</h2>
 
-Escreva em LaTeX, Typst ou Markdown. Compile ao lado do código-fonte. Mantenha
-cada revisão no Git. Use IA nos seus próprios termos.
+Escreva, compile e revise textos, pesquise a literatura, gerencie citações,
+crie figuras, confira PDFs e acompanhe cada alteração no Git. Use IA hospedada,
+um endpoint próprio, Ollama local ou nenhuma IA. O Oleafly mantém seus projetos
+em pastas comuns no seu computador.
 
-O Oleafly é um aplicativo de desktop gratuito e 100% open source para macOS,
-Windows e Linux. É local-first, funciona sem conta e mantém arquivos de projeto
-em texto simples no seu computador.
-
+[![Issues abertas](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Baixar o Oleafly](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[Ler a documentação de engenharia](../README.md) ·
+[Ler a documentação do produto](https://oleafly.com/docs/overview/) ·
 [Compilar a partir do código-fonte](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="Oleafly com um editor LaTeX e o PDF compilado abertos lado a lado (tema claro)" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="Oleafly com um editor LaTeX e o PDF compilado abertos lado a lado (tema escuro)" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="A biblioteca do Oleafly exibindo projetos como livros coloridos, com rótulos de motor, tipo e última modificação (tema escuro)" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="A biblioteca do Oleafly exibindo projetos como livros coloridos, com rótulos de motor, tipo e última modificação (tema claro)" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="Oleafly editando o artigo de pesquisa LLaMA em LaTeX, com a árvore de arquivos, o sumário do documento e o PDF compilado abertos ao mesmo tempo" width="100%" />
 </div>
 
 <!--
@@ -50,14 +37,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> O Oleafly já está pronto para documentos do dia a dia, mas o projeto ainda
-> evolui rapidamente. A compatibilidade com pacotes avançados e algumas
-> integrações de plataforma ainda estão sendo consolidadas. As builds para
-> macOS são assinadas e notarizadas; as builds para Windows ainda não são
-> assinadas. Baixe apenas da página oficial de releases e leia as notas de
-> lançamento antes de instalar uma versão de pré-visualização não assinada.
 
 ## A pesquisa já tem partes móveis demais
 
@@ -175,10 +154,6 @@ que o leitor vê.
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="Uma página compilada mostrando gráficos, uma superfície de erro com mapa de cores e uma tabela de resultados ao lado do código LaTeX" width="88%" />
 </div>
 
 Diminua o zoom e o documento inteiro cabe na tela de uma vez, o que costuma
@@ -424,6 +399,28 @@ permanecem na sua máquina.
 As chaves de API são armazenadas localmente. Os arquivos de documento em texto
 simples continuam utilizáveis mesmo se você parar de usar o Oleafly.
 
+## Em breve
+
+O roteiro mantém o Oleafly aberto, local-first e útil em todo o fluxo de
+pesquisa.
+
+- **Localização do aplicativo.** Use o Oleafly em mais idiomas e trabalhe com
+  a interface que parecer mais natural para você.
+- **Habilidades e plugins para agentes.** Adicione fluxos de IA focados e
+  reutilizáveis que reenviam menos contexto e usam menos tokens.
+- **Agentes autônomos de pesquisa.** Transforme uma pergunta de pesquisa e um
+  conjunto de fontes em um primeiro rascunho estruturado.
+- **Colaboração em tempo real e comentários.** Trabalhe em equipe com
+  colaboração ilimitada e auto-hospedada.
+- **Oleafly CLI.** Use um pacote leve e instalável de linha de comando para
+  fluxos de pesquisa que não precisam de interface gráfica.
+- **Melhor suporte a Typst e Markdown.** Leve mais recursos de edição,
+  visualização e publicação do Oleafly aos dois formatos.
+- **Mais integrações de pesquisa.** Conecte o Mendeley e outros serviços de
+  referências, bibliotecas e pesquisa.
+- **Sincronização em nuvem auto-hospedada.** Mantenha projetos sincronizados
+  entre dispositivos e melhore a sincronização automática com o GitHub.
+
 ## Instalação
 
 Baixe a versão mais recente em
@@ -444,20 +441,50 @@ Para rodar a partir do código-fonte:
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 Consulte o [guia de desenvolvimento](../development.md) para pré-requisitos,
 configuração por plataforma e builds de produção.
 
-## Documentação
+Esses scripts baixam para `src-tauri/binaries` os executáveis auxiliares do
+compilador, fixados por checksum, para a plataforma atual. O argumento `all`
+serve para CI e pacotes de lançamento, quando todas as plataformas compatíveis
+precisam ser preparadas.
 
-O repositório mantém as referências públicas de engenharia e de produto perto
-do código. Os guias de tarefas para o usuário final são mantidos separadamente
-deste índice público.
+A inteligência do editor por TexLab e Tinymist é opcional em uma execução
+local. Baixe esses servidores de linguagem com
+`pnpm language-servers:fetch`. Consulte a
+[cadeia de ferramentas dos servidores de linguagem](../language-server-toolchain.md)
+para conhecer as políticas de integridade, licença e distribuição.
+
+### Linha de comando
+
+`oleaflyc` gerencia projetos do Oleafly sem abrir o aplicativo de desktop. Ele
+é compilado a partir do código deste repositório e ainda não é publicado como
+um pacote independente.
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+Os comandos usam o diretório atual. Passe `-C <path>` para indicar outro
+projeto. Execute `oleaflyc --help` para ver a lista completa de comandos.
+
+## Documentação para desenvolvedores
+
+Os guias do usuário estão na
+[documentação do produto Oleafly](https://oleafly.com/docs/overview/). As
+referências abaixo são para colaboradores, integradores e responsáveis por lançamentos.
 
 | Referência | Cobre |
 | --- | --- |
@@ -474,10 +501,12 @@ deste índice público.
 
 ## Contribuindo
 
-O Oleafly é construído abertamente por
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) e
-colaboradores. Relatos de bugs, correções, modelos, documentação e feedback de
-produto criterioso são bem-vindos.
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="O Clube Oleafly: uma comunidade aberta de pesquisa que celebra rascunhos, revisões, testes e submissões bem-sucedidas" width="100%" /></td>
+    <td width="62%" valign="top"><h3>Pesquisadores merecem ferramentas que possam inspecionar, ampliar e usar com confiança.</h3><p>O Oleafly é construído abertamente por <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> e colaboradores. Relatos de bugs, correções, modelos, documentação e feedback criterioso sobre o produto são bem-vindos.</p></td>
+  </tr>
+</table>
 
 1. Leia o [CONTRIBUTING.md](../../CONTRIBUTING.md).
 2. Abra uma issue antes de uma mudança grande; correções pequenas e focadas
@@ -493,6 +522,25 @@ produto criterioso são bem-vindos.
 Por favor, relate problemas de segurança de forma privada, conforme descrito em
 [SECURITY.md](../../SECURITY.md). A participação é regida pelo
 [Código de Conduta](../../CODE_OF_CONDUCT.md).
+
+## Comunidade e suporte
+
+- Faça perguntas e compartilhe ideias nas [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions).
+- Relate bugs e solicite recursos nas [GitHub Issues](https://github.com/Oleafly/Oleafly/issues).
+- 🔔 Siga [@OleaflyHQ no X](https://x.com/OleaflyHQ) para novidades do produto e das versões.
+
+⭐ Se o Oleafly ajuda no seu trabalho, considere [dar uma estrela ao repositório](https://github.com/Oleafly/Oleafly).
+Esse pequeno gesto ajuda mais pesquisadores a encontrar o projeto e apoia o desenvolvimento contínuo.
+
+## Histórico de estrelas
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="Gráfico do histórico de estrelas" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## Créditos
 

--- a/docs/readme-translations/README.ru.md
+++ b/docs/readme-translations/README.ru.md
@@ -6,43 +6,30 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | [Español](README.es.md) | [Français](README.fr.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Português](README.pt.md) | **Русский** | [中文](README.zh.md)
 
-**Пишите, компилируйте и публикуйте научные работы в ИИ-пространстве, которое принадлежит вам.**
+<h2>Полная исследовательская среда, заново спроектированная для эпохи ИИ.</h2>
 
-Пишите на LaTeX, Typst или Markdown. Компилируйте рядом с исходником. Храните
-каждую версию в Git. Используйте ИИ на своих условиях.
+Пишите, компилируйте и вычитывайте тексты, ищите научную литературу, управляйте
+ссылками, создавайте иллюстрации, проверяйте PDF и отслеживайте каждое изменение
+в Git. Используйте размещённый ИИ, собственную конечную точку, локальный Ollama
+или работайте без ИИ. Oleafly хранит проекты в обычных папках на вашем компьютере.
 
-Oleafly — бесплатное, на 100 % открытое настольное приложение для macOS,
-Windows и Linux. Оно работает по принципу local-first, не требует учётной
-записи и хранит обычные файлы проектов на вашем компьютере.
-
+[![Открытые задачи](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[Скачать Oleafly](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[Инженерная документация](../README.md) ·
+[Документация продукта](https://oleafly.com/docs/overview/) ·
 [Сборка из исходников](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="Oleafly с редактором LaTeX и скомпилированным PDF, открытыми бок о бок (светлая тема)" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="Oleafly с редактором LaTeX и скомпилированным PDF, открытыми бок о бок (тёмная тема)" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="Библиотека Oleafly, где проекты показаны как цветные книги с метками движка, типа и даты последнего изменения (тёмная тема)" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="Библиотека Oleafly, где проекты показаны как цветные книги с метками движка, типа и даты последнего изменения (светлая тема)" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="Oleafly редактирует исследовательскую статью LLaMA в LaTeX, одновременно показывая дерево файлов, структуру документа и скомпилированный PDF" width="100%" />
 </div>
 
 <!--
@@ -50,14 +37,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly готов к повседневной работе с документами, но проект всё ещё быстро
-> развивается. Совместимость с продвинутыми пакетами и некоторые платформенные
-> интеграции продолжают дорабатываться. Сборки для macOS подписаны и
-> нотаризованы; сборки для Windows пока не подписаны. Скачивайте приложение
-> только со страницы официальных релизов и просматривайте примечания к выпуску,
-> прежде чем устанавливать неподписанную предварительную сборку.
 
 ## В научной работе и без того хватает движущихся частей
 
@@ -177,10 +156,6 @@ above with https://cdn.oleafly.com/videos/workspace-tour.webp.
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="Скомпилированная страница с графиками, цветовой картой поверхности ошибки и таблицей результатов рядом с исходником LaTeX" width="88%" />
 </div>
 
 Уменьшите масштаб — и весь документ окажется на экране целиком; обычно это
@@ -424,6 +399,28 @@ Claude Code, Cursor и других MCP-клиентов. MCP-подключен
 API-ключи хранятся локально. Обычные файлы документов останутся пригодными к
 работе, даже если вы перестанете пользоваться Oleafly.
 
+## Скоро
+
+В дальнейшем Oleafly останется открытым, local-first и полезным на всех
+этапах исследования.
+
+- **Локализация приложения.** Используйте Oleafly на большем числе языков
+  и выбирайте наиболее удобный интерфейс.
+- **Навыки и плагины для агентов.** Добавляйте целевые повторяемые
+  сценарии ИИ, которые передают меньше контекста и расходуют меньше токенов.
+- **Автономные исследовательские агенты.** Превращайте исследовательский
+  вопрос и набор источников в структурированный первый черновик.
+- **Совместная работа в реальном времени и комментарии.** Работайте в команде
+  без ограничений в самостоятельно развёрнутой среде.
+- **Oleafly CLI.** Используйте лёгкий устанавливаемый пакет командной строки
+  для исследовательских сценариев, которым не нужен графический интерфейс.
+- **Улучшенная поддержка Typst и Markdown.** Расширяйте возможности редактирования,
+  предпросмотра и публикации в обоих форматах.
+- **Больше интеграций для исследований.** Подключайте Mendeley и другие сервисы
+  для библиографии, библиотек и исследований.
+- **Самостоятельно развёрнутая облачная синхронизация.** Синхронизируйте проекты
+  между устройствами и используйте улучшенную автоматическую синхронизацию с GitHub.
+
 ## Установка
 
 Скачайте свежую сборку со страницы
@@ -444,20 +441,50 @@ API-ключи хранятся локально. Обычные файлы до
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 Требования, настройка платформ и производственные сборки описаны в
 [руководстве по разработке](../development.md).
 
-## Документация
+Эти скрипты загружают в `src-tauri/binaries` вспомогательные исполняемые файлы
+компилятора для текущей платформы. Их контрольные суммы зафиксированы. Аргумент
+`all` предназначен для CI и подготовки релизов, где нужны все поддерживаемые
+платформы.
 
-Репозиторий хранит публичные инженерные и продуктовые справочники рядом с
-кодом. Пользовательские руководства по конкретным задачам ведутся отдельно от
-этого публичного указателя.
+Функции редактора на основе TexLab и Tinymist необязательны для локального
+запуска. Загрузите эти языковые серверы командой
+`pnpm language-servers:fetch`. Правила проверки целостности, лицензирования и
+распространения описаны в
+[документации по языковым серверам](../language-server-toolchain.md).
+
+### Командная строка
+
+`oleaflyc` управляет проектами Oleafly без запуска настольного приложения.
+Пока он собирается из исходного кода этого репозитория и не публикуется как
+отдельный пакет.
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+Команды работают с текущим каталогом. Передайте `-C <path>`, чтобы выбрать
+другой проект. Полный список доступен по команде `oleaflyc --help`.
+
+## Документация для разработчиков
+
+Руководства пользователя находятся в
+[документации продукта Oleafly](https://oleafly.com/docs/overview/). Ссылки ниже
+предназначены для участников, интеграторов и ответственных за выпуск релизов.
 
 | Справочник | Содержание |
 | --- | --- |
@@ -474,10 +501,12 @@ pnpm tauri dev
 
 ## Участие в разработке
 
-Oleafly открыто разрабатывают
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) и участники
-сообщества. Мы рады сообщениям об ошибках, исправлениям, шаблонам,
-документации и вдумчивой обратной связи о продукте.
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="Клуб Oleafly: открытое исследовательское сообщество, которое отмечает черновики, правки, тесты и успешные публикации" width="100%" /></td>
+    <td width="62%" valign="top"><h3>Исследователям нужны инструменты, которые можно изучать, расширять и которым можно доверять.</h3><p>Oleafly открыто разрабатывают <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> и участники сообщества. Мы рады сообщениям об ошибках, исправлениям, шаблонам, документации и вдумчивой обратной связи о продукте.</p></td>
+  </tr>
+</table>
 
 1. Прочитайте [CONTRIBUTING.md](../../CONTRIBUTING.md).
 2. Перед крупным изменением откройте issue; небольшие точечные исправления
@@ -493,6 +522,25 @@ Oleafly открыто разрабатывают
 О проблемах безопасности, пожалуйста, сообщайте приватно, как описано в
 [SECURITY.md](../../SECURITY.md). Участие регулируется
 [кодексом поведения](../../CODE_OF_CONDUCT.md).
+
+## Сообщество и поддержка
+
+- Задавайте вопросы и делитесь идеями в [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions).
+- Сообщайте об ошибках и предлагайте функции в [GitHub Issues](https://github.com/Oleafly/Oleafly/issues).
+- 🔔 Подписывайтесь на [@OleaflyHQ в X](https://x.com/OleaflyHQ), чтобы узнавать новости продукта и релизов.
+
+⭐ Если Oleafly помогает вам, [поставьте звезду репозиторию](https://github.com/Oleafly/Oleafly).
+Этот небольшой жест помогает другим исследователям найти проект и поддерживает его развитие.
+
+## История звёзд
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="График истории звёзд GitHub" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## Благодарности
 

--- a/docs/readme-translations/README.zh.md
+++ b/docs/readme-translations/README.zh.md
@@ -6,43 +6,29 @@
 
 [Deutsch](README.de.md) | [English](../../README.md) | [Español](README.es.md) | [Français](README.fr.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Português](README.pt.md) | [Русский](README.ru.md) | **中文**
 
-**在完全属于你的 AI 工作区中撰写、编译并发表研究成果。**
+<h2>为 AI 时代重新设计的一体化研究环境。</h2>
 
-用 LaTeX、Typst 或 Markdown 写作，在源码旁边即时编译，
-用 Git 保存每一次修订，按你自己的方式使用 AI。
+在一个工作区中完成写作、编译、校对、文献检索、引文管理、图表制作、PDF
+审阅和 Git 变更追踪。你可以使用托管式 AI、自定义端点、本地 Ollama，也可以
+完全不使用 AI。Oleafly 将项目保存在你电脑上的普通文件夹中。
 
-Oleafly 是一款免费且 100% 开源的桌面应用，支持 macOS、Windows 和 Linux。
-它坚持本地优先，无需注册账号，项目文件以纯文本形式
-保存在你自己的电脑上。
-
+[![待处理 Issue](https://img.shields.io/github/issues/Oleafly/Oleafly?label=Issues&color=22c55e)](https://github.com/Oleafly/Oleafly/issues)
 [![Download](https://img.shields.io/github/v/release/Oleafly/Oleafly?label=Download&color=22c55e)](https://github.com/Oleafly/Oleafly/releases/latest)
-[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FOleafly%2FOleafly%2Fbadges%2F.github%2Fbadges%2Fdownloads.json)](https://github.com/Oleafly/Oleafly/releases)
+[![CI](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml/badge.svg)](https://github.com/Oleafly/Oleafly/actions/workflows/release.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-22c55e.svg)](../../LICENSE)
+<br/>
 [![macOS · Windows · Linux](https://img.shields.io/badge/macOS%20·%20Windows%20·%20Linux-blue)](https://github.com/Oleafly/Oleafly/releases/latest)
 [![Stars](https://img.shields.io/github/stars/Oleafly/Oleafly?style=social)](https://github.com/Oleafly/Oleafly)
 [![GitGem](https://gitgem.org/api/badge/github/Oleafly/Oleafly.svg)](https://gitgem.org/github/Oleafly/Oleafly)
-
 **[下载 Oleafly](https://github.com/Oleafly/Oleafly/releases/latest) ·
-[阅读工程文档](../README.md) ·
+[阅读产品文档](https://oleafly.com/docs/overview/) ·
 [从源码构建](../development.md)**
 
 </div>
 
 <div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-light.png" alt="Oleafly 并排显示 LaTeX 编辑器与编译后的 PDF（浅色主题）" width="92%" />
-  <br /><br />
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor.png" alt="Oleafly 并排显示 LaTeX 编辑器与编译后的 PDF（深色主题）" width="92%" />
-</div>
-
-<div align="center">
-
-<table>
-  <tr>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf.png" alt="Oleafly 项目库以彩色书籍形式展示项目，并标注引擎、类型和最近修改时间（深色主题）" /></td>
-    <td width="50%"><img src="https://cdn.oleafly.com/images/screenshots/desktop/library-shelf-light.png" alt="Oleafly 项目库以彩色书籍形式展示项目，并标注引擎、类型和最近修改时间（浅色主题）" /></td>
-  </tr>
-</table>
-
+  <img src="https://cdn.oleafly.com/images/screenshots/desktop/hero-editor-v0.3.10-r2.png" alt="Oleafly 正在使用 LaTeX 编辑 LLaMA 研究论文，同时显示源码树、文档大纲和编译后的 PDF" width="100%" />
 </div>
 
 <!--
@@ -50,13 +36,6 @@ Recording placeholder: the stacked hero stands in until a 45–60 second
 workspace walkthrough is ready. Keep the same framing and replace the sources
 above with https://cdn.oleafly.com/videos/workspace-tour.webp.
 -->
-
-> [!NOTE]
-> Oleafly 已经能够胜任日常文档写作，但项目仍在快速迭代中。
-> 高级宏包兼容性和部分平台集成仍在持续完善。
-> macOS 构建已完成签名和公证；Windows 构建尚未签名。
-> 请只从官方发布页面下载，并在安装未签名的预览版之前
-> 仔细阅读发行说明。
 
 ## 研究本身的环节已经够多了
 
@@ -165,10 +144,6 @@ Oleafly 目前不提供多人实时在线协作编辑，Git 和 GitHub
   </tr>
 </table>
 
-</div>
-
-<div align="center">
-  <img src="https://cdn.oleafly.com/images/screenshots/desktop/pdf-figures.png" alt="编译后的页面在 LaTeX 源码旁展示曲线图、彩色映射的误差曲面和结果表格" width="88%" />
 </div>
 
 缩小视图即可一屏纵览整个文档，这通常是检查浮动体、图片
@@ -399,6 +374,19 @@ Cursor 及其他 MCP 客户端。MCP 连接支持只读模式和
 API 密钥保存在本地。即使不再使用 Oleafly，纯文本文档文件
 依然完全可用。
 
+## 即将推出
+
+路线图将继续保持 Oleafly 的开放、本地优先特性，并覆盖完整的研究工作流。
+
+- **应用本地化。** 支持更多界面语言，让研究人员能在最自然的语言环境中使用 Oleafly。
+- **智能体技能和插件。** 添加专注、可复用的 AI 工作流，减少重复上下文和 token 用量。
+- **自主研究智能体。** 将研究问题和资料集转换为结构化的初稿，帮助研究快速起步。
+- **实时协作和评论。** 为研究团队提供无限、自托管的协作环境。
+- **Oleafly CLI。** 为不需要图形界面的研究工作流提供轻量、可安装的命令行工具包。
+- **更完善的 Typst 和 Markdown 支持。** 让两种格式都能使用更多编辑、预览和发布功能。
+- **更多研究集成。** 连接 Mendeley 以及其他参考文献、资源库和研究服务。
+- **自托管云同步。** 在多台设备之间同步项目，并按需使用更完善的 GitHub 自动同步。
+
 ## 安装
 
 从
@@ -419,19 +407,45 @@ Tectonic 会缓存这些宏包供后续构建使用，而离线模式会将编�
 ```bash
 git clone https://github.com/Oleafly/Oleafly.git
 cd Oleafly
-./scripts/fetch-tectonic.sh all
-./scripts/fetch-typst.sh all
 pnpm install
+host_target="$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/fetch-tectonic.sh "$host_target"
+./scripts/fetch-biber.sh "$host_target"
+./scripts/fetch-typst.sh "$host_target"
 pnpm tauri dev
 ```
 
 前置依赖、各平台环境搭建和生产构建，请参阅
 [开发指南](../development.md)。
 
-## 文档
+这些脚本会把当前平台所需且已锁定校验和的编译器辅助程序下载到
+`src-tauri/binaries`。`all` 参数用于 CI 和发布打包，因为这些场景需要准备
+所有受支持的平台。
 
-本仓库将公开的工程与产品参考文档和代码放在一起维护。
-面向最终用户的操作指南单独维护，不在此公开索引之列。
+本地运行时可以不安装 TexLab 和 Tinymist 提供的编辑器智能功能。需要时可运行
+`pnpm language-servers:fetch` 下载这些语言服务器。有关完整性校验、许可证和
+分发规则，请参阅[语言服务器工具链](../language-server-toolchain.md)。
+
+### 命令行
+
+`oleaflyc` 可以在不启动桌面应用的情况下管理 Oleafly 项目。目前它需要从本
+仓库的源码构建，尚未作为独立软件包发布。
+
+```bash
+cargo run -p oleafly-cli --bin oleaflyc -- init
+cargo run -p oleafly-cli --bin oleaflyc -- doctor
+cargo run -p oleafly-cli --bin oleaflyc -- build
+cargo run -p oleafly-cli --bin oleaflyc -- watch
+cargo run -p oleafly-cli --bin oleaflyc -- project info --json
+```
+
+这些命令默认作用于当前目录。使用 `-C <path>` 可指定其他项目。运行
+`oleaflyc --help` 可查看完整命令列表。
+
+## 开发者文档
+
+用户指南位于 [Oleafly 产品文档](https://oleafly.com/docs/overview/)。
+以下资料面向贡献者、集成开发者和发布维护者。
 
 | 参考文档 | 内容 |
 | --- | --- |
@@ -448,10 +462,12 @@ pnpm tauri dev
 
 ## 参与贡献
 
-Oleafly 由
-[Prajwal S Venkateshmurthy](https://github.com/prajwal-svm) 和
-众多贡献者公开开发。欢迎提交错误报告、修复、模板、文档，
-以及经过深思的产品反馈。
+<table>
+  <tr>
+    <td width="38%" valign="top"><img src="../assets/oleafly-club.png" alt="Oleafly Club：一个共同庆祝初稿、修订、测试和成功投稿的开源研究社区" width="100%" /></td>
+    <td width="62%" valign="top"><h3>研究者值得拥有可以审查、扩展并信赖的工具。</h3><p>Oleafly 由 <a href="https://github.com/prajwal-svm">Prajwal Murthy</a> 和众多贡献者公开开发。欢迎提交错误报告、修复、模板、文档，以及经过深思的产品反馈。</p></td>
+  </tr>
+</table>
 
 1. 阅读 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
 2. 大的改动请先开 issue 讨论；小而聚焦的修复可以直接
@@ -467,6 +483,25 @@ Oleafly 由
 安全问题请按照
 [SECURITY.md](../../SECURITY.md) 中的说明私下报告。参与本项目须遵守
 [行为准则](../../CODE_OF_CONDUCT.md)。
+
+## 社区与支持
+
+- 在 [GitHub Discussions](https://github.com/Oleafly/Oleafly/discussions) 提问并分享想法。
+- 在 [GitHub Issues](https://github.com/Oleafly/Oleafly/issues) 报告错误并提出功能建议。
+- 🔔 关注 X 上的 [@OleaflyHQ](https://x.com/OleaflyHQ)，获取产品和版本更新。
+
+⭐ 如果 Oleafly 对你有帮助，请考虑[为仓库加星](https://github.com/Oleafly/Oleafly)。
+这个小小的点击能帮助更多研究人员发现项目，并支持持续开发。
+
+## 星标趋势
+
+<a href="https://www.star-history.com/?repos=Oleafly%2FOleafly&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&theme=dark&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+   <img alt="GitHub 星标趋势图" src="https://api.star-history.com/chart?repos=Oleafly/Oleafly&type=date&legend=top-left&sealed_token=ZRIr-1jiqjn35WhaqiDqKsmeII-LmnrILQdxzg5v_RX8-PFtlYa4d5IY7U2-Mcn1_D2-0k4e440BGXMhRskNzn-mZUGI59rpIErWId2F600cSJDgZqwcQ3BxV6zC3m5peZz6s_P_Mla0ZW06zikSg5LHLCIALEzrFnLqag7R_rQ7haTYEGHvSdgx76__" />
+ </picture>
+</a>
 
 ## 致谢
 

--- a/packages/ai-core/src/figure-prompt.test.ts
+++ b/packages/ai-core/src/figure-prompt.test.ts
@@ -16,7 +16,7 @@ describe("vision capability", () => {
 
   it("still recognises the other vendors' vision models", () => {
     expect(modelSupportsVision("openai", "gpt-4o")).toBe(true);
-    expect(modelSupportsVision("google", "gemini-2.5-pro")).toBe(true);
+    expect(modelSupportsVision("google", "gemini-3.5-flash")).toBe(true);
     expect(modelSupportsVision("anthropic", "claude-sonnet-4-20250514")).toBe(true);
     expect(modelSupportsVision("openrouter", "qwen/qwen2-vl-7b")).toBe(true);
   });

--- a/packages/ai-core/src/providers.ts
+++ b/packages/ai-core/src/providers.ts
@@ -48,7 +48,6 @@ export const PROVIDERS: AIProvider[] = [
       { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
       { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro (preview)" },
       { id: "gemini-3.5-flash-lite", name: "Gemini 3.5 Flash-Lite" },
-      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
       { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
     ],
   },

--- a/packages/ai-core/src/providers.ts
+++ b/packages/ai-core/src/providers.ts
@@ -48,7 +48,6 @@ export const PROVIDERS: AIProvider[] = [
       { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
       { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro (preview)" },
       { id: "gemini-3.5-flash-lite", name: "Gemini 3.5 Flash-Lite" },
-      { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
     ],
   },
   {

--- a/packages/ai-core/src/providers.ts
+++ b/packages/ai-core/src/providers.ts
@@ -44,9 +44,11 @@ export const PROVIDERS: AIProvider[] = [
     blurb: "Gemini models from Google AI Studio.",
     signupUrl: "https://aistudio.google.com/app/api-keys",
     models: [
+      { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
+      { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro (preview)" },
+      { id: "gemini-3.5-flash-lite", name: "Gemini 3.5 Flash-Lite" },
       { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
       { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
-      { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash" },
     ],
   },
   {
@@ -83,7 +85,7 @@ export const PROVIDERS: AIProvider[] = [
     models: [
       { id: "openai/gpt-4o-mini", name: "GPT-4o mini" },
       { id: "anthropic/claude-3.5-sonnet", name: "Claude 3.5 Sonnet" },
-      { id: "google/gemini-flash-1.5", name: "Gemini Flash 1.5" },
+      { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" },
       { id: "meta-llama/llama-3.3-70b-instruct", name: "Llama 3.3 70B" },
     ],
   },

--- a/packages/ai-core/src/providers.ts
+++ b/packages/ai-core/src/providers.ts
@@ -20,11 +20,11 @@ export const PROVIDERS: AIProvider[] = [
     blurb: "GPT models. The default choice.",
     signupUrl: "https://platform.openai.com/api-keys",
     models: [
-      { id: "gpt-4o", name: "GPT-4o" },
+      { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+      { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
       { id: "gpt-4o-mini", name: "GPT-4o mini" },
-      { id: "gpt-4.1", name: "GPT-4.1" },
-      { id: "gpt-4.1-mini", name: "GPT-4.1 mini" },
-      { id: "o3-mini", name: "o3-mini" },
     ],
   },
   {
@@ -33,9 +33,10 @@ export const PROVIDERS: AIProvider[] = [
     blurb: "Claude models - strong at code and writing.",
     signupUrl: "https://console.anthropic.com/settings/keys",
     models: [
-      { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4" },
-      { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet" },
-      { id: "claude-3-5-haiku-20241022", name: "Claude 3.5 Haiku" },
+      { id: "claude-opus-5", name: "Claude Opus 5" },
+      { id: "claude-sonnet-5", name: "Claude Sonnet 5" },
+      { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+      { id: "claude-fable-5", name: "Claude Fable 5" },
     ],
   },
   {
@@ -59,21 +60,22 @@ export const PROVIDERS: AIProvider[] = [
     // Use the Coding Plan endpoint. The general /api/paas/v4 one bills separate
     baseURL: "https://api.z.ai/api/coding/paas/v4",
     models: [
+      { id: "glm-5.3", name: "GLM-5.3" },
       { id: "glm-5.2", name: "GLM-5.2" },
       { id: "glm-4.6", name: "GLM-4.6" },
       { id: "glm-4.5-air", name: "GLM-4.5 Air" },
-      { id: "glm-4.5", name: "GLM-4.5" },
     ],
   },
   {
     id: "groq",
     name: "Groq",
-    blurb: "Very fast Llama & Mixtral inference.",
+    blurb: "Very fast open-model inference.",
     signupUrl: "https://console.groq.com/keys",
     baseURL: "https://api.groq.com/openai/v1",
     models: [
+      { id: "openai/gpt-oss-120b", name: "GPT-OSS 120B" },
+      { id: "openai/gpt-oss-20b", name: "GPT-OSS 20B" },
       { id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B" },
-      { id: "llama-3.1-8b-instant", name: "Llama 3.1 8B Instant" },
     ],
   },
   {
@@ -84,7 +86,7 @@ export const PROVIDERS: AIProvider[] = [
     baseURL: "https://openrouter.ai/api/v1",
     models: [
       { id: "openai/gpt-4o-mini", name: "GPT-4o mini" },
-      { id: "anthropic/claude-3.5-sonnet", name: "Claude 3.5 Sonnet" },
+      { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" },
       { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" },
       { id: "meta-llama/llama-3.3-70b-instruct", name: "Llama 3.3 70B" },
     ],
@@ -92,12 +94,12 @@ export const PROVIDERS: AIProvider[] = [
   {
     id: "deepseek",
     name: "DeepSeek",
-    blurb: "DeepSeek V3 / R1 reasoning models.",
+    blurb: "DeepSeek V4 models.",
     signupUrl: "https://platform.deepseek.com/api_keys",
     baseURL: "https://api.deepseek.com",
     models: [
-      { id: "deepseek-chat", name: "DeepSeek V3 (chat)" },
-      { id: "deepseek-reasoner", name: "DeepSeek R1 (reasoner)" },
+      { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
+      { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
     ],
   },
   {
@@ -108,6 +110,7 @@ export const PROVIDERS: AIProvider[] = [
     baseURL: "https://api.mistral.ai/v1",
     models: [
       { id: "mistral-large-latest", name: "Mistral Large" },
+      { id: "magistral-medium-latest", name: "Magistral Medium" },
       { id: "codestral-latest", name: "Codestral" },
       { id: "mistral-small-latest", name: "Mistral Small" },
     ],
@@ -119,8 +122,9 @@ export const PROVIDERS: AIProvider[] = [
     signupUrl: "https://console.x.ai",
     baseURL: "https://api.x.ai/v1",
     models: [
-      { id: "grok-2", name: "Grok 2" },
-      { id: "grok-beta", name: "Grok Beta" },
+      { id: "grok-4.6", name: "Grok 4.6" },
+      { id: "grok-4.3", name: "Grok 4.3" },
+      { id: "grok-build-0.1", name: "Grok Build" },
     ],
   },
   {
@@ -132,7 +136,7 @@ export const PROVIDERS: AIProvider[] = [
     models: [
       { id: "sonar", name: "Sonar" },
       { id: "sonar-pro", name: "Sonar Pro" },
-      { id: "sonar-reasoning", name: "Sonar Reasoning" },
+      { id: "sonar-reasoning-pro", name: "Sonar Reasoning Pro" },
     ],
   },
   {
@@ -143,9 +147,9 @@ export const PROVIDERS: AIProvider[] = [
     isHost: true,
     models: [
       { id: "llama3.2", name: "Llama 3.2" },
-      { id: "qwen2.5", name: "Qwen 2.5" },
-      { id: "mistral", name: "Mistral" },
-      { id: "gemma2", name: "Gemma 2" },
+      { id: "qwen3.6:27b", name: "Qwen 3.6 27B" },
+      { id: "qwen3-coder:30b", name: "Qwen3 Coder 30B" },
+      { id: "gemma4:12b", name: "Gemma 4 12B" },
     ],
   },
 ];

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,6 +18,13 @@ sonar.rust.lcov.reportPaths=coverage/rust/lcov.info
 # new-code coverage gate down on any change that touches tooling.
 sonar.coverage.exclusions=scripts/**,src/developer/**,src/lib/e2e-import-registry.ts
 
+# The provider and model registries are declarative data tables whose entries
+# all share one shape (id, name, base URL, model list). Copy-paste detection
+# anonymizes literals, so it reads every catalog row as a clone of its
+# neighbors and fails the duplication gate whenever the catalogs are updated.
+# Correctness of these tables is guarded by catalog-parity.test.ts instead.
+sonar.cpd.exclusions=packages/ai-core/src/providers.ts,crates/oleafly-agent/src/provider.rs
+
 # The existing Rust CI job already runs Clippy with warnings denied. Running it
 # again inside the scanner would duplicate work without adding a distinct gate.
 sonar.rust.clippy.enabled=false

--- a/src-tauri/resources/ai-models.json
+++ b/src-tauri/resources/ai-models.json
@@ -69,7 +69,6 @@
       "gemini-3.1-pro-preview",
       "gemini-3.1-flash-lite",
       "gemini-3-flash-preview",
-      "gemini-2.5-pro",
       "gemini-2.5-flash",
       "gemini-2.5-flash-lite"
     ],

--- a/src-tauri/resources/ai-models.json
+++ b/src-tauri/resources/ai-models.json
@@ -68,9 +68,7 @@
       "gemini-3.5-flash-lite",
       "gemini-3.1-pro-preview",
       "gemini-3.1-flash-lite",
-      "gemini-3-flash-preview",
-      "gemini-2.5-flash",
-      "gemini-2.5-flash-lite"
+      "gemini-3-flash-preview"
     ],
     "ollama": [
       "llama3.2",

--- a/src-tauri/resources/ai-models.json
+++ b/src-tauri/resources/ai-models.json
@@ -51,12 +51,15 @@
       "gpt-5.6-luna"
     ],
     "anthropic": [
-      "claude-opus-4-1-20250805",
-      "claude-opus-4-20250514",
-      "claude-sonnet-4-20250514",
-      "claude-3-7-sonnet-20250219",
-      "claude-3-5-sonnet-20241022",
-      "claude-3-5-haiku-20241022"
+      "claude-fable-5",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-haiku-4-5",
+      "claude-haiku-4-5-20251001",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6"
     ],
     "google": [
       "gemini-3.7-flash",
@@ -71,42 +74,66 @@
       "gemini-2.5-flash-lite"
     ],
     "ollama": [
+      "llama3.2",
       "llama3.2:3b",
-      "llama3.2:latest"
+      "llama3.2:latest",
+      "qwen3.6:27b",
+      "qwen3.6:35b-a3b",
+      "qwen3-coder:30b",
+      "gemma4:12b",
+      "qwen2.5",
+      "qwen2.5:latest",
+      "mistral",
+      "mistral:latest",
+      "gemma2",
+      "gemma2:latest"
     ],
     "zai": [
+      "glm-5.3",
       "glm-5.2",
       "glm-4.6",
       "glm-4.5-air",
       "glm-4.5"
     ],
     "groq": [
+      "openai/gpt-oss-120b",
+      "openai/gpt-oss-20b",
+      "groq/compound",
+      "groq/compound-mini",
       "llama-3.3-70b-versatile",
       "llama-3.1-8b-instant"
     ],
     "openrouter": [
       "openai/gpt-4o-mini",
-      "anthropic/claude-3.5-sonnet",
+      "anthropic/claude-sonnet-5",
+      "anthropic/claude-opus-5",
       "google/gemini-2.5-flash",
       "meta-llama/llama-3.3-70b-instruct"
     ],
     "deepseek": [
-      "deepseek-chat",
-      "deepseek-reasoner"
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash-vision-exp"
     ],
     "mistral": [
       "mistral-large-latest",
+      "mistral-medium-latest",
+      "magistral-medium-latest",
+      "magistral-small-latest",
       "codestral-latest",
       "mistral-small-latest"
     ],
     "xai": [
-      "grok-2",
-      "grok-beta"
+      "grok-4.6",
+      "grok-4.5",
+      "grok-4.3",
+      "grok-build-0.1"
     ],
     "perplexity": [
       "sonar",
       "sonar-pro",
-      "sonar-reasoning"
+      "sonar-reasoning-pro",
+      "sonar-deep-research"
     ]
   }
 }

--- a/src-tauri/resources/ai-models.json
+++ b/src-tauri/resources/ai-models.json
@@ -59,11 +59,16 @@
       "claude-3-5-haiku-20241022"
     ],
     "google": [
+      "gemini-3.7-flash",
+      "gemini-3.6-flash",
+      "gemini-3.5-flash",
+      "gemini-3.5-flash-lite",
+      "gemini-3.1-pro-preview",
+      "gemini-3.1-flash-lite",
+      "gemini-3-flash-preview",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
-      "gemini-2.5-flash-lite",
-      "gemini-2.0-flash",
-      "gemini-2.0-flash-lite"
+      "gemini-2.5-flash-lite"
     ],
     "ollama": [
       "llama3.2:3b",
@@ -82,7 +87,7 @@
     "openrouter": [
       "openai/gpt-4o-mini",
       "anthropic/claude-3.5-sonnet",
-      "google/gemini-flash-1.5",
+      "google/gemini-2.5-flash",
       "meta-llama/llama-3.3-70b-instruct"
     ],
     "deepseek": [

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -250,8 +250,28 @@ async fn native_agent_tool(
         Err(_) => return Some(tool_error("the tool arguments were not valid JSON")),
     };
     match crate::mcp::native::call(project_id, name, &arguments).await {
-        Ok(outcome) => Some(oleafly_agent::ToolOutput::text(outcome.result.to_string())),
+        Ok(outcome) => Some(oleafly_agent::ToolOutput::text(unwrap_mcp_text(
+            &outcome.result,
+        ))),
         Err(error) => Some(tool_error(&error)),
+    }
+}
+
+fn unwrap_mcp_text(result: &serde_json::Value) -> String {
+    let texts: Vec<&str> = result
+        .get("content")
+        .and_then(|content| content.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("text").and_then(|text| text.as_str()))
+                .collect()
+        })
+        .unwrap_or_default();
+    if texts.is_empty() {
+        result.to_string()
+    } else {
+        texts.join("\n")
     }
 }
 

--- a/src-tauri/src/agent_tests.rs
+++ b/src-tauri/src/agent_tests.rs
@@ -117,7 +117,7 @@ fn a_configured_key_resolves_end_to_end_from_app_config() {
     let cfg = config_with("groq", &[("groq", "gsk-1")]);
     let resolved = oleafly_agent::resolve(&provider_config(&cfg)).unwrap();
     assert_eq!(resolved.provider_id, "groq");
-    assert_eq!(resolved.model_id, "llama-3.3-70b-versatile");
+    assert_eq!(resolved.model_id, "openai/gpt-oss-120b");
     assert_eq!(resolved.credential, "gsk-1");
 }
 

--- a/src-tauri/src/agent_tests.rs
+++ b/src-tauri/src/agent_tests.rs
@@ -421,3 +421,32 @@ async fn native_read_file_answers_with_project_content() {
     std::env::remove_var("OLEAFLY_DATA_DIR");
     std::fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn native_tool_output_is_the_payload_not_the_mcp_envelope() {
+    let envelope = serde_json::json!({
+        "content": [{ "type": "text", "text": "{\"files\":[{\"path\":\"main.tex\"}]}" }]
+    });
+    assert_eq!(
+        unwrap_mcp_text(&envelope),
+        "{\"files\":[{\"path\":\"main.tex\"}]}"
+    );
+
+    let multi = serde_json::json!({
+        "content": [
+            { "type": "text", "text": "first" },
+            { "type": "image", "data": "AAAB" },
+            { "type": "text", "text": "second" }
+        ]
+    });
+    assert_eq!(unwrap_mcp_text(&multi), "first\nsecond");
+}
+
+#[test]
+fn a_result_that_is_not_an_envelope_passes_through_verbatim() {
+    let plain = serde_json::json!({ "error": "not found" });
+    assert_eq!(unwrap_mcp_text(&plain), plain.to_string());
+
+    let empty_content = serde_json::json!({ "content": [] });
+    assert_eq!(unwrap_mcp_text(&empty_content), empty_content.to_string());
+}

--- a/src/components/ai/ChatCore.tsx
+++ b/src/components/ai/ChatCore.tsx
@@ -1037,9 +1037,10 @@ ${sandboxedCustom}`;
 
       usageSteps = outcome.steps;
       if (outcome.error) {
+        const displayError = formatError(outcome.error, activeProviderName);
         updateRunLast((m) => ({
           ...m,
-          content: (m.content ? `${m.content}\n\n` : "") + outcome.error,
+          content: (m.content ? `${m.content}\n\n` : "") + displayError,
         }));
       }
       if (outcome.stopped_at_cap) {

--- a/src/components/ai/ChatCore.tsx
+++ b/src/components/ai/ChatCore.tsx
@@ -87,6 +87,7 @@ import {
   InfoHint,
   MessageItem,
   formatError,
+  formatToolOutput,
 } from "@/components/ai/chat-parts";
 import type { EngineFeature } from "@/lib/tauri";
 
@@ -1016,9 +1017,7 @@ ${sandboxedCustom}`;
               ],
             })),
           onToolResult: ({ id, output }) => {
-            const outStr = (
-              typeof output === "string" ? output : JSON.stringify(output, null, 2)
-            ).slice(0, 500);
+            const outStr = formatToolOutput(output).slice(0, 500);
             updateRunLast((m) => {
               const calls = [...(m.toolCalls || [])];
               for (let i = calls.length - 1; i >= 0; i--) {

--- a/src/components/ai/ChatCore.tsx
+++ b/src/components/ai/ChatCore.tsx
@@ -260,8 +260,6 @@ export function ChatCore() {
   const pendingImagesRef = useRef<string[]>([]);
   // Timestamp of the last stream part, for the stall watchdog.
   const lastPartAtRef = useRef<number>(0);
-  // Set when the watchdog aborts a silent run, so the catch shows a timeout note.
-  const timedOutRef = useRef(false);
   const figureModeOpen = useSettingsStore((s) => s.figureModeOpen);
   const setFigureModeOpen = useSettingsStore((s) => s.setFigureModeOpen);
   // User's own system-prompt addition (sandboxed into our prompt at send time).
@@ -370,23 +368,18 @@ export function ChatCore() {
     if (!figureModeAvailable) setFigureMode(false);
   }, [figureModeAvailable]);
 
-  // Stall watchdog: if the provider goes quiet mid-run, tell the user it is
-  // still working (reasoning models can be slow) rather than looking frozen.
+  // Stall notice: if the provider goes quiet mid-run, tell the user it is
+  // still working rather than looking frozen. Hard aborts belong to the
+  // backend stream's idle timeout, which knows whether the provider is a
+  // local server (long silent prompt prefill is normal there) or a cloud API.
   useEffect(() => {
     if (!streaming) return;
     const id = window.setInterval(() => {
       const quietMs = Date.now() - (activeChatRun()?.lastPartAt ?? lastPartAtRef.current);
-      // Hard timeout: 90s of total silence from the provider aborts the run so a
-      // hung or unavailable model never spins forever.
-      if (quietMs > 90000) {
-        timedOutRef.current = true;
-        abortRef.current?.abort();
-        return;
-      }
       if (quietMs > 20000) {
         const secs = Math.round(quietMs / 1000);
         setThinkingText(
-          `Still working (${secs}s). Reasoning models and the first figure compile can be slow. Click stop to cancel.`,
+          `Still working (${secs}s). Reasoning models and local prompt processing can be slow. Click stop to cancel.`,
         );
       }
     }, 5000);
@@ -796,7 +789,6 @@ export function ChatCore() {
     setRunThinking("Thinking…");
     lastPartAtRef.current = Date.now();
     runHandle.lastPartAt = Date.now();
-    timedOutRef.current = false;
 
     // Persist this conversation as a chat (creates one on the first message).
     {
@@ -1064,9 +1056,7 @@ ${sandboxedCustom}`;
         ac.signal.aborted ||
         (typeof e === "object" && e !== null && "name" in e && e.name === "AbortError")
       ) {
-        const note = timedOutRef.current
-          ? "_Timed out after 90s with no response. The model may be unavailable or overloaded. Try again, or switch models from the menu above._"
-          : "_Stopped._";
+        const note = "_Stopped._";
         updateRunLast((m) => ({
           ...m,
           content: (m.content ? `${m.content}\n\n` : "") + note,

--- a/src/components/ai/chat-parts.test.ts
+++ b/src/components/ai/chat-parts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatToolOutput, friendlyHint } from "./chat-parts";
+import { formatError, formatToolOutput, friendlyHint } from "./chat-parts";
 
 describe("formatToolOutput", () => {
   it("shows a text payload's content field as readable text", () => {
@@ -51,5 +51,16 @@ describe("friendlyHint", () => {
 
   it("stays quiet on errors it does not recognize", () => {
     expect(friendlyHint("something odd happened")).toBeNull();
+  });
+});
+
+describe("formatError", () => {
+  it("formats string overload errors returned as run outcomes", () => {
+    const formatted = formatError(
+      "The provider returned 503. This model is currently experiencing high demand.",
+      "Google Gemini",
+    );
+    expect(formatted).toContain("Google Gemini");
+    expect(formatted).toContain("overloaded");
   });
 });

--- a/src/components/ai/chat-parts.test.ts
+++ b/src/components/ai/chat-parts.test.ts
@@ -19,6 +19,14 @@ describe("friendlyHint", () => {
     expect(friendlyHint("invalid api key", 401)).toContain("API key");
   });
 
+  it("explains a capacity spike", () => {
+    const hint = friendlyHint(
+      "The provider returned 503. This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.",
+      503,
+    );
+    expect(hint).toContain("overloaded");
+  });
+
   it("stays quiet on errors it does not recognize", () => {
     expect(friendlyHint("something odd happened")).toBeNull();
   });

--- a/src/components/ai/chat-parts.test.ts
+++ b/src/components/ai/chat-parts.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { friendlyHint } from "./chat-parts";
+import { formatToolOutput, friendlyHint } from "./chat-parts";
+
+describe("formatToolOutput", () => {
+  it("shows a text payload's content field as readable text", () => {
+    const out = formatToolOutput({
+      path: "bare_adv.tex",
+      truncated: false,
+      content: "% The publisher's ID mark\n\\IEEEpubid{0000}",
+    });
+    expect(out).toBe("% The publisher's ID mark\n\\IEEEpubid{0000}");
+  });
+
+  it("keeps plain strings and surfaces errors", () => {
+    expect(formatToolOutput("done")).toBe("done");
+    expect(formatToolOutput({ error: "file not found" })).toBe("Error: file not found");
+  });
+
+  it("pretty-prints structured payloads without a content field", () => {
+    const out = formatToolOutput({ files: [{ path: "a.tex" }] });
+    expect(out).toContain('"a.tex"');
+    expect(out).toContain("\n");
+  });
+});
 
 describe("friendlyHint", () => {
   it("explains a retired or restricted model", () => {

--- a/src/components/ai/chat-parts.test.ts
+++ b/src/components/ai/chat-parts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { friendlyHint } from "./chat-parts";
+
+describe("friendlyHint", () => {
+  it("explains a retired or restricted model", () => {
+    const hint = friendlyHint(
+      "The provider returned 404. This model models/gemini-2.5-pro is no longer available to new users. Please update your code to use models/gemini-3.1-pro-preview for the latest features and improvements.",
+      404,
+    );
+    expect(hint).toContain("retired or restricted this model");
+
+    expect(friendlyHint("The model `grok-2` was deprecated on 2026-01-01.")).toContain(
+      "retired or restricted",
+    );
+    expect(friendlyHint("model_not_found: deepseek-chat")).toContain("retired or restricted");
+  });
+
+  it("keeps credential problems ahead of model problems", () => {
+    expect(friendlyHint("invalid api key", 401)).toContain("API key");
+  });
+
+  it("stays quiet on errors it does not recognize", () => {
+    expect(friendlyHint("something odd happened")).toBeNull();
+  });
+});

--- a/src/components/ai/chat-parts.test.tsx
+++ b/src/components/ai/chat-parts.test.tsx
@@ -51,16 +51,13 @@ describe("AI chat overflow surfaces", () => {
     );
   });
 
-  it("wraps expanded reasoning without horizontal scrolling", () => {
-    const { container } = render(<ReasoningBlock text="A long reasoning trace" />);
+  it("wraps expanded reasoning without horizontal scrolling and renders its markdown", () => {
+    const { container } = render(<ReasoningBlock text="**Exploring Project Contents**" />);
 
     fireEvent.click(getByRole(container, "button"));
 
-    expect(container.querySelector("pre")).toHaveClass(
-      "overflow-x-hidden",
-      "overflow-y-auto",
-      "whitespace-pre-wrap",
-      "break-words",
-    );
+    const body = container.querySelector("div.max-h-56");
+    expect(body).toHaveClass("overflow-x-hidden", "overflow-y-auto", "break-words");
+    expect(body?.querySelector("strong")).toHaveTextContent("Exploring Project Contents");
   });
 });

--- a/src/components/ai/chat-parts.test.tsx
+++ b/src/components/ai/chat-parts.test.tsx
@@ -60,4 +60,16 @@ describe("AI chat overflow surfaces", () => {
     expect(body).toHaveClass("overflow-x-hidden", "overflow-y-auto", "break-words");
     expect(body?.querySelector("strong")).toHaveTextContent("Exploring Project Contents");
   });
+
+  it("keeps active reasoning as plain text until streaming completes", () => {
+    const { container } = render(
+      <ReasoningBlock text="**Exploring Project Contents**" active />,
+    );
+
+    fireEvent.click(getByRole(container, "button"));
+
+    const body = container.querySelector("div.max-h-56");
+    expect(body?.querySelector("strong")).toBeNull();
+    expect(body).toHaveTextContent("**Exploring Project Contents**");
+  });
 });

--- a/src/components/ai/chat-parts.tsx
+++ b/src/components/ai/chat-parts.tsx
@@ -164,6 +164,16 @@ export function ToolBadge({ tc }: { tc: ToolEntry }) {
   );
 }
 
+export function formatToolOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (output && typeof output === "object") {
+    const record = output as Record<string, unknown>;
+    if (typeof record.content === "string") return record.content;
+    if (typeof record.error === "string") return `Error: ${record.error}`;
+  }
+  return JSON.stringify(output, null, 2) ?? String(output);
+}
+
 export function friendlyHint(text: string, statusCode?: number): string | null {
   const t = text.toLowerCase();
   if (
@@ -246,7 +256,7 @@ export function ReasoningBlock({
 }) {
   const [userToggled, setUserToggled] = useState<boolean | null>(null);
   const open = userToggled ?? false;
-  const scrollRef = useRef<HTMLPreElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     void text;
@@ -273,12 +283,12 @@ export function ReasoningBlock({
         <ChevronRight className={cn("ml-auto size-3 transition-transform", open && "rotate-90")} />
       </button>
       {open && (
-        <pre
+        <div
           ref={scrollRef}
-          className="max-h-56 overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words border-t px-2.5 py-1.5 font-sans text-[11px] leading-relaxed text-muted-foreground"
+          className="max-h-56 overflow-x-hidden overflow-y-auto break-words border-t px-2.5 py-1.5 text-[11px] leading-relaxed text-muted-foreground"
         >
-          {text}
-        </pre>
+          <Markdown className="chat-markdown">{text}</Markdown>
+        </div>
       )}
     </div>
   );

--- a/src/components/ai/chat-parts.tsx
+++ b/src/components/ai/chat-parts.tsx
@@ -189,6 +189,9 @@ export function friendlyHint(text: string, statusCode?: number): string | null {
   ) {
     return "The provider retired or restricted this model. Pick a newer model from the model menu above (Settings → AI Assistant lists what your key can use).";
   }
+  if (statusCode === 503 || /high demand|overloaded|over capacity|service unavailable|\b503\b/.test(t)) {
+    return "The provider's servers are overloaded right now (this was already retried). Wait a minute and try again, or switch to a sibling model from the model menu above.";
+  }
   if (/econnrefused|failed to fetch|fetch failed|load failed|network error|not reachable|connection refused/.test(t)) {
     return "Couldn't reach the AI provider. Check your connection, or if you're using Ollama, make sure it's running (Settings → AI Assistant → Check for Ollama).";
   }

--- a/src/components/ai/chat-parts.tsx
+++ b/src/components/ai/chat-parts.tsx
@@ -182,6 +182,13 @@ export function friendlyHint(text: string, statusCode?: number): string | null {
   if (statusCode === 429 || /rate limit|too many requests|\b429\b/.test(t)) {
     return "The provider is rate-limiting requests. Wait a moment and retry, or switch providers from the model menu above.";
   }
+  if (
+    /no longer available|has been retired|model.{0,40}(deprecated|discontinued|not found|does not exist)|unknown model|model_not_found/.test(
+      t,
+    )
+  ) {
+    return "The provider retired or restricted this model. Pick a newer model from the model menu above (Settings → AI Assistant lists what your key can use).";
+  }
   if (/econnrefused|failed to fetch|fetch failed|load failed|network error|not reachable|connection refused/.test(t)) {
     return "Couldn't reach the AI provider. Check your connection, or if you're using Ollama, make sure it's running (Settings → AI Assistant → Check for Ollama).";
   }

--- a/src/components/ai/chat-parts.tsx
+++ b/src/components/ai/chat-parts.tsx
@@ -244,7 +244,7 @@ export function formatError(e: unknown, providerLabel?: string): string {
   return parts.join(" ");
 }
 
-// Plain text, not markdown, so a long stream stays cheap.
+// Keep active streams as plain text, then parse Markdown once reasoning is complete.
 export function ReasoningBlock({
   text,
   active,
@@ -287,7 +287,11 @@ export function ReasoningBlock({
           ref={scrollRef}
           className="max-h-56 overflow-x-hidden overflow-y-auto break-words border-t px-2.5 py-1.5 text-[11px] leading-relaxed text-muted-foreground"
         >
-          <Markdown className="chat-markdown">{text}</Markdown>
+          {active ? (
+            <span className="whitespace-pre-wrap">{text}</span>
+          ) : (
+            <Markdown className="chat-markdown">{text}</Markdown>
+          )}
         </div>
       )}
     </div>

--- a/src/lib/agent-backend.ts
+++ b/src/lib/agent-backend.ts
@@ -3,7 +3,7 @@ import { Channel, invoke } from "@tauri-apps/api/core";
 export type AgentContentPart =
   | { type: "text"; text: string }
   | { type: "image"; image: string }
-  | { type: "toolUse"; id: string; name: string; arguments: string }
+  | { type: "toolUse"; id: string; name: string; arguments: string; thoughtSignature?: string }
   | { type: "toolResult"; id: string; name: string; output: string };
 
 export function agentErrorKind(error: unknown): string {

--- a/src/lib/ai-figure.test.ts
+++ b/src/lib/ai-figure.test.ts
@@ -47,7 +47,8 @@ describe("modelSupportsVision", () => {
     expect(modelSupportsVision("openai", "gpt-4.1-mini")).toBe(true);
     expect(modelSupportsVision("anthropic", "claude-3-5-sonnet-20241022")).toBe(true);
     expect(modelSupportsVision("anthropic", "claude-sonnet-4-20250514")).toBe(true);
-    expect(modelSupportsVision("openrouter", "google/gemini-flash-1.5")).toBe(true);
+    expect(modelSupportsVision("openrouter", "google/gemini-2.5-flash")).toBe(true);
+    expect(modelSupportsVision("google", "gemini-3.7-flash")).toBe(true);
     expect(modelSupportsVision("ollama", "llama3.2-vision")).toBe(true);
   });
 

--- a/src/lib/ai-pricing.ts
+++ b/src/lib/ai-pricing.ts
@@ -8,16 +8,23 @@ export interface ModelPrice {
 
 const PRICES: Record<string, ModelPrice> = {
   // OpenAI
+  "gpt-5.6-sol": { inputPerMTok: 5, outputPerMTok: 30 },
+  "gpt-5.6-terra": { inputPerMTok: 2, outputPerMTok: 12 },
+  "gpt-5.6-luna": { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+  "gpt-5.3-codex": { inputPerMTok: 1.75, outputPerMTok: 14 },
   "gpt-4o": { inputPerMTok: 2.5, outputPerMTok: 10 },
   "gpt-4o-mini": { inputPerMTok: 0.15, outputPerMTok: 0.6 },
   "gpt-4.1": { inputPerMTok: 2, outputPerMTok: 8 },
   "gpt-4.1-mini": { inputPerMTok: 0.4, outputPerMTok: 1.6 },
   "o3-mini": { inputPerMTok: 1.1, outputPerMTok: 4.4 },
   // Anthropic
-  "claude-sonnet-4-20250514": { inputPerMTok: 3, outputPerMTok: 15 },
-  "claude-3-5-sonnet-20241022": { inputPerMTok: 3, outputPerMTok: 15 },
-  "claude-3-5-haiku-20241022": { inputPerMTok: 0.8, outputPerMTok: 4 },
+  "claude-fable-5": { inputPerMTok: 10, outputPerMTok: 50 },
+  "claude-opus-5": { inputPerMTok: 5, outputPerMTok: 25 },
+  "claude-sonnet-5": { inputPerMTok: 2, outputPerMTok: 10 },
+  "claude-haiku-4-5": { inputPerMTok: 1, outputPerMTok: 5 },
   // Groq (approx)
+  "openai/gpt-oss-120b": { inputPerMTok: 0.15, outputPerMTok: 0.6 },
+  "openai/gpt-oss-20b": { inputPerMTok: 0.075, outputPerMTok: 0.3 },
   "llama-3.3-70b-versatile": { inputPerMTok: 0.59, outputPerMTok: 0.79 },
   "llama-3.1-8b-instant": { inputPerMTok: 0.05, outputPerMTok: 0.08 },
   // Google Gemini
@@ -29,23 +36,35 @@ const PRICES: Record<string, ModelPrice> = {
   "gemini-2.5-flash-lite": { inputPerMTok: 0.1, outputPerMTok: 0.4 },
   // OpenRouter catalog ids
   "openai/gpt-4o-mini": { inputPerMTok: 0.15, outputPerMTok: 0.6 },
-  "anthropic/claude-3.5-sonnet": { inputPerMTok: 3, outputPerMTok: 15 },
+  "anthropic/claude-sonnet-5": { inputPerMTok: 2, outputPerMTok: 10 },
   "google/gemini-2.5-flash": { inputPerMTok: 0.3, outputPerMTok: 2.5 },
   "meta-llama/llama-3.3-70b-instruct": { inputPerMTok: 0.1, outputPerMTok: 0.3 },
-  // DeepSeek
-  "deepseek-chat": { inputPerMTok: 0.27, outputPerMTok: 1.1 },
-  "deepseek-reasoner": { inputPerMTok: 0.55, outputPerMTok: 2.19 },
+  // DeepSeek (peak-hour cache-miss rates; off-peak is half)
+  "deepseek-v4-flash": { inputPerMTok: 0.44, outputPerMTok: 1.32 },
+  "deepseek-v4-pro": { inputPerMTok: 1.32, outputPerMTok: 3.96 },
   // Mistral
-  "mistral-large-latest": { inputPerMTok: 2, outputPerMTok: 6 },
+  "mistral-large-latest": { inputPerMTok: 0.5, outputPerMTok: 1.5 },
+  "magistral-medium-latest": { inputPerMTok: 2, outputPerMTok: 5 },
+  "magistral-small-latest": { inputPerMTok: 0.5, outputPerMTok: 1.5 },
   "codestral-latest": { inputPerMTok: 0.3, outputPerMTok: 0.9 },
-  "mistral-small-latest": { inputPerMTok: 0.1, outputPerMTok: 0.3 },
-  // xAI
-  "grok-2": { inputPerMTok: 2, outputPerMTok: 10 },
-  "grok-beta": { inputPerMTok: 5, outputPerMTok: 15 },
+  "mistral-small-latest": { inputPerMTok: 0.15, outputPerMTok: 0.6 },
+  // xAI (under 200k prompt tokens)
+  "grok-4.6": { inputPerMTok: 2, outputPerMTok: 6 },
+  "grok-4.5": { inputPerMTok: 2, outputPerMTok: 6 },
+  "grok-4.3": { inputPerMTok: 1.25, outputPerMTok: 2.5 },
+  "grok-build-0.1": { inputPerMTok: 1, outputPerMTok: 2 },
+  // Perplexity (token rates; request fees not modeled)
+  sonar: { inputPerMTok: 1, outputPerMTok: 1 },
+  "sonar-pro": { inputPerMTok: 3, outputPerMTok: 15 },
+  "sonar-reasoning-pro": { inputPerMTok: 2, outputPerMTok: 8 },
   "llama3.2": { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
+  "qwen3.6:27b": { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
+  "qwen3-coder:30b": { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
+  "gemma4:12b": { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
   "qwen2.5": { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
   mistral: { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
   gemma2: { inputPerMTok: 0, outputPerMTok: 0, note: "local" },
+  "glm-5.3": { inputPerMTok: 0, outputPerMTok: 0, note: "plan" },
   "glm-5.2": { inputPerMTok: 0, outputPerMTok: 0, note: "plan" },
   "glm-4.6": { inputPerMTok: 0, outputPerMTok: 0, note: "plan" },
   "glm-4.5-air": { inputPerMTok: 0, outputPerMTok: 0, note: "plan" },

--- a/src/lib/ai-pricing.ts
+++ b/src/lib/ai-pricing.ts
@@ -20,10 +20,17 @@ const PRICES: Record<string, ModelPrice> = {
   // Groq (approx)
   "llama-3.3-70b-versatile": { inputPerMTok: 0.59, outputPerMTok: 0.79 },
   "llama-3.1-8b-instant": { inputPerMTok: 0.05, outputPerMTok: 0.08 },
+  // Google Gemini
+  "gemini-3.7-flash": { inputPerMTok: 0.75, outputPerMTok: 3.75 },
+  "gemini-3.1-pro-preview": { inputPerMTok: 2, outputPerMTok: 12 },
+  "gemini-3.5-flash-lite": { inputPerMTok: 0.1, outputPerMTok: 0.4 },
+  "gemini-2.5-pro": { inputPerMTok: 1.25, outputPerMTok: 10 },
+  "gemini-2.5-flash": { inputPerMTok: 0.3, outputPerMTok: 2.5 },
+  "gemini-2.5-flash-lite": { inputPerMTok: 0.1, outputPerMTok: 0.4 },
   // OpenRouter catalog ids
   "openai/gpt-4o-mini": { inputPerMTok: 0.15, outputPerMTok: 0.6 },
   "anthropic/claude-3.5-sonnet": { inputPerMTok: 3, outputPerMTok: 15 },
-  "google/gemini-flash-1.5": { inputPerMTok: 0.075, outputPerMTok: 0.3 },
+  "google/gemini-2.5-flash": { inputPerMTok: 0.3, outputPerMTok: 2.5 },
   "meta-llama/llama-3.3-70b-instruct": { inputPerMTok: 0.1, outputPerMTok: 0.3 },
   // DeepSeek
   "deepseek-chat": { inputPerMTok: 0.27, outputPerMTok: 1.1 },


### PR DESCRIPTION
Fixes #81.

## What was broken

Gemini 3 models attach an encrypted `thoughtSignature` to the response part that carries a `functionCall`, and the API refuses any follow-up request whose history is missing those signatures. Our Google stream translator flattened parts into `ToolCall { id, name, arguments }` and dropped the field, so the second request of every tool loop (the one that replays the model's function call plus its result) came back with:

> 400: Function call is missing a thought_signature in functionCall parts.

Any Gemini 3 model with any tool was affected. Gemini 2.5 kept working because it doesn't enforce the check.

Two more problems surfaced while fixing it:

1. `ai-models.json` is an allow-list intersected with each provider's live model listing, and it had gone stale across the board. Google shut down the 2.0 models it listed while every Gemini 3 model was hidden. The same rot applied elsewhere: Anthropic retired all Claude 3.x and dated 4.x ids, DeepSeek retired `deepseek-chat`/`deepseek-reasoner`, xAI dropped `grok-2`/`grok-beta`, Groq deprecated its Llama models, and Perplexity removed plain `sonar-reasoning`.
2. Native tools (list_files, read_file, search_project) reuse the MCP server's `CallToolResult` wrapper, and the agent path forwarded the whole wrapper. The model burned context on double-encoded JSON and the chat transcript rendered the raw envelope, which is the unreadable `{"content":[{"text":"{\"files\":..."` block in the issue screenshots.

## The fix

Thought signatures (commit 1):

- `ToolCall` and `ContentPart::ToolUse` get an optional `thought_signature`
- the Google translator reads the part-level field while streaming
- `google_part` writes it back beside `functionCall` when history is replayed
- parallel calls keep the signature only where Google put it (the first part); other providers never see the field, and it serializes as optional so histories written by older builds still load

Model catalogs (commits 2 and 3): every provider's list in `ai-models.json`, the Rust catalog defaults, the TypeScript registry, and the pricing table now match lineups verified against each provider's official docs on 2026-08-24. New defaults: `gemini-3.7-flash`, `claude-opus-5`, `gpt-5.6-terra`, `glm-5.3`, `openai/gpt-oss-120b` (Groq), `deepseek-v4-flash`, `grok-4.6`. The Ollama allow-list also grows past llama3.2, which was hiding every other locally pulled model from the picker.

Tool output (commit 4): the agent path unwraps the MCP envelope, joining text parts the way an MCP client would, with non-envelope results (errors) passing through untouched.

## Rollout note

The remote catalog at `cdn.oleafly.com/catalogs/ai-models.json` overrides the bundled one. The matching oleafly-assets PR should merge only after this fix ships in a release, otherwise released builds gain Gemini 3 models they still can't talk to.

## Testing

- cargo fmt, clippy, and `cargo test --workspace` all green (10 new tests across the agent crate and src-tauri)
- `pnpm lint`, `pnpm test` (2113 passed, catalog parity included), `pnpm build`
- new tests: the translator keeps the part-level signature, parallel calls keep it only on the first part, the wire body echoes it beside `functionCall` and omits it when absent, other providers' shapes never include it, the serde form round-trips with and without the field, and native tool output is the payload rather than the MCP envelope

<img width="1755" height="2099" alt="image" src="https://github.com/user-attachments/assets/485d02fb-ee62-4235-b290-e8e2b3a24c3d" />

