### PR TITLE
fix: accept TinyTeX release archive metadata

### DIFF
--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -1725,6 +1725,10 @@ pub async fn compile_tagged(
 }
 
 #[cfg(test)]
+#[path = "latex_engine/tests/release_archives.rs"]
+mod release_archive_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -2346,66 +2350,6 @@ mod tests {
     fn tinytex_tag_is_a_fixed_release() {
         assert_ne!(TINYTEX_TAG, "daily");
         assert!(TINYTEX_TAG.starts_with('v'));
-    }
-
-    #[test]
-    #[ignore = "downloads are large; run manually against local archives when bumping TINYTEX_TAG"]
-    fn pinned_release_archives_pass_reviewed_policies() {
-        use sha2::Digest as _;
-        use std::io::Read as _;
-
-        let dir = std::env::var("TINYTEX_ARCHIVE_DIR").expect(
-            "set TINYTEX_ARCHIVE_DIR to a directory holding the release archives for every platform",
-        );
-        let mut verified = Vec::new();
-        for (os, arch) in [
-            ("macos", "aarch64"),
-            ("windows", "x86_64"),
-            ("linux", "x86_64"),
-            ("linux", "aarch64"),
-        ] {
-            let asset = tinytex_asset_for(os, arch).unwrap();
-            let name = asset.url.rsplit('/').next().unwrap();
-            let path = std::path::Path::new(&dir).join(name);
-            assert!(path.is_file(), "missing archive {name} in {dir}");
-            assert_eq!(
-                std::fs::metadata(&path).unwrap().len(),
-                asset.expected_bytes,
-                "{name}: size does not match the pinned release"
-            );
-            let mut hasher = sha2::Sha256::new();
-            let mut file = std::fs::File::open(&path).unwrap();
-            let mut buffer = vec![0u8; 1 << 20];
-            loop {
-                let read = file.read(&mut buffer).unwrap();
-                if read == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..read]);
-            }
-            assert_eq!(
-                format!("{:x}", hasher.finalize()),
-                asset.expected_sha256,
-                "{name}: sha256 does not match the pinned release"
-            );
-            let result = if asset.format == ArchiveFormat::TarXz && !cfg!(target_os = "linux") {
-                let tar = path.with_extension("").with_extension("tar");
-                assert!(
-                    tar.is_file(),
-                    "this host cannot decode xz; place the decompressed {} next to the archive",
-                    tar.file_name().unwrap().to_string_lossy()
-                );
-                crate::tinytex_archive::inspect_tar(
-                    std::fs::File::open(tar).unwrap(),
-                    asset.member_policy(),
-                )
-            } else {
-                crate::tinytex_archive::inspect_archive(&path, asset.format, asset.member_policy())
-            };
-            result.unwrap_or_else(|error| panic!("{name}: {error}"));
-            verified.push(name.to_string());
-        }
-        assert_eq!(verified.len(), 4, "expected all four platform archives");
     }
 
     #[test]

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -46,14 +46,6 @@ fn find_latexmk() -> Option<String> {
     crate::tex_distro::find_tex_tool("latexmk").map(|p| p.to_string_lossy().into_owned())
 }
 
-fn exe(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
-    } else {
-        name.to_string()
-    }
-}
-
 const TEX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const TLMGR_INFO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
 const TLMGR_MUTATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15 * 60);
@@ -287,8 +279,7 @@ fn utility_error(output: &TexUtilityOutput) -> String {
 fn find_in_texdir(root: &Path, name: &str) -> Option<PathBuf> {
     crate::tex_distro::texdir_bin_dirs(root)
         .into_iter()
-        .map(|bin| bin.join(exe(name)))
-        .find(|candidate| candidate.is_file())
+        .find_map(|bin| crate::tex_distro::find_tool_in_dir(&bin, name))
 }
 
 /// Our own TinyTeX install root: `~/.oleafly/tinytex`.
@@ -313,8 +304,7 @@ fn legacy_tinytex_download_path() -> Result<PathBuf, String> {
 }
 
 fn sibling_tool(tool: &Path, name: &str) -> Option<PathBuf> {
-    let candidate = tool.parent()?.join(exe(name));
-    candidate.is_file().then_some(candidate)
+    crate::tex_distro::find_tool_in_dir(tool.parent()?, name)
 }
 
 fn engine_kind_for_path(lualatex: &Path, managed_root: Option<&Path>) -> &'static str {

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -2349,6 +2349,66 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "downloads are large; run manually against local archives when bumping TINYTEX_TAG"]
+    fn pinned_release_archives_pass_reviewed_policies() {
+        use sha2::Digest as _;
+        use std::io::Read as _;
+
+        let dir = std::env::var("TINYTEX_ARCHIVE_DIR").expect(
+            "set TINYTEX_ARCHIVE_DIR to a directory holding the release archives for every platform",
+        );
+        let mut verified = Vec::new();
+        for (os, arch) in [
+            ("macos", "aarch64"),
+            ("windows", "x86_64"),
+            ("linux", "x86_64"),
+            ("linux", "aarch64"),
+        ] {
+            let asset = tinytex_asset_for(os, arch).unwrap();
+            let name = asset.url.rsplit('/').next().unwrap();
+            let path = std::path::Path::new(&dir).join(name);
+            assert!(path.is_file(), "missing archive {name} in {dir}");
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().len(),
+                asset.expected_bytes,
+                "{name}: size does not match the pinned release"
+            );
+            let mut hasher = sha2::Sha256::new();
+            let mut file = std::fs::File::open(&path).unwrap();
+            let mut buffer = vec![0u8; 1 << 20];
+            loop {
+                let read = file.read(&mut buffer).unwrap();
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+            assert_eq!(
+                format!("{:x}", hasher.finalize()),
+                asset.expected_sha256,
+                "{name}: sha256 does not match the pinned release"
+            );
+            let result = if asset.format == ArchiveFormat::TarXz && !cfg!(target_os = "linux") {
+                let tar = path.with_extension("").with_extension("tar");
+                assert!(
+                    tar.is_file(),
+                    "this host cannot decode xz; place the decompressed {} next to the archive",
+                    tar.file_name().unwrap().to_string_lossy()
+                );
+                crate::tinytex_archive::inspect_tar(
+                    std::fs::File::open(tar).unwrap(),
+                    asset.member_policy(),
+                )
+            } else {
+                crate::tinytex_archive::inspect_archive(&path, asset.format, asset.member_policy())
+            };
+            result.unwrap_or_else(|error| panic!("{name}: {error}"));
+            verified.push(name.to_string());
+        }
+        assert_eq!(verified.len(), 4, "expected all four platform archives");
+    }
+
+    #[test]
     fn parse_tlmgr_versions_reads_name_and_cat_version() {
         let out = "amsmath,2.17o\nbiblatex,3.20\nlatexmk,4.86a\n";
         let map = parse_tlmgr_versions(out);

--- a/src-tauri/src/latex_engine/tests/release_archives.rs
+++ b/src-tauri/src/latex_engine/tests/release_archives.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[test]
+#[ignore = "downloads are large; run manually against local archives when bumping TINYTEX_TAG"]
+fn pinned_release_archives_pass_reviewed_policies() {
+    use sha2::Digest as _;
+    use std::io::Read as _;
+
+    let dir = std::env::var("TINYTEX_ARCHIVE_DIR").expect(
+        "set TINYTEX_ARCHIVE_DIR to a directory holding the release archives for every platform",
+    );
+    let mut verified = Vec::new();
+    for (os, arch) in [
+        ("macos", "aarch64"),
+        ("windows", "x86_64"),
+        ("linux", "x86_64"),
+        ("linux", "aarch64"),
+    ] {
+        let asset = tinytex_asset_for(os, arch).unwrap();
+        let name = asset.url.rsplit('/').next().unwrap();
+        let path = std::path::Path::new(&dir).join(name);
+        assert!(path.is_file(), "missing archive {name} in {dir}");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().len(),
+            asset.expected_bytes,
+            "{name}: size does not match the pinned release"
+        );
+        let mut hasher = sha2::Sha256::new();
+        let mut file = std::fs::File::open(&path).unwrap();
+        let mut buffer = vec![0u8; 1 << 20];
+        loop {
+            let read = file.read(&mut buffer).unwrap();
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        assert_eq!(
+            format!("{:x}", hasher.finalize()),
+            asset.expected_sha256,
+            "{name}: sha256 does not match the pinned release"
+        );
+        let result = if asset.format == ArchiveFormat::TarXz && !cfg!(target_os = "linux") {
+            let tar = path.with_extension("").with_extension("tar");
+            assert!(
+                tar.is_file(),
+                "this host cannot decode xz; place the decompressed {} next to the archive",
+                tar.file_name().unwrap().to_string_lossy()
+            );
+            crate::tinytex_archive::inspect_tar(
+                std::fs::File::open(tar).unwrap(),
+                asset.member_policy(),
+            )
+        } else {
+            crate::tinytex_archive::inspect_archive(&path, asset.format, asset.member_policy())
+        };
+        result.unwrap_or_else(|error| panic!("{name}: {error}"));
+        verified.push(name.to_string());
+    }
+    assert_eq!(verified.len(), 4, "expected all four platform archives");
+}

--- a/src-tauri/src/tex_distro.rs
+++ b/src-tauri/src/tex_distro.rs
@@ -16,6 +16,29 @@ pub fn exe(name: &str) -> String {
     }
 }
 
+/// File names a TeX tool may resolve to, best-first. TeX Live on Windows
+/// ships most tools as `.exe` wrappers but installs `tlmgr` as `tlmgr.bat`,
+/// so `.exe`-only lookups miss it and TinyTeX validation fails with "no
+/// host-compatible tlmgr binary".
+fn tool_file_names(name: &str) -> Vec<String> {
+    tool_file_names_for(cfg!(windows), name)
+}
+
+fn tool_file_names_for(windows: bool, name: &str) -> Vec<String> {
+    if windows {
+        vec![format!("{name}.exe"), format!("{name}.bat")]
+    } else {
+        vec![name.to_string()]
+    }
+}
+
+pub(crate) fn find_tool_in_dir(dir: &Path, name: &str) -> Option<PathBuf> {
+    tool_file_names(name)
+        .into_iter()
+        .map(|file| dir.join(file))
+        .find(|candidate| candidate.is_file())
+}
+
 /// TeX binary directories to probe, best-first: full system installs (MacTeX,
 /// TeX Live by year, MiKTeX), then Oleafly's managed TinyTeX, then generic
 /// locations. A complete system distribution must outrank the compact TinyTeX:
@@ -154,7 +177,7 @@ fn compose_tex_bin_dirs(
 fn bin_dir_has_tex(dir: &Path) -> bool {
     ["latexmk", "tlmgr", "pdflatex", "xelatex", "lualatex"]
         .into_iter()
-        .any(|tool| dir.join(exe(tool)).is_file())
+        .any(|tool| find_tool_in_dir(dir, tool).is_some())
 }
 
 fn bin_dir_has_complete_tex(dir: &Path) -> bool {
@@ -167,7 +190,7 @@ fn bin_dir_has_complete_tex(dir: &Path) -> bool {
         "biber",
     ]
     .into_iter()
-    .all(|tool| dir.join(exe(tool)).is_file())
+    .all(|tool| find_tool_in_dir(dir, tool).is_some())
 }
 
 fn bin_dir_is_tinytex(dir: &Path) -> bool {
@@ -176,7 +199,8 @@ fn bin_dir_is_tinytex(dir: &Path) -> bool {
     }
     ["latexmk", "tlmgr", "pdflatex", "xelatex", "lualatex"]
         .into_iter()
-        .filter_map(|tool| std::fs::canonicalize(dir.join(exe(tool))).ok())
+        .filter_map(|tool| find_tool_in_dir(dir, tool))
+        .filter_map(|tool| std::fs::canonicalize(tool).ok())
         .any(|tool| named_tinytex_root(&tool).is_some())
 }
 
@@ -185,11 +209,12 @@ where
     I: IntoIterator<Item = P>,
     P: AsRef<Path>,
 {
-    let file = exe(name);
     let mut candidates = Vec::new();
     for dir in dirs {
-        let candidate = dir.as_ref().join(&file);
-        if candidate.is_file() && !candidates.contains(&candidate) {
+        let Some(candidate) = find_tool_in_dir(dir.as_ref(), name) else {
+            continue;
+        };
+        if !candidates.contains(&candidate) {
             candidates.push(candidate);
         }
     }
@@ -201,10 +226,8 @@ where
     I: IntoIterator<Item = P>,
     P: AsRef<Path>,
 {
-    let file = exe(name);
     dirs.into_iter()
-        .map(|dir| dir.as_ref().join(&file))
-        .find(|candidate| candidate.is_file())
+        .find_map(|dir| find_tool_in_dir(dir.as_ref(), name))
 }
 
 /// One detected TeX distribution, for the Settings "Manage TeX distributions"
@@ -256,23 +279,19 @@ pub fn list_distributions() -> Vec<TexDistribution> {
 
 fn distribution_for_bin_dir(dir: &Path) -> Option<TexDistribution> {
     let (kind, root) = classify_bin_dir(dir);
-    let latexmk = dir.join(exe("latexmk"));
-    let tlmgr = dir.join(exe("tlmgr"));
-    let has_tex = latexmk.is_file()
-        || tlmgr.is_file()
-        || dir.join(exe("pdflatex")).is_file()
-        || dir.join(exe("xelatex")).is_file()
-        || dir.join(exe("lualatex")).is_file();
+    let latexmk = find_tool_in_dir(dir, "latexmk");
+    let tlmgr = find_tool_in_dir(dir, "tlmgr");
+    let has_tex = latexmk.is_some()
+        || tlmgr.is_some()
+        || find_tool_in_dir(dir, "pdflatex").is_some()
+        || find_tool_in_dir(dir, "xelatex").is_some()
+        || find_tool_in_dir(dir, "lualatex").is_some();
     has_tex.then(|| TexDistribution {
         label: label_for(&kind, &root),
         kind,
         bin_dir: dir.to_string_lossy().into_owned(),
-        latexmk: latexmk
-            .is_file()
-            .then(|| latexmk.to_string_lossy().into_owned()),
-        tlmgr: tlmgr
-            .is_file()
-            .then(|| tlmgr.to_string_lossy().into_owned()),
+        latexmk: latexmk.map(|tool| tool.to_string_lossy().into_owned()),
+        tlmgr: tlmgr.map(|tool| tool.to_string_lossy().into_owned()),
     })
 }
 
@@ -550,6 +569,38 @@ mod tests {
             assert_eq!(exe("latexmk"), "latexmk.exe");
         } else {
             assert_eq!(exe("latexmk"), "latexmk");
+        }
+    }
+
+    #[test]
+    fn windows_tool_names_include_bat_fallback() {
+        assert_eq!(
+            tool_file_names_for(true, "tlmgr"),
+            vec!["tlmgr.exe".to_string(), "tlmgr.bat".to_string()]
+        );
+        assert_eq!(
+            tool_file_names_for(false, "tlmgr"),
+            vec!["tlmgr".to_string()]
+        );
+    }
+
+    #[test]
+    fn find_tool_in_dir_resolves_windows_bat_scripts() {
+        let directory = tempfile::tempdir().unwrap();
+        let dir = directory.path();
+        std::fs::write(dir.join("tlmgr.bat"), b"@echo off").unwrap();
+        std::fs::write(dir.join(exe("latexmk")), b"tool").unwrap();
+
+        assert_eq!(
+            find_tool_in_dir(dir, "latexmk"),
+            Some(dir.join(exe("latexmk")))
+        );
+        if cfg!(windows) {
+            assert_eq!(find_tool_in_dir(dir, "tlmgr"), Some(dir.join("tlmgr.bat")));
+            std::fs::write(dir.join("tlmgr.exe"), b"tool").unwrap();
+            assert_eq!(find_tool_in_dir(dir, "tlmgr"), Some(dir.join("tlmgr.exe")));
+        } else {
+            assert_eq!(find_tool_in_dir(dir, "tlmgr"), None);
         }
     }
 

--- a/src-tauri/src/tinytex_archive.rs
+++ b/src-tauri/src/tinytex_archive.rs
@@ -116,8 +116,18 @@ impl<'a> ArchiveManifest<'a> {
     }
 }
 
-fn validate_tar_mode(path: &Path, mode: u32) -> Result<(), String> {
-    if mode & 0o7000 != 0 || mode & 0o002 != 0 {
+fn validate_tar_mode(
+    path: &Path,
+    mode: u32,
+    is_directory: bool,
+    is_symlink: bool,
+) -> Result<(), String> {
+    if is_symlink {
+        return Ok(());
+    }
+    let has_privilege_bits = mode & 0o6000 != 0;
+    let has_non_directory_sticky_bit = mode & 0o1000 != 0 && !is_directory;
+    if has_privilege_bits || has_non_directory_sticky_bit || mode & 0o002 != 0 {
         return Err(format!(
             "TinyTeX archive member {} has unsafe permissions.",
             path.display()
@@ -126,7 +136,7 @@ fn validate_tar_mode(path: &Path, mode: u32) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_zip_member_mode(path: &Path, mode: u32) -> Result<(), String> {
+fn validate_zip_member_mode(path: &Path, mode: u32, is_directory: bool) -> Result<(), String> {
     let file_type = mode & 0o170000;
     if file_type == 0o120000 {
         return Err("TinyTeX ZIP contains an unsupported symbolic link.".into());
@@ -137,7 +147,7 @@ fn validate_zip_member_mode(path: &Path, mode: u32) -> Result<(), String> {
             path.display()
         ));
     }
-    validate_tar_mode(path, mode)
+    validate_tar_mode(path, mode, is_directory, false)
 }
 
 fn validated_archive_path(path: &Path) -> Result<String, String> {
@@ -199,7 +209,12 @@ pub(crate) fn inspect_tar<R: std::io::Read>(
         let mut entry = entry.map_err(|e| e.to_string())?;
         let (kind, link_target) = tar_member_kind(&mut entry)?;
         let path = entry.path().map_err(|e| e.to_string())?.into_owned();
-        validate_tar_mode(&path, entry.header().mode().map_err(|e| e.to_string())?)?;
+        validate_tar_mode(
+            &path,
+            entry.header().mode().map_err(|e| e.to_string())?,
+            entry.header().entry_type().is_dir(),
+            entry.header().entry_type().is_symlink(),
+        )?;
         manifest.record(kind, &path, entry.size(), link_target.as_deref())?;
     }
     manifest.finish()
@@ -247,7 +262,12 @@ fn validate_tar_entry<R: std::io::Read>(
 ) -> Result<std::path::PathBuf, String> {
     let path = entry.path().map_err(|e| e.to_string())?.into_owned();
     validated_archive_path(&path)?;
-    validate_tar_mode(&path, entry.header().mode().map_err(|e| e.to_string())?)?;
+    validate_tar_mode(
+        &path,
+        entry.header().mode().map_err(|e| e.to_string())?,
+        entry.header().entry_type().is_dir(),
+        entry.header().entry_type().is_symlink(),
+    )?;
     if entry.header().entry_type().is_symlink() {
         let target = entry
             .link_name()
@@ -294,7 +314,7 @@ fn inspect_zip(file: std::fs::File, policy: ArchiveMemberPolicy<'_>) -> Result<(
             .ok_or_else(|| "TinyTeX archive contains an unsafe member path.".to_string())?;
         let kind = if entry.is_dir() { "directory" } else { "file" };
         if let Some(mode) = entry.unix_mode() {
-            validate_zip_member_mode(&path, mode)?;
+            validate_zip_member_mode(&path, mode, entry.is_dir())?;
         }
         manifest.record(kind, &path, entry.size(), None)?;
     }
@@ -371,6 +391,24 @@ mod tests {
     use super::*;
     use std::io::Write as _;
 
+    fn manifest_digest(entries: &[(&str, &str, u64, Option<&str>)]) -> String {
+        use sha2::Digest as _;
+
+        let mut hasher = sha2::Sha256::new();
+        for (kind, path, size, link_target) in entries {
+            hasher.update(kind.as_bytes());
+            hasher.update([0]);
+            hasher.update(path.as_bytes());
+            hasher.update([0]);
+            hasher.update(size.to_le_bytes());
+            if let Some(target) = link_target {
+                hasher.update(target.as_bytes());
+            }
+            hasher.update([0]);
+        }
+        format!("{:x}", hasher.finalize())
+    }
+
     fn policy() -> ArchiveMemberPolicy<'static> {
         ArchiveMemberPolicy {
             members: 1,
@@ -418,9 +456,79 @@ mod tests {
 
     #[test]
     fn unsafe_archive_permissions_are_rejected() {
-        assert!(validate_tar_mode(Path::new("TinyTeX/file"), 0o755).is_ok());
-        assert!(validate_tar_mode(Path::new("TinyTeX/file"), 0o4755).is_err());
-        assert!(validate_tar_mode(Path::new("TinyTeX/file"), 0o777).is_err());
+        let path = Path::new("TinyTeX/member");
+        assert!(validate_tar_mode(path, 0o755, false, false).is_ok());
+        assert!(validate_tar_mode(path, 0o1755, false, false).is_err());
+        assert!(validate_tar_mode(path, 0o1755, true, false).is_ok());
+        assert!(validate_tar_mode(path, 0o2755, true, false).is_err());
+        assert!(validate_tar_mode(path, 0o4755, true, false).is_err());
+        assert!(validate_tar_mode(path, 0o1757, true, false).is_err());
+        assert!(validate_tar_mode(path, 0o777, false, false).is_err());
+        assert!(validate_tar_mode(path, 0o777, false, true).is_ok());
+    }
+
+    #[test]
+    fn sticky_directory_permissions_are_accepted() {
+        let path = "TinyTeX/texmf-var/fonts/pk/ljfour/";
+        let mut writer = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o1755);
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_cksum();
+        writer.append_data(&mut header, path, &[][..]).unwrap();
+        let tar = writer.into_inner().unwrap();
+        let digest = manifest_digest(&[("directory", path, 0, None)]);
+        let policy = ArchiveMemberPolicy {
+            members: 1,
+            expanded_bytes: 0,
+            manifest_sha256: &digest,
+        };
+
+        inspect_tar(std::io::Cursor::new(&tar), policy).unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        extract_tar(std::io::Cursor::new(&tar), destination.path()).unwrap();
+        let extracted = destination.path().join(path);
+        assert!(extracted.is_dir());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(extracted).unwrap().permissions().mode() & 0o7000,
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn world_writable_symlink_modes_are_accepted() {
+        let link = "TinyTeX/bin/x86_64-linux/texhash";
+        let mut writer = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o777);
+        header.set_entry_type(tar::EntryType::Symlink);
+        writer.append_link(&mut header, link, "mktexlsr").unwrap();
+        let tar = writer.into_inner().unwrap();
+        let digest = manifest_digest(&[("symlink", link, 0, Some("mktexlsr"))]);
+        let policy = ArchiveMemberPolicy {
+            members: 1,
+            expanded_bytes: 0,
+            manifest_sha256: &digest,
+        };
+
+        inspect_tar(std::io::Cursor::new(&tar), policy).unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        extract_tar(std::io::Cursor::new(&tar), destination.path()).unwrap();
+        assert!(destination
+            .path()
+            .join(link)
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes: https://github.com/Oleafly/Oleafly/issues/94

TinyTeX downloads could finish, pass checksum verification, and then fail during archive inspection.

The pinned archives contain two kinds of normal metadata that our blanket permission check rejected: PK font cache directories packed as `1755`, and Linux symlinks recorded as `0777`. Windows had a separate problem. TeX Live ships `tlmgr` as `tlmgr.bat`, but tool discovery only checked for an `.exe`.

The validator now handles the actual archive member type. It permits a sticky bit on directories and ignores symlink modes. Setuid and setgid entries, sticky regular files, and world-writable files or directories are still rejected. Extraction continues to strip special permission bits before anything is written.

Windows tool lookup now tries `.exe` first and `.bat` second. The same resolver is used for distribution detection and sibling-tool discovery.

## Release archive check

The new ignored test checks the four pinned v2026.08 assets against their exact size, SHA-256, and reviewed member manifest. It covers macOS arm64, Windows x86_64, and both Linux architectures. The test does not download anything; it reads archives supplied through `TINYTEX_ARCHIVE_DIR`.

All four release archives pass the check with this change.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `pinned_release_archives_pass_reviewed_policies` against all four v2026.08 release archives

<img width="1967" height="1510" alt="image" src="https://github.com/user-attachments/assets/3a465e2d-3fd7-4ded-93e3-f64e7f3efa20" />

