### PR TITLE
chore: release v0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12] - 2026-08-25
+
+### Fixed
+
+- TinyTeX setup accepts the safe directory and symlink permissions in the
+  pinned release archives. On Windows it also finds TeX Live's `tlmgr.bat`, so
+  a finished download no longer falls back into the resume loop.
+
 ## [0.3.11] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "oleafly"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "atomicwrites",
  "axum",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oleafly",
   "private": true,
-  "version": "0.3.11",
+  "version": "0.3.12",
   "type": "module",
   "packageManager": "pnpm@11.9.0",
   "engines": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oleafly"
-version = "0.3.11"
+version = "0.3.12"
 description = "Oleafly - the intelligent research workspace, free, local-first, 100% open source"
 authors = ["Prajwal Murthy and contributors"]
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Oleafly",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "identifier": "com.oleafly.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Prepare v0.3.12 after the TinyTeX archive fix landed on a green `main`.

This adds the 0.3.12 changelog entry and updates the package, Tauri, Cargo, and lockfile versions together.

## Testing

- `./scripts/changelog-extract.sh v0.3.12`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
