### PR TITLE
docs: close Arabic README RTL wrapper

### DIFF
--- a/docs/readme-translations/README.ar.md
+++ b/docs/readme-translations/README.ar.md
@@ -341,3 +341,5 @@ _ملاحظة:_ تُنفّذ الأوامر نسبةً إلى المسار ال�
 [Hunspell](https://hunspell.github.io/).
 
 يخضع Oleafly لترخيص [AGPL-3.0-or-later](../../LICENSE). وتتوفر إشعارات الأطراف الخارجية في ملف [THIRD_PARTY_LICENSES.md](../../THIRD_PARTY_LICENSES.md).
+
+</div>


### PR DESCRIPTION
Closes the RTL wrapper in the Arabic README. The missing tag left the document HTML unbalanced.

Checks:
- Compared headings, code fences, and image URLs with the English README.
- Resolved every relative link and confirmed that the HTML tags balance.