### PR TITLE
fix(editor): keep the caret in the editor when toolbar buttons are clicked

### DIFF
--- a/e2e/tests/52-editor-workflows-semantics.spec.ts
+++ b/e2e/tests/52-editor-workflows-semantics.spec.ts
@@ -903,22 +903,42 @@ WYSRAWANCHOR
   );
   await rawAction('[aria-label="Insert footnote"]', "Insert footnote");
 
-  await atAnchor();
-  await clickToolbarControl(
-    tauriPage,
-    '[aria-label="Cite from project"]',
-    "Cite from project",
-  );
-  await clickPortalButton(
-    tauriPage,
-    `candidate.textContent?.trim() === "Find and add a new citation…"`,
-    "Find and add a new citation",
-  );
-  await expect(
-    tauriPage.locator(
-      'input[placeholder="DOI, arXiv id, URL, or a paper title…"]',
-    ),
-  ).toBeVisible({ timeout: 5_000 });
+  // Same headless-webview flake rawHeading guards against: the click that
+  // should open the toolbar menu is sometimes lost, and the failure reports
+  // `portals=[]` because no popper wrapper ever entered the DOM. The item
+  // click and the dialog it opens are inside the retry too, so a lost click
+  // at any of the three steps costs an attempt rather than the run.
+  let citationError: unknown;
+  let citationDialogOpen = false;
+  for (let attempt = 0; attempt < 4 && !citationDialogOpen; attempt++) {
+    await tauriPage.press("body", "Escape").catch(() => {});
+    await atAnchor();
+    await clickToolbarControl(
+      tauriPage,
+      '[aria-label="Cite from project"]',
+      "Cite from project",
+    );
+    try {
+      await clickPortalButton(
+        tauriPage,
+        `candidate.textContent?.trim() === "Find and add a new citation…"`,
+        "Find and add a new citation",
+      );
+      await expect(
+        tauriPage.locator(
+          'input[placeholder="DOI, arXiv id, URL, or a paper title…"]',
+        ),
+      ).toBeVisible({ timeout: 5_000 });
+      citationDialogOpen = true;
+    } catch (error) {
+      citationError = error;
+    }
+  }
+  if (!citationDialogOpen) {
+    throw citationError instanceof Error
+      ? citationError
+      : new Error("citation search dialog never opened");
+  }
   const citation = await tauriPage.evaluate<{ key?: string; error?: string }>(
     `Promise.all([
       import("/src/features/citation.ts"),

--- a/e2e/tests/71-toolbar-focus.spec.ts
+++ b/e2e/tests/71-toolbar-focus.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures";
 import {
+  compileAndWait,
   editorSource,
   openProject,
   readProjectText,
@@ -22,13 +23,23 @@ const COMPILE_REVISION = `(() => {
   return Number(button?.dataset.e2eCompileRevision ?? "0");
 })()`;
 
+const COMPILE_BUTTON_ENABLED = `(() => {
+  const button = document.querySelector('[data-testid="compile-button"]');
+  return button instanceof HTMLButtonElement && !button.disabled;
+})()`;
+
 // Chromium (WebView2 on Windows) focuses a <button> on mousedown unless the
 // page prevents the default; WebKit (macOS, Linux) never focuses one. Driving
 // both halves here makes the guard mean the same thing on every runner.
+//
+// React does not run onMouseDown on a disabled button, so a disabled control
+// looks exactly like an unguarded one. It reports itself rather than silently
+// failing as "took-focus".
 function chromiumStyleClick(selector: string): string {
   return `(() => {
     const button = document.querySelector(${JSON.stringify(selector)});
     if (!(button instanceof HTMLElement)) return "missing";
+    if ("disabled" in button && button.disabled) return "disabled";
     const focusable = button.dispatchEvent(
       new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
     );
@@ -56,9 +67,13 @@ function pressUndo(page: Page, mod: "ctrl" | "meta") {
   })()`);
 }
 
+// Opening a project in split view auto-compiles, which disables the compile
+// button. Drive that build to completion before touching anything, otherwise
+// the click lands on a disabled control.
 async function openWithCaretInEditor(page: Page) {
   await openProject(page, "E2E Doc");
   await waitEditorShowsFile(page, "main.tex");
+  await compileAndWait(page, 240_000);
   await page.evaluate(
     `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) => {
       getEditorView()?.focus();
@@ -88,6 +103,7 @@ test("compiling from the toolbar leaves keyboard undo reachable", async ({ tauri
   expect(await editorSource(tauriPage)).not.toBe(baseline);
   expect(await tauriPage.evaluate<boolean>(FOCUS_IS_IN_EDITOR)).toBe(true);
 
+  await waitLong(tauriPage, COMPILE_BUTTON_ENABLED, 240_000);
   const revisionBefore = await tauriPage.evaluate<number>(COMPILE_REVISION);
   expect(
     await tauriPage.evaluate<string>(

--- a/e2e/tests/71-toolbar-focus.spec.ts
+++ b/e2e/tests/71-toolbar-focus.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from "../fixtures";
+import {
+  editorSource,
+  openProject,
+  readProjectText,
+  typeInEditorAtStart,
+  waitEditorShowsFile,
+  waitLong,
+} from "../helpers";
+
+type Page = Parameters<typeof openProject>[0];
+
+const PROBE_LINE = "% toolbar-focus-probe\n";
+
+const FOCUS_IS_IN_EDITOR = `(() => {
+  const el = document.activeElement;
+  return !!(el && el.closest && el.closest(".cm-editor"));
+})()`;
+
+const COMPILE_REVISION = `(() => {
+  const button = document.querySelector('[data-testid="compile-button"]');
+  return Number(button?.dataset.e2eCompileRevision ?? "0");
+})()`;
+
+// Chromium (WebView2 on Windows) focuses a <button> on mousedown unless the
+// page prevents the default; WebKit (macOS, Linux) never focuses one. Driving
+// both halves here makes the guard mean the same thing on every runner.
+function chromiumStyleClick(selector: string): string {
+  return `(() => {
+    const button = document.querySelector(${JSON.stringify(selector)});
+    if (!(button instanceof HTMLElement)) return "missing";
+    const focusable = button.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
+    if (focusable) button.focus();
+    button.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    button.click();
+    return focusable ? "took-focus" : "kept-focus";
+  })()`;
+}
+
+function pressUndo(page: Page, mod: "ctrl" | "meta") {
+  return page.evaluate<boolean>(`(() => {
+    const target = document.activeElement ?? document.body;
+    return target.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "z",
+      code: "KeyZ",
+      keyCode: 90,
+      which: 90,
+      ctrlKey: ${mod === "ctrl"},
+      metaKey: ${mod === "meta"},
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }));
+  })()`);
+}
+
+async function openWithCaretInEditor(page: Page) {
+  await openProject(page, "E2E Doc");
+  await waitEditorShowsFile(page, "main.tex");
+  await page.evaluate(
+    `import("/src/components/editor/cm/controller.ts").then(({ getEditorView }) => {
+      getEditorView()?.focus();
+      return true;
+    })`,
+  );
+  await waitLong(page, FOCUS_IS_IN_EDITOR, 15_000);
+}
+
+async function restoreMainDoc(page: Page, baseline: string) {
+  await page.evaluate(
+    `import("/src/store/files.ts").then(({ useFilesStore }) => useFilesStore.getState().saveActive())`,
+  );
+  await waitLong(
+    page,
+    `import("/src/store/files.ts").then(({ useFilesStore }) => !useFilesStore.getState().files["main.tex"]?.dirty)`,
+    20_000,
+  );
+  expect(await readProjectText(page, "main.tex")).toBe(baseline);
+}
+
+test("compiling from the toolbar leaves keyboard undo reachable", async ({ tauriPage }) => {
+  await openWithCaretInEditor(tauriPage);
+
+  const baseline = await editorSource(tauriPage);
+  await typeInEditorAtStart(tauriPage, PROBE_LINE);
+  expect(await editorSource(tauriPage)).not.toBe(baseline);
+  expect(await tauriPage.evaluate<boolean>(FOCUS_IS_IN_EDITOR)).toBe(true);
+
+  const revisionBefore = await tauriPage.evaluate<number>(COMPILE_REVISION);
+  expect(
+    await tauriPage.evaluate<string>(
+      chromiumStyleClick('[data-testid="compile-button"]'),
+    ),
+  ).toBe("kept-focus");
+
+  // The compile button disables itself while the build runs, and a disabled
+  // element that holds focus hands it to <body>. Undo lives only in
+  // CodeMirror's keymap, so the caret has to survive the whole compile.
+  await waitLong(tauriPage, `${COMPILE_REVISION} > ${revisionBefore}`, 240_000);
+  expect(await tauriPage.evaluate<boolean>(FOCUS_IS_IN_EDITOR)).toBe(true);
+
+  await pressUndo(tauriPage, "meta");
+  await pressUndo(tauriPage, "ctrl");
+  expect(await editorSource(tauriPage)).toBe(baseline);
+
+  await restoreMainDoc(tauriPage, baseline);
+});
+
+test("editor toolbar buttons keep the caret in the editor", async ({ tauriPage }) => {
+  await openWithCaretInEditor(tauriPage);
+
+  const baseline = await editorSource(tauriPage);
+  await typeInEditorAtStart(tauriPage, PROBE_LINE);
+  expect(await editorSource(tauriPage)).not.toBe(baseline);
+
+  expect(
+    await tauriPage.evaluate<string>(
+      chromiumStyleClick('[data-testid="editor-toolbar"] [aria-label^="Undo"]'),
+    ),
+  ).toBe("kept-focus");
+  expect(await tauriPage.evaluate<boolean>(FOCUS_IS_IN_EDITOR)).toBe(true);
+  expect(await editorSource(tauriPage)).toBe(baseline);
+
+  await restoreMainDoc(tauriPage, baseline);
+});

--- a/src/components/editor/EditorToolbar.test.tsx
+++ b/src/components/editor/EditorToolbar.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@/components/editor/project-info-data", () => ({
   collectProjectInfo: collectProjectInfoMock,
 }));
 
-import { EditorToolbar } from "./EditorToolbar";
+import { EditorToolbar, IconBtn } from "./EditorToolbar";
 
 class ResizeObserverStub {
   observe() {}
@@ -152,5 +152,28 @@ describe("EditorToolbar wysiwyg toggle", () => {
 
     await waitFor(() => expect(screen.getByText("Words")).toBeInTheDocument());
     expect(screen.getAllByText("0").length).toBeGreaterThan(1);
+  });
+});
+
+describe("EditorToolbar focus", () => {
+  it("keeps the caret where it was when a toolbar button is pressed", () => {
+    const onClick = vi.fn();
+    render(
+      <IconBtn onClick={onClick} title="Undo probe">
+        <span>undo</span>
+      </IconBtn>,
+    );
+    const button = screen.getByLabelText("Undo probe");
+
+    expect(fireEvent.mouseDown(button)).toBe(false);
+    expect(onClick).not.toHaveBeenCalled();
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels the toolbar so focus assertions can scope to it", () => {
+    render(<EditorToolbar wysiwyg={false} onToggleWysiwyg={vi.fn()} />);
+    expect(screen.getByTestId("editor-toolbar")).toBeInTheDocument();
   });
 });

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -111,6 +111,7 @@ export function IconBtn({
     <Tooltip label={title} side="bottom">
       <button
         type="button"
+        onMouseDown={(e) => e.preventDefault()}
         onClick={onClick}
         aria-label={title}
         data-tour={dataTour}
@@ -436,7 +437,7 @@ export function EditorToolbar({
   const overflowControls = controls.slice(visibleCount);
 
   return (
-    <div className="flex h-9 items-center gap-0.5 border-b px-2">
+    <div data-testid="editor-toolbar" className="flex h-9 items-center gap-0.5 border-b px-2">
       {showVisualToggle && (
         <>
           <WysiwygModeSwitch

--- a/src/components/layout/CompileControls.test.tsx
+++ b/src/components/layout/CompileControls.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCompileStore } from "@/store/compile";
+import { useFilesStore } from "@/store/files";
+
+import { CompileControls } from "./CompileControls";
+
+describe("compile button focus", () => {
+  beforeEach(() => {
+    useFilesStore.setState({ engineLoaded: true });
+    useCompileStore.setState({ status: "idle" });
+  });
+
+  it("keeps the caret where it was when Compile is pressed", () => {
+    const recompile = vi.fn();
+    useCompileStore.setState({ recompile });
+    render(<CompileControls />);
+    const button = screen.getByTestId("compile-button");
+
+    const accepted = fireEvent.mouseDown(button);
+
+    expect(accepted).toBe(false);
+    expect(recompile).not.toHaveBeenCalled();
+
+    fireEvent.click(button);
+    expect(recompile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/layout/CompileControls.tsx
+++ b/src/components/layout/CompileControls.tsx
@@ -142,6 +142,7 @@ export function CompileControls() {
           "rounded-r-none",
         )}
         disabled={compiling || !engineLoaded}
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => {
           // If the PDF pane is hidden (editor-only), reveal it so the result shows.
           if (viewMode === "editor") setViewMode("split");


### PR DESCRIPTION
Fixes #101: on Windows, Ctrl+Z stops working after you compile.

The undo history is not gone. Focus is. That took a while to pin down, because everything about the symptom points at the editor state and none of it is the editor state.

## What happens

Chromium focuses a `<button>` on mousedown. WebKit doesn't, which is the macOS and Linux convention. On Windows the webview is WebView2, so clicking Compile moves DOM focus out of CodeMirror and onto the compile button.

That button sets `disabled` while the build runs (`CompileControls.tsx:144`). A focused element that becomes disabled hands focus to `<body>`, and nothing ever gives it back.

Undo and redo only exist in CodeMirror's keymap, and that fires when focus is inside the editor. There's no global undo binding anywhere in the app. So after a compile the shortcut lands on nothing, and the edit looks unrecoverable.

## Evidence

Measured against the real app through the e2e bridge, driving both halves of the mousedown difference so the Windows path is reproducible on any runner:

| | before | after |
| --- | --- | --- |
| click outcome | `took-focus` | `kept-focus` |
| activeElement after click | `BUTTON compile-button` | `.cm-content` |
| activeElement after compile | `BODY` | `.cm-content` |
| Ctrl/Cmd+Z restores the edit | no | yes |

Calling `editorUndo()` after the compile restored the document byte for byte, which is what proves the history survived. I also checked the obvious suspects and cleared them: `docVersion` never moves during a compile, the editor is never remounted, and nothing in the files store rewrites the buffer. None of the reload machinery is involved.

## The change

`onMouseDown={(e) => e.preventDefault()}` on the compile button and on `IconBtn`.

`IconBtn` backs every button in the LaTeX and Markdown toolbars, so this picks up the wider version of the same bug. Clicking Bold or Undo on Windows took focus too, which killed whatever you typed next. Tab and keyboard focus are untouched.

## Testing

`e2e/tests/71-toolbar-focus.spec.ts` dispatches a cancelable mousedown, focuses the button only if the page lets it, then asserts the caret is still in the editor after a full compile and that Ctrl+Z restores the edit.

- with the fix: 3/3 green
- with the guards reverted: 2/2 red, both tests

`pnpm lint`, `pnpm build` and `pnpm test` (2122 passing) are green. No Rust changes.
