### PR TITLE
feat: type at the click point in the compiled PDF preview

### DIFF
--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./controller": "./src/controller.ts",
-    "./polyfills": "./src/polyfills.ts"
+    "./polyfills": "./src/polyfills.ts",
+    "./typingEcho": "./src/typingEcho.ts"
   },
   "dependencies": {
     "pdfjs-dist": "6.2.108",

--- a/packages/preview/src/PdfViewer.tsx
+++ b/packages/preview/src/PdfViewer.tsx
@@ -40,7 +40,8 @@ import {
 } from "./pdfSearch";
 import { safePdfExternalUrl } from "./pdfSecurity";
 import { createPdfScreenReaderLayer } from "./pdfScreenReader";
-import { closestMatchingElement, wordAtHorizontalPosition, wordInText } from "./textHit";
+import { charOffsetAtHorizontalPosition, closestMatchingElement, wordAtHorizontalPosition, wordInText } from "./textHit";
+import type { PreviewTextTarget } from "./typingEcho";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = workerSrc;
 
@@ -234,18 +235,19 @@ async function probePageText(doc: pdfjsLib.PDFDocumentProxy): Promise<PageTextCo
   }
 }
 
-function wordAtPoint(
+type CaretPointDocument = Document & {
+  caretRangeFromPoint?: (x: number, y: number) => Range | null;
+  caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+};
+
+function findTextLayerSpanAt(
   clientX: number,
   clientY: number,
   eventTarget?: EventTarget | null,
   root: ParentNode = document,
-): string | null {
-  const d = document as Document & {
-    caretRangeFromPoint?: (x: number, y: number) => Range | null;
-    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
-  };
+): HTMLElement | null {
   const clickedSpan = closestMatchingElement<HTMLElement>(eventTarget, ".textLayer span");
-  const containingSpan =
+  return (
     clickedSpan ??
     Array.from(root.querySelectorAll<HTMLElement>(".textLayer span")).find((span) => {
       const rect = span.getBoundingClientRect();
@@ -255,7 +257,66 @@ function wordAtPoint(
         clientY >= rect.top &&
         clientY <= rect.bottom
       );
-    });
+    }) ??
+    null
+  );
+}
+
+function caretTextOffsetAt(
+  clientX: number,
+  clientY: number,
+  span: HTMLElement,
+): number | null {
+  const d = document as CaretPointDocument;
+  const range = d.caretRangeFromPoint?.(clientX, clientY);
+  if (
+    range &&
+    range.startContainer.nodeType === Node.TEXT_NODE &&
+    span.contains(range.startContainer)
+  ) {
+    return range.startOffset;
+  }
+  const pos = d.caretPositionFromPoint?.(clientX, clientY);
+  if (
+    pos &&
+    pos.offsetNode.nodeType === Node.TEXT_NODE &&
+    span.contains(pos.offsetNode)
+  ) {
+    return pos.offset;
+  }
+  return null;
+}
+
+function textTargetAtPoint(
+  clientX: number,
+  clientY: number,
+  eventTarget?: EventTarget | null,
+  root: ParentNode = document,
+): PreviewTextTarget | null {
+  const span = findTextLayerSpanAt(clientX, clientY, eventTarget, root);
+  if (!span) return null;
+  const offset = caretTextOffsetAt(clientX, clientY, span);
+  if (offset !== null) return { span, offset };
+  const rect = span.getBoundingClientRect();
+  return {
+    span,
+    offset: charOffsetAtHorizontalPosition(
+      span.textContent ?? "",
+      rect.left,
+      rect.width,
+      clientX,
+    ),
+  };
+}
+
+function wordAtPoint(
+  clientX: number,
+  clientY: number,
+  eventTarget?: EventTarget | null,
+  root: ParentNode = document,
+): string | null {
+  const d = document as CaretPointDocument;
+  const containingSpan = findTextLayerSpanAt(clientX, clientY, eventTarget, root) ?? undefined;
   if (containingSpan) {
     const text = containingSpan.textContent ?? "";
     const rect = containingSpan.getBoundingClientRect();
@@ -808,7 +869,13 @@ export interface PdfViewerProps {
   /** Exact compile/PDF-load identity; never use a filename as this value. */
   documentIdentity?: string;
   scale: number;
-  onInverse?: (page: number, x: number, y: number, word?: string) => void;
+  onInverse?: (
+    page: number,
+    x: number,
+    y: number,
+    word?: string,
+    textTarget?: PreviewTextTarget,
+  ) => void;
   onPageChange?: (current: number, total: number) => void;
   layout?: PdfLayout;
   onOpenLink?: (url: string) => void;
@@ -2051,7 +2118,14 @@ export const PdfViewer = forwardRef<PdfViewerHandle, PdfViewerProps>(function Pd
           const hit = pageClickToBp(wrap, p, { clientX, clientY });
           if (hit) {
             const word = wordAtPoint(clientX, clientY, ev.target, wrap);
-            onInverseRef.current?.(hit.page, hit.x, hit.y, word ?? undefined);
+            const textTarget = textTargetAtPoint(clientX, clientY, ev.target, wrap);
+            onInverseRef.current?.(
+              hit.page,
+              hit.x,
+              hit.y,
+              word ?? undefined,
+              textTarget ?? undefined,
+            );
           }
         });
         container.appendChild(wrap);

--- a/packages/preview/src/index.ts
+++ b/packages/preview/src/index.ts
@@ -19,3 +19,4 @@ export {
   setPdfLogger,
   type SynctexRect,
 } from "./pdfController";
+export type { PreviewTextTarget } from "./typingEcho";

--- a/packages/preview/src/textHit.test.ts
+++ b/packages/preview/src/textHit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { closestMatchingElement, wordAtHorizontalPosition, wordInText } from "./textHit";
+import { charOffsetAtHorizontalPosition, closestMatchingElement, snapAfterWord, wordAtHorizontalPosition, wordInText } from "./textHit";
 
 describe("PDF text hit testing", () => {
   it("finds a word at a text offset", () => {
@@ -25,5 +25,36 @@ describe("PDF text hit testing", () => {
 
   it("returns null for non-element event targets", () => {
     expect(closestMatchingElement({} as EventTarget, ".textLayer span")).toBeNull();
+  });
+});
+
+describe("charOffsetAtHorizontalPosition", () => {
+  it("maps a click position to a character offset proportionally", () => {
+    expect(charOffsetAtHorizontalPosition("abcd", 100, 100, 100)).toBe(0);
+    expect(charOffsetAtHorizontalPosition("abcd", 100, 100, 150)).toBe(2);
+    expect(charOffsetAtHorizontalPosition("abcd", 100, 100, 200)).toBe(4);
+  });
+
+  it("clamps positions outside the span", () => {
+    expect(charOffsetAtHorizontalPosition("abcd", 100, 100, 50)).toBe(0);
+    expect(charOffsetAtHorizontalPosition("abcd", 100, 100, 400)).toBe(4);
+    expect(charOffsetAtHorizontalPosition("", 100, 100, 150)).toBe(0);
+  });
+});
+
+describe("snapAfterWord", () => {
+  it("moves an offset inside a word to the end of that word", () => {
+    expect(snapAfterWord("hello world", 2)).toBe(5);
+    expect(snapAfterWord("hello world", 8)).toBe(11);
+  });
+
+  it("keeps an offset that is already at a boundary", () => {
+    expect(snapAfterWord("hello world", 5)).toBe(5);
+    expect(snapAfterWord("hello world", 11)).toBe(11);
+  });
+
+  it("clamps out-of-range offsets", () => {
+    expect(snapAfterWord("abc", -2)).toBe(3);
+    expect(snapAfterWord("abc", 99)).toBe(99 > 3 ? 3 : 99);
   });
 });

--- a/packages/preview/src/textHit.ts
+++ b/packages/preview/src/textHit.ts
@@ -28,3 +28,22 @@ export function wordAtHorizontalPosition(
   const offset = Math.min(text.length - 1, Math.floor(ratio * text.length));
   return wordInText(text, offset);
 }
+
+export function charOffsetAtHorizontalPosition(
+  text: string,
+  left: number,
+  width: number,
+  clientX: number,
+): number {
+  if (!text || width <= 0) return 0;
+  const ratio = Math.min(1, Math.max(0, (clientX - left) / width));
+  return Math.min(text.length, Math.round(ratio * text.length));
+}
+
+export function snapAfterWord(text: string, offset: number): number {
+  const isWordChar = (character: string | undefined) =>
+    !!character && /[\p{L}\p{N}]/u.test(character);
+  let end = Math.min(Math.max(0, offset), text.length);
+  while (end < text.length && isWordChar(text[end])) end++;
+  return end;
+}

--- a/packages/preview/src/typingEcho.test.ts
+++ b/packages/preview/src/typingEcho.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { createPreviewTypingEcho } from "./typingEcho";
+
+const COLORS = { ink: "#111", paper: "#fff" };
+
+function makeSpan(text: string): HTMLElement {
+  const span = document.createElement("span");
+  span.textContent = text;
+  document.body.appendChild(span);
+  return span;
+}
+
+describe("createPreviewTypingEcho", () => {
+  it("places a caret at the offset and echoes typed characters before it", () => {
+    const span = makeSpan("hello world");
+    const echo = createPreviewTypingEcho({ span, offset: 5 }, COLORS);
+    expect(echo).not.toBeNull();
+    echo?.insert(",");
+    echo?.insert(" y");
+    expect(span.textContent).toBe("hello, y world");
+    const caret = span.querySelector("[data-pdf-typing-caret]");
+    expect(caret).not.toBeNull();
+    expect(caret?.previousSibling?.textContent).toBe("hello, y");
+  });
+
+  it("removes the character before the caret on backspace and stops at the segment start", () => {
+    const span = makeSpan("ab cd");
+    const echo = createPreviewTypingEcho({ span, offset: 2 }, COLORS);
+    expect(echo?.backspace()).toBe(true);
+    expect(echo?.backspace()).toBe(true);
+    expect(echo?.backspace()).toBe(false);
+    expect(span.textContent).toBe(" cd");
+  });
+
+  it("makes the span visible on the first edit only", () => {
+    const span = makeSpan("abc");
+    const echo = createPreviewTypingEcho({ span, offset: 3 }, COLORS);
+    expect(span.style.color).toBe("");
+    echo?.insert("x");
+    expect(span.style.color).toBe("rgb(17, 17, 17)");
+    expect(span.style.backgroundColor).toBe("rgb(255, 255, 255)");
+  });
+
+  it("keeps echoed text but removes the caret on dispose", () => {
+    const span = makeSpan("abc");
+    const echo = createPreviewTypingEcho({ span, offset: 3 }, COLORS);
+    echo?.insert("d");
+    echo?.dispose();
+    expect(span.querySelector("[data-pdf-typing-caret]")).toBeNull();
+    expect(span.textContent).toBe("abcd");
+    expect(echo?.isConnected()).toBe(false);
+  });
+
+  it("reports disconnection after the text layer is rebuilt", () => {
+    const span = makeSpan("abc");
+    const echo = createPreviewTypingEcho({ span, offset: 1 }, COLORS);
+    span.remove();
+    expect(echo?.isConnected()).toBe(false);
+    echo?.insert("x");
+    expect(span.textContent).toBe("abc");
+  });
+
+  it("returns null for a span without a text node", () => {
+    const span = document.createElement("span");
+    expect(createPreviewTypingEcho({ span, offset: 0 }, COLORS)).toBeNull();
+  });
+
+  it("clamps an out-of-range offset to the text length", () => {
+    const span = makeSpan("abc");
+    const echo = createPreviewTypingEcho({ span, offset: 99 }, COLORS);
+    echo?.insert("d");
+    expect(span.textContent).toBe("abcd");
+  });
+});

--- a/packages/preview/src/typingEcho.ts
+++ b/packages/preview/src/typingEcho.ts
@@ -1,0 +1,80 @@
+export { snapAfterWord } from "./textHit";
+
+export interface PreviewTextTarget {
+  span: HTMLElement;
+  offset: number;
+}
+
+export interface PreviewTypingEcho {
+  insert(text: string): void;
+  backspace(): boolean;
+  isConnected(): boolean;
+  dispose(): void;
+}
+
+export interface PreviewTypingEchoColors {
+  ink: string;
+  paper: string;
+}
+
+function firstTextNode(span: HTMLElement): Text | null {
+  for (const child of Array.from(span.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) return child as Text;
+  }
+  return null;
+}
+
+export function createPreviewTypingEcho(
+  target: PreviewTextTarget,
+  colors: PreviewTypingEchoColors,
+): PreviewTypingEcho | null {
+  const { span } = target;
+  const textNode = firstTextNode(span);
+  if (!textNode) return null;
+  const text = textNode.data;
+  const offset = Math.min(Math.max(0, target.offset), text.length);
+
+  const before = textNode;
+  const after = before.splitText(offset);
+  const caret = span.ownerDocument.createElement("span");
+  caret.dataset.pdfTypingCaret = "true";
+  caret.style.display = "inline-block";
+  caret.style.width = "0";
+  caret.style.borderLeft = `1.5px solid ${colors.ink}`;
+  caret.style.height = "1em";
+  caret.style.verticalAlign = "baseline";
+  span.insertBefore(caret, after);
+  caret.animate?.(
+    [{ opacity: 1 }, { opacity: 0 }],
+    { duration: 1000, iterations: Number.POSITIVE_INFINITY, easing: "steps(2, start)" },
+  );
+
+  let materialized = false;
+  const materialize = () => {
+    if (materialized) return;
+    materialized = true;
+    span.style.color = colors.ink;
+    span.style.backgroundColor = colors.paper;
+  };
+
+  return {
+    insert(insertion: string) {
+      if (!caret.isConnected) return;
+      materialize();
+      before.appendData(insertion);
+    },
+    backspace() {
+      if (!caret.isConnected || before.data.length === 0) return false;
+      materialize();
+      before.deleteData(before.data.length - 1, 1);
+      return true;
+    },
+    isConnected() {
+      return caret.isConnected;
+    },
+    dispose() {
+      caret.remove();
+      span.normalize();
+    },
+  };
+}

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -183,6 +183,8 @@ export function SettingsModal() {
   const setOffline = useSettingsStore((s) => s.setOffline);
   const visualEditor = useSettingsStore((s) => s.visualEditor);
   const setVisualEditor = useSettingsStore((s) => s.setVisualEditor);
+  const previewTyping = useSettingsStore((s) => s.previewTyping);
+  const setPreviewTyping = useSettingsStore((s) => s.setPreviewTyping);
   const latexTools = useSettingsStore((s) => s.latexTools);
   const setLatexTools = useSettingsStore((s) => s.setLatexTools);
 
@@ -1110,6 +1112,12 @@ export function SettingsModal() {
                   description="Show the Visual/Code toggle in the document editor. Off by default, so documents open in the code editor only. Diagrams always keep their own canvas toggle."
                   checked={visualEditor}
                   onChange={setVisualEditor}
+                />
+                <SettingsToggleRow
+                  label="Type in the preview"
+                  description="Click text in the compiled PDF to put the cursor at that spot in your source, then keep typing. Keystrokes go into the source file and show up at the click point until the next compile redraws the page. Needs a compiler with source sync."
+                  checked={previewTyping}
+                  onChange={setPreviewTyping}
                 />
                 <SettingsToggleRow
                   label="LaTeX tools"

--- a/src/components/preview/PreviewPane.tsx
+++ b/src/components/preview/PreviewPane.tsx
@@ -86,6 +86,10 @@ import {
   canUseSyncTexForCheckpoint,
   inverseFromClick,
 } from "@/features/synctex";
+import {
+  armPreviewTyping,
+  disarmPreviewTyping,
+} from "@/features/preview-typing";
 import { askAiAboutCompileErrors } from "@/features/ask-ai-compile-errors";
 import {
   revealInDir,
@@ -799,6 +803,14 @@ export function PreviewPane() {
   }, [compileCheckpoint, pdfBytes]);
 
   const displayedCheckpoint = viewerDocument?.checkpoint ?? null;
+  const viewerIdentity = viewerDocument?.identity ?? null;
+  useEffect(() => {
+    void viewerIdentity;
+    disarmPreviewTyping();
+    return () => {
+      disarmPreviewTyping();
+    };
+  }, [viewerIdentity]);
   const pdfIsCurrent =
     viewerDocument !== null &&
     displayedCheckpoint !== null &&
@@ -2076,14 +2088,24 @@ export function PreviewPane() {
                     onOutlineStateChange={setOutlineState}
                     onInverse={
                       syncTexAvailable
-                        ? (pageNumber, clickX, clickY, word) =>
+                        ? (pageNumber, clickX, clickY, word, textTarget) => {
+                            const wantsTyping =
+                              useSettingsStore.getState().previewTyping &&
+                              textTarget !== undefined;
                             void inverseFromClick(
                               pageNumber,
                               clickX,
                               clickY,
                               word,
                               displayedCheckpoint,
-                            )
+                            ).then((placed) => {
+                              if (placed && wantsTyping && textTarget) {
+                                armPreviewTyping(textTarget);
+                              } else {
+                                disarmPreviewTyping();
+                              }
+                            });
+                          }
                         : undefined
                     }
                     onPageChange={(current, total) => {

--- a/src/features/preview-typing.test.ts
+++ b/src/features/preview-typing.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { setEditorView } from "@oleafly/editor";
+import {
+  armPreviewTyping,
+  disarmPreviewTyping,
+  isPreviewTypingArmed,
+} from "./preview-typing";
+
+let view: EditorView | null = null;
+
+function setup(spanText = "hello world") {
+  const parent = document.createElement("div");
+  document.body.append(parent);
+  view = new EditorView({
+    parent,
+    state: EditorState.create({ doc: "hello world line" }),
+  });
+  setEditorView(view);
+  view.contentDOM.focus();
+  const layer = document.createElement("div");
+  layer.className = "textLayer";
+  const span = document.createElement("span");
+  span.textContent = spanText;
+  layer.append(span);
+  document.body.append(layer);
+  return { span, layer };
+}
+
+function key(init: KeyboardEventInit) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, ...init }));
+}
+
+afterEach(() => {
+  disarmPreviewTyping();
+  setEditorView(null);
+  view?.destroy();
+  view = null;
+  document.body.replaceChildren();
+});
+
+describe("preview typing", () => {
+  it("arms at the end of the clicked word and collapses the editor selection", () => {
+    const { span } = setup();
+    view?.dispatch({ selection: { anchor: 0, head: 5 } });
+    expect(armPreviewTyping({ span, offset: 2 })).toBe(true);
+    expect(isPreviewTypingArmed()).toBe(true);
+    const selection = view?.state.selection.main;
+    expect(selection?.empty).toBe(true);
+    expect(selection?.head).toBe(5);
+    const caret = span.querySelector("[data-pdf-typing-caret]");
+    expect(caret?.previousSibling?.textContent).toBe("hello");
+  });
+
+  it("mirrors printable keys and backspace into the preview without touching the document", () => {
+    const { span } = setup();
+    armPreviewTyping({ span, offset: 2 });
+    key({ key: "x" });
+    key({ key: "y" });
+    expect(span.textContent).toBe("helloxy world");
+    key({ key: "Backspace" });
+    expect(span.textContent).toBe("hellox world");
+    expect(view?.state.doc.toString()).toBe("hello world line");
+    expect(isPreviewTypingArmed()).toBe(true);
+  });
+
+  it("disarms on Escape and keeps the echoed text", () => {
+    const { span } = setup();
+    armPreviewTyping({ span, offset: 2 });
+    key({ key: "x" });
+    key({ key: "Escape" });
+    expect(isPreviewTypingArmed()).toBe(false);
+    expect(span.querySelector("[data-pdf-typing-caret]")).toBeNull();
+    expect(span.textContent).toBe("hellox world");
+  });
+
+  it("disarms on navigation keys and on shortcuts with a modifier", () => {
+    const { span } = setup();
+    armPreviewTyping({ span, offset: 2 });
+    key({ key: "Shift" });
+    expect(isPreviewTypingArmed()).toBe(true);
+    key({ key: "ArrowLeft" });
+    expect(isPreviewTypingArmed()).toBe(false);
+
+    armPreviewTyping({ span, offset: 2 });
+    key({ key: "z", metaKey: true });
+    expect(isPreviewTypingArmed()).toBe(false);
+  });
+
+  it("disarms when the editor loses focus", () => {
+    const { span } = setup();
+    armPreviewTyping({ span, offset: 2 });
+    view?.contentDOM.blur();
+    key({ key: "x" });
+    expect(isPreviewTypingArmed()).toBe(false);
+    expect(span.textContent).toBe("hello world");
+  });
+
+  it("disarms on a mousedown outside the text layer but not inside it", () => {
+    const { span } = setup();
+    armPreviewTyping({ span, offset: 2 });
+    span.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(isPreviewTypingArmed()).toBe(true);
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(isPreviewTypingArmed()).toBe(false);
+  });
+
+  it("disarms when the target span is removed by a text layer rebuild", () => {
+    const { span, layer } = setup();
+    armPreviewTyping({ span, offset: 2 });
+    layer.replaceChildren();
+    key({ key: "x" });
+    expect(isPreviewTypingArmed()).toBe(false);
+  });
+
+  it("does not arm without an editor view", () => {
+    const { span } = setup();
+    setEditorView(null);
+    expect(armPreviewTyping({ span, offset: 2 })).toBe(false);
+  });
+});

--- a/src/features/preview-typing.ts
+++ b/src/features/preview-typing.ts
@@ -1,0 +1,88 @@
+import {
+  createPreviewTypingEcho,
+  snapAfterWord,
+  type PreviewTextTarget,
+  type PreviewTypingEcho,
+} from "@oleafly/preview/typingEcho";
+import { getEditorView } from "@/components/editor/cm/controller";
+
+const INK = "#18181b";
+const PAPER = "#ffffff";
+
+interface ActiveTyping {
+  echo: PreviewTypingEcho;
+  removeListeners: () => void;
+}
+
+let active: ActiveTyping | null = null;
+
+export function isPreviewTypingArmed(): boolean {
+  return active !== null;
+}
+
+export function disarmPreviewTyping() {
+  if (!active) return;
+  const current = active;
+  active = null;
+  current.removeListeners();
+  current.echo.dispose();
+}
+
+function editorHasFocus(): boolean {
+  return getEditorView()?.hasFocus ?? false;
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+  const current = active;
+  if (!current) return;
+  if (!current.echo.isConnected() || !editorHasFocus()) {
+    disarmPreviewTyping();
+    return;
+  }
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    disarmPreviewTyping();
+    return;
+  }
+  if (event.key === "Backspace") {
+    current.echo.backspace();
+    return;
+  }
+  if (event.key.length === 1) {
+    current.echo.insert(event.key);
+    return;
+  }
+  if (event.key === "Shift" || event.key === "CapsLock") return;
+  disarmPreviewTyping();
+}
+
+function handleMouseDown(event: MouseEvent) {
+  const target = event.target;
+  if (target instanceof Element && target.closest(".textLayer")) return;
+  disarmPreviewTyping();
+}
+
+export function armPreviewTyping(target: PreviewTextTarget): boolean {
+  disarmPreviewTyping();
+  const view = getEditorView();
+  if (!view) return false;
+  const selection = view.state.selection.main;
+  if (!selection.empty) {
+    view.dispatch({ selection: { anchor: selection.to } });
+  }
+  const text = target.span.textContent ?? "";
+  const echo = createPreviewTypingEcho(
+    { span: target.span, offset: snapAfterWord(text, target.offset) },
+    { ink: INK, paper: PAPER },
+  );
+  if (!echo) return false;
+  window.addEventListener("keydown", handleKeyDown, true);
+  window.addEventListener("mousedown", handleMouseDown, true);
+  active = {
+    echo,
+    removeListeners: () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      window.removeEventListener("mousedown", handleMouseDown, true);
+    },
+  };
+  return true;
+}

--- a/src/features/synctex.ts
+++ b/src/features/synctex.ts
@@ -216,20 +216,20 @@ export async function inverseFromClick(
   y: number,
   word?: string,
   expectedCheckpoint: CompileSuccessCheckpoint | null = null,
-) {
+): Promise<boolean> {
   const store = useFilesStore.getState();
   const { projectId } = store;
   const mainDoc = resolveEffectiveMainDoc().mainDoc;
-  if (!projectId) return;
-  if (!store.engineLoaded || !store.engine.capabilities.supports_synctex) return;
+  if (!projectId) return false;
+  if (!store.engineLoaded || !store.engine.capabilities.supports_synctex) return false;
   const context = currentSyncTexContext(expectedCheckpoint);
-  if (!context) return;
+  if (!context) return false;
   const currentLine = getCurrentLine();
   if (word && currentLine != null) selectWordNearLine(currentLine, word);
   try {
     const hit = await synctexInverse(projectId, mainDoc, page, x, y);
-    if (!contextStillValid(context)) return;
-    if (!hit) return;
+    if (!contextStillValid(context)) return false;
+    if (!hit) return false;
 
     let targetPath: string | null = null;
     let targetLine = hit.line;
@@ -244,7 +244,7 @@ export async function inverseFromClick(
         hit.line,
         false,
       );
-      if (!mapped) return;
+      if (!mapped) return false;
       targetPath = mapped[1];
       targetLine = mapped[2];
     }
@@ -253,14 +253,16 @@ export async function inverseFromClick(
     if (targetPath && targetPath !== activePath) {
       await store.openFile(targetPath);
       await nextFrames(2); // let the editor mount the new file
-      if (!contextStillValid(context)) return;
+      if (!contextStillValid(context)) return false;
     }
     // SyncTeX only resolves to a line (its column is coarse and often lands on a
     // `\begin`/`\end`). If we know the word that was clicked, place the cursor on
     // the nearest matching word; otherwise fall back to the line start.
-    if (word && selectWordNearLine(targetLine, word)) return;
+    if (word && selectWordNearLine(targetLine, word)) return true;
     gotoLine(targetLine);
+    return true;
   } catch (e) {
     void logError("synctex inverse", e);
+    return false;
   }
 }

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -381,6 +381,8 @@ interface SettingsState {
   setHomeProjectLayout: (v: HomeProjectLayout) => void;
   visualEditor: boolean;
   setVisualEditor: (v: boolean) => void;
+  previewTyping: boolean;
+  setPreviewTyping: (v: boolean) => void;
   latexTools: boolean;
   setLatexTools: (v: boolean) => void;
   // Engine for NEW LaTeX projects: "tectonic" (bundled, zero-setup) or
@@ -632,6 +634,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   setVisualEditor: (v) => {
     saveLs("oleafly.visualEditor", v ? "1" : "0");
     set({ visualEditor: v });
+  },
+  previewTyping: ls("oleafly.previewTyping", "0") === "1",
+  setPreviewTyping: (v) => {
+    saveLs("oleafly.previewTyping", v ? "1" : "0");
+    set({ previewTyping: v });
   },
   latexTools: ls("oleafly.latexTools", "0") === "1",
   setLatexTools: (v) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
       "@oleafly/templates": ["./packages/templates/src/index.ts"],
       "@oleafly/preview": ["./packages/preview/src/index.ts"],
       "@oleafly/preview/controller": ["./packages/preview/src/controller.ts"],
+      "@oleafly/preview/typingEcho": ["./packages/preview/src/typingEcho.ts"],
       "@oleafly/preview/polyfills": ["./packages/preview/src/polyfills.ts"],
       "@oleafly/preview/mainThreadWorker": ["./packages/preview/src/mainThreadWorker.ts"],
       "@oleafly/pdf-to-latex": ["./packages/pdf-to-latex/src/index.ts"],


### PR DESCRIPTION
Adds an experimental, off-by-default way to edit without looking away from the preview.

A sync click in the compiled PDF already puts the editor cursor on the right word, and the editor already receives everything you type afterwards. The missing half was visual: your eyes are on the preview, but the caret and the feedback are in the source pane. With the new toggle on (Settings, Experimentation, "Type in the preview"), a successful inverse-sync click arms a mirror layer in the PDF text layer. It draws a blinking caret at the end of the clicked word and echoes printable keys and backspace right there, on an opaque ink-on-paper run that covers the rasterized glyphs, until the next compile redraws the page with the real output.

The mirror never touches the document and never blocks an event, so editor behavior, shortcuts, and undo work exactly as before. It disarms whenever it could not stay faithful: Escape, navigation keys, any control or command combination, a click outside the text layer, editor focus loss, a rebuilt text layer, or a new compiled document in the viewer.

Plumbing: the preview package's click handler now also reports which text-layer span was hit and the character offset inside it (an optional extra argument on onInverse), the echo module ships behind its own subpath so importing it does not pull pdf.js into module evaluation, and inverseFromClick reports whether it actually placed the cursor so the pane only arms after a confirmed placement.

Tests: 7 cases for the echo module, 8 for the arming/mirroring/disarming logic, plus offset helper cases. Full unit suite passes (2145 tests). No e2e coverage yet; that needs a compiled document with SyncTeX in the harness and is a follow-up.