### PR TITLE
chore: tracked ignore list and seed sync default path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,12 +45,6 @@ coverage/
 # e2e secrets (copy from e2e/.env.example)
 e2e/.env
 
-# Grok CLI session state
-.grok/
-
-# Claude Code local session state
-.claude/
-.superpowers/
 e2e-debug/
 src-tauri/tauri.windows-signing.conf.json
 

--- a/docs/research/seed-project-catalog.md
+++ b/docs/research/seed-project-catalog.md
@@ -123,7 +123,7 @@ The corpus is 28 projects: 17 LaTeX and 11 Typst. Every one is verified to compi
 
 ```bash
 pnpm seed:research:validate           # compile every fixture, or a named slug
-pnpm seed:research:sync               # pack fixtures into ~/Codespace/Oleafly/oleafly-seed
+pnpm seed:research:sync               # pack fixtures into ../oleafly-seed, or OLEAFLY_SEED_ROOT
 ```
 
 `sync` writes one archive per fixture, adds `project.json` and `FIXTURE.md`,

--- a/scripts/sync-research-seeds.mjs
+++ b/scripts/sync-research-seeds.mjs
@@ -1,5 +1,4 @@
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { zipSync } from "fflate";
@@ -12,7 +11,7 @@ import {
 const MAX_PROJECT_BYTES = 25 * 1024 * 1024;
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = resolve(scriptDir, "..");
-const defaultSeedRoot = join(homedir(), "Codespace", "Oleafly", "oleafly-seed");
+const defaultSeedRoot = resolve(repositoryRoot, "..", "oleafly-seed");
 const seedRoot = resolve(process.env.OLEAFLY_SEED_ROOT || defaultSeedRoot);
 const archiveRoot = join(seedRoot, "archives");
 const encoder = new TextEncoder();


### PR DESCRIPTION
Two small tidy-ups.

The tracked ignore list only lists project entries now. Per-machine editor and CLI state belongs in each contributor's global excludes, not in the repository.

The research seed sync script defaulted to a directory under one specific home folder. It now defaults to an oleafly-seed directory next to the repository and still honours OLEAFLY_SEED_ROOT. The seed catalog doc reflects that.