### PR TITLE
fix(acp): ask for a CLI sign-in when a login expires mid-conversation

### DIFF
--- a/src-tauri/src/acp/catalog.rs
+++ b/src-tauri/src/acp/catalog.rs
@@ -94,7 +94,7 @@ const BUILTINS: &[Builtin] = &[
         dist: BuiltinDist::Bridge {
             package: "@google/gemini-cli@0.57.0",
             cmd: "gemini",
-            args: &["--acp"],
+            args: &["--experimental-acp"],
             node: 20,
         },
     },

--- a/src-tauri/src/acp/protocol.rs
+++ b/src-tauri/src/acp/protocol.rs
@@ -70,6 +70,29 @@ fn disconnect_message(prefix: &str, tail: &StderrTail) -> String {
     }
 }
 
+const AUTH_FAILURE_PHRASES: &[&str] = &[
+    "failed to authenticate",
+    "authentication failed",
+    "not authenticated",
+    "oauth",
+    "unauthorized",
+    "invalid api key",
+    "expired credentials",
+    "credentials have expired",
+    "session expired",
+    "please log in",
+    "please sign in",
+    "log in again",
+    "sign in again",
+];
+
+pub fn reads_as_auth_failure(message: &str) -> bool {
+    let message = message.to_lowercase();
+    AUTH_FAILURE_PHRASES
+        .iter()
+        .any(|phrase| message.contains(phrase))
+}
+
 #[derive(Clone, Debug)]
 pub struct RpcError {
     pub code: i64,
@@ -84,7 +107,7 @@ impl RpcError {
         }
     }
     pub fn auth_required(&self) -> bool {
-        self.code == -32000
+        self.code == -32000 || reads_as_auth_failure(&self.message)
     }
 }
 

--- a/src-tauri/src/acp/protocol.rs
+++ b/src-tauri/src/acp/protocol.rs
@@ -61,10 +61,16 @@ pub fn rpc_error_message(error: &Value) -> String {
     }
 }
 
+pub fn reads_as_command_help(tail: &str) -> bool {
+    tail.contains("--help") || tail.contains("Options:") || tail.starts_with("Usage:")
+}
+
 fn disconnect_message(prefix: &str, tail: &StderrTail) -> String {
     let tail = tail_text(tail);
     if tail.is_empty() {
         prefix.to_owned()
+    } else if reads_as_command_help(&tail) {
+        format!("{prefix} It answered with its command-line help, so this version does not accept the options Oleafly started it with.")
     } else {
         format!("{prefix} It reported: {tail}")
     }

--- a/src-tauri/src/acp/runtime.rs
+++ b/src-tauri/src/acp/runtime.rs
@@ -892,6 +892,11 @@ impl AcpRuntime {
                     "cancelled".into(),
                     None,
                 ),
+                Err(error) if !closed && error.auth_required() => (
+                    SessionStatus::AuthRequired,
+                    "error".into(),
+                    Some(session.redactor.text(&error.to_string())),
+                ),
                 Err(error) => (
                     live_status.clone(),
                     "error".into(),
@@ -913,6 +918,7 @@ impl AcpRuntime {
                     )?;
                 }
             }
+            let authenticating = status == SessionStatus::AuthRequired;
             state.record.status = status;
             state.record.error = message.clone();
             error = message;
@@ -922,6 +928,14 @@ impl AcpRuntime {
                 "turn_complete",
                 json!({"stopReason":stop,"error":error}),
             )?;
+            if authenticating {
+                self.emit_locked(
+                    &session,
+                    &mut state,
+                    "status",
+                    json!({"status":"auth_required"}),
+                )?;
+            }
         }
         if let Some(error) = error {
             if closed || session.connection.is_closed() {

--- a/src-tauri/src/acp/tests.rs
+++ b/src-tauri/src/acp/tests.rs
@@ -398,6 +398,19 @@ async fn a_failed_turn_keeps_the_agent_connected_and_reports_its_message() {
 }
 
 #[test]
+fn a_cli_that_prints_its_usage_is_not_quoted_back_at_the_reader() {
+    assert!(protocol::reads_as_command_help(
+        "-d, --debug Run in debug mode? [boolean] Options: --experimental-acp Starts the agent in ACP mode"
+    ));
+    assert!(protocol::reads_as_command_help(
+        "Usage: gemini [options] Run --help for the full list"
+    ));
+    assert!(!protocol::reads_as_command_help(
+        "Traceback: the agent could not open paper.tex"
+    ));
+}
+
+#[test]
 fn an_agents_wording_decides_whether_a_failure_needs_a_sign_in() {
     assert!(protocol::RpcError {
         code: -32000,

--- a/src-tauri/src/acp/tests.rs
+++ b/src-tauri/src/acp/tests.rs
@@ -397,6 +397,45 @@ async fn a_failed_turn_keeps_the_agent_connected_and_reports_its_message() {
     runtime.close(&id).await.unwrap();
 }
 
+#[test]
+fn an_agents_wording_decides_whether_a_failure_needs_a_sign_in() {
+    assert!(protocol::RpcError {
+        code: -32000,
+        message: "Authentication required".into(),
+    }
+    .auth_required());
+    assert!(protocol::RpcError::local(
+        "Internal error: Failed to authenticate: OAuth session expired and could not be refreshed"
+    )
+    .auth_required());
+    assert!(!protocol::RpcError::local("Agent failure sk-fixture-credential").auth_required());
+    assert!(!protocol::RpcError::local("The agent could not read paper.tex").auth_required());
+}
+
+#[tokio::test]
+async fn a_login_that_expires_mid_turn_asks_for_sign_in_rather_than_staying_ready() {
+    let (_temp, runtime, snapshot) = runtime(Vec::new()).await;
+    let id = snapshot.session.id;
+    let error = runtime
+        .prompt(&id, "auth-expired".into(), Vec::new())
+        .await
+        .unwrap_err();
+    assert!(error.contains("Failed to authenticate"), "{error}");
+    assert_eq!(
+        runtime.snapshot(&id).await.unwrap().session.status,
+        SessionStatus::AuthRequired
+    );
+    let events = runtime.events(&id, 0, 500).unwrap().events;
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "status" && event.data["status"] == "auth_required"));
+    assert!(runtime
+        .prompt(&id, "retry before signing in".into(), Vec::new())
+        .await
+        .is_err());
+    runtime.close(&id).await.unwrap();
+}
+
 #[tokio::test]
 async fn startup_failures_carry_the_agent_stderr() {
     let temp = fixture_temp();

--- a/src-tauri/src/acp/tests/catalog.rs
+++ b/src-tauri/src/acp/tests/catalog.rs
@@ -264,6 +264,21 @@ fn sign_in_hints_name_the_vendor_command_and_stay_specific_for_api_key_agents() 
 }
 
 #[test]
+fn gemini_starts_in_the_acp_mode_its_own_cli_offers() {
+    let gemini = builtins()
+        .into_iter()
+        .find(|value| value.id == "gemini")
+        .unwrap();
+    let args = gemini
+        .distribution
+        .npx
+        .as_ref()
+        .map(|npx| npx.args.clone())
+        .unwrap_or_default();
+    assert_eq!(args, ["--experimental-acp"]);
+}
+
+#[test]
 fn definition_validation_checks_every_distribution() {
     for definition in builtins().into_iter().chain([binary_definition()]) {
         validate(&definition).unwrap();
@@ -473,10 +488,17 @@ fn managed_node_receipts_put_the_script_before_agent_arguments() {
         Some(node) => {
             let launch = resolve(temp.path(), &definition).unwrap();
             assert_eq!(launch.executable, node);
-            assert_eq!(
-                launch.args,
-                [script.to_string_lossy().into_owned(), "--acp".into()]
-            );
+            let agent_args = definition
+                .distribution
+                .npx
+                .as_ref()
+                .map(|npx| npx.args.clone())
+                .unwrap_or_default();
+            assert!(!agent_args.is_empty());
+            let expected: Vec<String> = std::iter::once(script.to_string_lossy().into_owned())
+                .chain(agent_args)
+                .collect();
+            assert_eq!(launch.args, expected);
             assert!(launch.managed);
             assert_eq!(launch.version, Some(definition.version));
         }

--- a/src-tauri/src/acp/tests/fixtures/agent.py
+++ b/src-tauri/src/acp/tests/fixtures/agent.py
@@ -106,7 +106,10 @@ for line in sys.stdin:
             update("config_option_update", configOptions=[{"id": "model-selector", "type": "select", "category": "model", "currentValue": credential, "options": []}])
             result(request, {"stopReason": "end_turn"})
         elif prompt == "leak-error":
-            send({"id": request["id"], "error": {"code": -32000, "message": "Agent failure " + credential}})
+            send({"id": request["id"], "error": {"code": -32603, "message": "Agent failure " + credential}})
+        elif prompt == "auth-expired":
+            update("agent_message_chunk", content={"type": "text", "text": "Failed to authenticate: OAuth session expired and could not be refreshed"})
+            send({"id": request["id"], "error": {"code": -32603, "message": "Internal error: Failed to authenticate: OAuth session expired and could not be refreshed"}})
         elif prompt in ("permission", "outside-permission", "leak-permission-tool", "leak-permission-option"):
             pending_prompt = request
             path = "/etc/passwd" if prompt == "outside-permission" else os.path.join(params.get("cwd", os.getcwd()), "paper.tex")

--- a/src/components/ai/ChatCore.tsx
+++ b/src/components/ai/ChatCore.tsx
@@ -3165,9 +3165,9 @@ ${sandboxedCustom}`;
                     !messages[messages.length - 1]?.reasoningBlocks?.some(
                       (b) => b.ms === undefined,
                     ) && (
-                      <div className="max-w-[85%] rounded-md border bg-muted text-xs">
-                        <div className="flex w-full items-center gap-2 px-2.5 py-1.5 text-muted-foreground">
-                          <Brain className="ai-shimmer-icon size-3.5" />
+                      <div className="max-w-[85%] text-xs">
+                        <div className="flex w-full items-center gap-2 py-1 text-sm text-muted-foreground">
+                          <Brain className="ai-shimmer-icon size-3.5 shrink-0" />
                           <Shimmer text={thinkingText || "Thinking…"} />
                         </div>
                       </div>

--- a/src/components/ai/acp/AcpWorkspaceAssistant.test.tsx
+++ b/src/components/ai/acp/AcpWorkspaceAssistant.test.tsx
@@ -501,4 +501,26 @@ describe("ACP assistant acceptance", () => {
     expect(acpPermission).not.toHaveBeenCalled();
     expect(acpReconnect).not.toHaveBeenCalled();
   });
+
+  it("offers the CLI sign-in instead of repeating an expired login", async () => {
+    const detail = "Internal error: Failed to authenticate: OAuth session expired and could not be refreshed";
+    vi.mocked(acpPrompt).mockImplementation(async (_project, _id, text) => {
+      const accepted = event(1, "user_message", { text });
+      history.saved = [
+        accepted,
+        event(2, "agent_message_chunk", { content: { type: "text", text: "Failed to authenticate: OAuth session expired and could not be refreshed" } }),
+        event(3, "turn_complete", { stopReason: "error", error: detail }),
+      ];
+      snapshots.saved = { session: session("saved", { status: "auth_required", lastSequence: 3, error: detail }), permissions: [] };
+      emit(accepted);
+      throw new Error(detail);
+    });
+    const ui = render(<AcpWorkspaceAssistant projectId="paper" />);
+    await waitFor(() => expect(acpEvents).toHaveBeenCalledWith("paper", "saved", 0));
+    typeMessage(ui.getByLabelText("Message CLI agent"), "Hello");
+    fireEvent.click(ui.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(ui.getByText("Run research-fixture login")).toBeInTheDocument());
+    expect(ui.getByRole("button", { name: "Reconnect after sign-in" })).toBeInTheDocument();
+    expect(ui.queryByRole("alert")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ai/acp/AcpWorkspaceAssistant.tsx
+++ b/src/components/ai/acp/AcpWorkspaceAssistant.tsx
@@ -178,9 +178,10 @@ export function AcpWorkspaceAssistant({ projectId }: { projectId: string }) {
       useAcpSessionsStore.getState().setSnapshot(await acpPrompt(projectId, activeId, message, attachments.map((value) => value.image)));
       clearComposer();
     } catch (value) {
-      setError(acpError(value));
       await useAcpSessionsStore.getState().resync(projectId, activeId).catch(() => {});
-      if (useAcpSessionsStore.getState().events[activeId]?.some((event) => event.kind === "user_message" && event.sequence > beforeSequence)) clearComposer();
+      const state = useAcpSessionsStore.getState();
+      if (state.sessions[activeId]?.status !== "auth_required") setError(acpError(value));
+      if (state.events[activeId]?.some((event) => event.kind === "user_message" && event.sequence > beforeSequence)) clearComposer();
     } finally { setSending(false); }
   };
   const choosePermission = async (id: string, option: string | null) => {
@@ -264,7 +265,7 @@ export function AcpWorkspaceAssistant({ projectId }: { projectId: string }) {
         />
       )}
     </div>
-    {(error || session?.error) && <div role="alert" className="mx-3 my-2 rounded-md border border-destructive/40 p-2 text-xs text-destructive">{error ?? session?.error}</div>}
+    {(error || (session?.error && session.status !== "auth_required")) && <div role="alert" className="mx-3 my-2 rounded-md border border-destructive/40 p-2 text-xs text-destructive">{error ?? session?.error}</div>}
     {session?.status === "auth_required" && <div className="space-y-2 border-t border-border p-3 text-xs">
       <p>{catalog.find((agent) => agent.definition.id === session.agentId)?.signInHint ?? "Sign in using this agent's CLI, then reconnect."}</p>
       <div className="flex flex-wrap gap-2">

--- a/src/components/ai/acp/AcpWorkspaceAssistant.tsx
+++ b/src/components/ai/acp/AcpWorkspaceAssistant.tsx
@@ -103,7 +103,12 @@ export function AcpWorkspaceAssistant({ projectId }: { projectId: string }) {
     );
     void perform(async () => {
       if (ready) {
-        await useAcpSessionsStore.getState().start(projectId, nextAgentId);
+        try {
+          await useAcpSessionsStore.getState().start(projectId, nextAgentId);
+        } catch (value) {
+          setComposer(projectId, { agentId: open.agentId });
+          throw value;
+        }
         return;
       }
       if (["ready", "auth_required"].includes(open.status)) {

--- a/src/components/ai/acp/projection.test.ts
+++ b/src/components/ai/acp/projection.test.ts
@@ -73,4 +73,24 @@ describe("ACP conversation projection", () => {
     expect(rows).toHaveLength(2);
     expect(rows.map((row) => row.msg.toolCalls?.[0].name)).toEqual(["First", "Second"]);
   });
+
+  it("does not repeat a failure the agent already said in its own words", () => {
+    const rows = projectAcpEvents([
+      event(1, "user_message", { text: "Hello" }),
+      chunk(2, "Failed to authenticate: OAuth session expired and could not be refreshed"),
+      event(3, "turn_complete", { stopReason: "error", error: "Internal error: Failed to authenticate: OAuth session expired and could not be refreshed" }),
+    ], false);
+    expect(rows).toHaveLength(2);
+    expect(rows[1].msg.content).toBe("Failed to authenticate: OAuth session expired and could not be refreshed");
+  });
+
+  it("still reports a failure the agent never mentioned", () => {
+    const rows = projectAcpEvents([
+      event(1, "user_message", { text: "Hello" }),
+      chunk(2, "Reading the manuscript."),
+      event(3, "turn_complete", { stopReason: "error", error: "The agent stopped before completing this turn." }),
+    ], false);
+    expect(rows).toHaveLength(3);
+    expect(rows[2].msg.content).toBe("The agent stopped before completing this turn.");
+  });
 });

--- a/src/components/ai/acp/projection.ts
+++ b/src/components/ai/acp/projection.ts
@@ -18,6 +18,22 @@ function noticed(message: ChatMessage, raw: string, prefix = ""): ChatMessage {
   };
 }
 
+function bareFailure(value: string): string {
+  return value.replace(/^\s*(?:internal error|error)\s*:\s*/i, "").trim().toLowerCase();
+}
+
+function alreadySaid(rows: readonly Row[], turn: string | null, failure: string): boolean {
+  const bare = bareFailure(failure);
+  if (!bare) return false;
+  for (let index = rows.length - 1; index >= 0; index--) {
+    const row = rows[index];
+    if (row.turn !== turn || row.msg.role !== "assistant") continue;
+    if (bareFailure(row.raw ?? row.msg.content) === bare) return true;
+    if (row.kind === "agent_message_chunk" || row.kind === "error") return false;
+  }
+  return false;
+}
+
 function toolOutput(data: Data): string {
   if (!Array.isArray(data.content)) return "";
   return data.content.map((entry: unknown) => {
@@ -88,7 +104,7 @@ export function createAcpProjector() {
             if (row.msg.reasoningBlocks?.some((block) => block.ms === undefined)) row.msg = { ...row.msg, reasoningBlocks: row.msg.reasoningBlocks.map((block) => ({ ...block, ms: block.ms ?? 0 })) };
             if (row.msg.toolCalls?.some((tool) => tool.status === "running")) row.msg = { ...row.msg, toolCalls: row.msg.toolCalls.map((tool) => tool.status === "running" ? { ...tool, status: "error" } : tool) };
           }
-          if (data.error) append("error", noticed({ role: "assistant", content: "" }, text(data.error)));
+          if (data.error && !alreadySaid(rows, event.turnId, text(data.error))) append("error", noticed({ role: "assistant", content: "" }, text(data.error)));
         }
       }
       lastKind = event.kind;

--- a/src/components/ai/chat-parts.tsx
+++ b/src/components/ai/chat-parts.tsx
@@ -1183,25 +1183,15 @@ export const MessageItem = memo(function MessageItem({
       }
       const tool = tools[i];
       const key = tool.id ?? `legacy-tool-${i}`;
-      if (tool.name === "run_command") {
-        rows.push(
-          <ExecCard
-            key={key}
-            tc={tool}
-            expansionKey={expansionScope ? `${expansionScope}:tool:${key}` : undefined}
-          />,
-        );
-      } else {
-        rows.push(
-          <ToolBadge
-            key={key}
-            tc={tool}
-            actions={actions}
-            expansionKey={expansionScope ? `${expansionScope}:tool:${key}` : undefined}
-            live={live}
-          />,
-        );
-      }
+      rows.push(
+        <ToolBadge
+          key={key}
+          tc={tool}
+          actions={actions}
+          expansionKey={expansionScope ? `${expansionScope}:tool:${key}` : undefined}
+          live={live}
+        />,
+      );
     }
   }
   for (const entry of msg.subagents ?? []) {


### PR DESCRIPTION
Three problems in the CLI Agent surface, each found from a screenshot of the
app failing, plus the transcript styling that went with them.

## An expired login left you with no way forward

When a Claude Code session's OAuth login expired mid-conversation, the view
showed the same sentence three times and left the status chip reading "ready".

The panel that says `Run claude auth login in your terminal, then reconnect.`
already existed, and the catalog already had the right command. Two
assumptions kept it shut. `RpcError::auth_required()` matched only JSON-RPC
code `-32000`, while an expired login arrives as `-32603` wrapped in
"Internal error: ...". And even a matching code was checked only when
establishing a session, so a credential expiring mid-turn fell to the generic
error arm, which takes session status from process liveness. The pipe was
still open, so the session stayed `Ready`.

The three copies were three channels carrying one string: the agent streams
its own sentence as a message chunk, the runtime puts the RPC error in
`turn_complete`, and `acp_prompt` rejects with the same text into the alert
bar.

Auth classification now reads the message text as well as the code, a prompt
failing on auth records `AuthRequired` and emits a status event, the
transcript drops a bubble repeating what the agent just said, and the alert
bar stops mirroring `session.error` while the panel is up. Errors from the
user's own actions still raise the bar.

`prompt()` still returns `Err` on failure. `child_acp.rs` and
`task_runtime.rs` both detect a failed delegated run from that rejection, so
returning `Ok` would make a failed subagent turn read as successful.

## Gemini CLI could never start

The catalog launched it with `--acp`, a flag the CLI does not define. Its only
ACP flag is `--experimental-acp`, so yargs answered with its usage text and
exited, and switching to Gemini CLI produced no session at all.

That usage text then went straight into the UI, because `disconnect_message`
appends whatever the process last wrote to stderr. A failure to accept
start-up flags now says so in one sentence rather than quoting a page of flag
documentation back at the reader. Any other stderr tail is still quoted.

`chooseAgent` writes the chosen agent into the composer before trying to start
it, so a failed switch left the picker naming an agent the session was not
using while the chip still showed the old one. The selection now returns to
the agent that is actually connected.

`managed_node_receipts_put_the_script_before_agent_arguments` had pinned
`--acp` as the expected argument list while testing argument ordering, so a
correct flag change read as a failure. It now takes that list from the
definition, and a separate test pins the gemini flag so this cannot regress
quietly again.

## Two rows still wore the old card style

The live thinking indicator sat in a rounded, filled, bordered box while the
reasoning row directly above it was a plain activity row, so "Continuing" and
"Thought for 7s" did not line up. Command tool calls kept reaching the older
`ExecCard` through a name check in the tool row builder, even though
`ResearchToolCard` already renders the command view and `chat-activity`
already maps `run_command` to it. Both now take the same path as every other
tool row, which also drops the bordered status strip under the command.

`ExecCard` keeps its tests and is no longer reachable from the app. Removing
it belongs with a check that the newer card covers each state it asserts.

## Testing

Four Rust tests (message classification, help-output detection, the gemini
flag, and a mid-turn expiry that flips to `AuthRequired` and refuses the
retry) and three frontend tests (the transcript dedupe, an error that must
still show, and the panel appearing with no alert bar).

Local gates: `cargo fmt`, `cargo clippy --workspace --all-targets -D
warnings`, `cargo test --workspace`, `pnpm lint`, `pnpm test`.

One caveat on that last one. `ChatCore.agent-loop.test.tsx > keeps a queued
follow-up when backend startup fails before acceptance` fails about one full
suite run in three, and it does so at the same rate with these changes and
with them stashed (2 of 3 passing in both arms, 5 of 5 passing in isolation).
It is pre-existing and tracked separately, but it can redden a CI round here.

Verified against the installed CLIs that `claude auth login` is real for
Claude Code 2.1.258 and that Gemini CLI 0.19.4 offers `--experimental-acp` and
no `--acp`.

## The tour could not be clicked over a dialog

A Radix dialog switches pointer events off on the body while it is open and
restores them only inside its own content. The tour renders in a portal that is
a sibling of that dialog, so every step shown over the new project chooser
inherited the dead body. Next, Back and Skip did nothing while the card carried
on painting over the modal. The tooltip opts back into pointer events now,
which covers the tour anywhere it appears over a dialog.

The packaged end to end suite could not catch this. Its clicks are dispatched
through the Tauri bridge as synthetic events, and a synthetic click ignores
pointer-events, so automation walked these steps happily while a real cursor
could not reach a button. `00-tours.spec.ts` already covered the exact
transition and passed on every shard.

Two smaller tour repairs came with it. "Three ways to begin" was centred on top
of the three cards it describes and is anchored below them now. The AI settings
walkthrough could never run at all: it is opt-in by design, the coordinator
skips any tour marked `autoStart: false`, and nothing else ever started it, so
the switch in Settings only moved it between Pending and off. The tour list
offers Start for such a tour now, moving Settings to the section where the first
step can find its target and asking for the tour by name through the event that
was already there.

## Changelog

The Unreleased section had stopped around the composer work. It now records the
research workspace and its task queue, linked folders, running the assistant on
a coding agent installed on the machine, the usage report and spend limit, the
Typst toolbar, the in app browser, and the Draw tab reading real TikZ, plus the
regressions a 0.3.13 user actually hit. Defects that only ever existed inside
this unreleased cycle are left out, since nobody on 0.3.13 could have met them.
