### PR TITLE
refactor(ai): drop the legacy ExecCard and render commands through ResearchToolCard

### DIFF
--- a/src/components/ai/chat-parts.test.tsx
+++ b/src/components/ai/chat-parts.test.tsx
@@ -23,7 +23,6 @@ vi.mock("@/lib/tauri", async (importOriginal) => {
 import {
   AgentRunSummary,
   AgentStatusPill,
-  ExecCard,
   MessageItem,
   ReasoningBlock,
   SubagentCard,
@@ -922,10 +921,12 @@ describe("AI chat overflow surfaces", () => {
   });
 });
 
-describe("ExecCard run_command contract", () => {
+describe("ResearchToolCard run_command contract", () => {
+  beforeEach(clearExpansionState);
+
   it("renders the command, output, status, and exit code from the exec envelope", () => {
     const { container, getByText, queryByText } = render(
-      <ExecCard
+      <ResearchToolCard
         tc={{
           name: "run_command",
           status: "done",
@@ -941,7 +942,7 @@ describe("ExecCard run_command contract", () => {
     );
 
     const card = container.querySelector('[data-testid="exec-card"]');
-    expect(card).toHaveAttribute("data-exec-status", "Failed with exit code 7");
+    expect(card).toHaveAttribute("data-exec-status", "failed with exit code 7");
     expect(getByText("$ pnpm test")).toBeInTheDocument();
     expect(getByText("Failed with exit code 7")).toBeInTheDocument();
     expect(card?.querySelector(".text-destructive")).not.toBeNull();
@@ -952,9 +953,35 @@ describe("ExecCard run_command contract", () => {
     expect(getByText("one test failed")).toBeInTheDocument();
   });
 
+  it("marks a clean exit as done and leaves an empty-output command unexpandable", () => {
+    const { container, getByText } = render(
+      <ResearchToolCard
+        tc={{
+          name: "run_command",
+          status: "done",
+          output: JSON.stringify({
+            exec: true,
+            command: "touch notes.tex",
+            output: "",
+            status: "Done",
+            exit_code: 0,
+          }),
+        }}
+      />,
+    );
+
+    const card = container.querySelector('[data-testid="exec-card"]');
+    expect(card).toHaveAttribute("data-exec-status", "Done");
+    expect(getByText("$ touch notes.tex")).toBeInTheDocument();
+    expect(getByText("Done")).toBeInTheDocument();
+    expect(card?.querySelector(".text-emerald-500")).not.toBeNull();
+    expect(card?.querySelector(".animate-spin")).toBeNull();
+    expect(getByRole(container, "button")).not.toHaveAttribute("aria-expanded");
+  });
+
   it("renders a declined command as a terminal declined state, not a spinner", () => {
     const { container, getByText } = render(
-      <ExecCard
+      <ResearchToolCard
         tc={{
           name: "run_command",
           status: "done",
@@ -975,9 +1002,28 @@ describe("ExecCard run_command contract", () => {
     expect(card?.querySelector(".text-destructive")).not.toBeNull();
   });
 
+  it("treats a rejected approval as declined even when the envelope looks clean", () => {
+    const { container, getByText } = render(
+      <ResearchToolCard
+        tc={{
+          name: "run_command",
+          status: "done",
+          approval: "rejected",
+          output: JSON.stringify({ exec: true, command: "rm -rf build", output: "", exit_code: 0 }),
+        }}
+      />,
+    );
+    const card = container.querySelector('[data-testid="exec-card"]');
+    expect(card).toHaveAttribute("data-exec-status", "declined");
+    expect(getByText("Declined")).toBeInTheDocument();
+    expect(getByText("Rejected")).toBeInTheDocument();
+    expect(card?.querySelector(".animate-spin")).toBeNull();
+    expect(card?.querySelector(".text-emerald-500")).toBeNull();
+  });
+
   it("renders a caught error as a terminal error state, not a spinner", () => {
     const { container, getByText } = render(
-      <ExecCard
+      <ResearchToolCard
         tc={{
           name: "run_command",
           status: "done",
@@ -986,14 +1032,18 @@ describe("ExecCard run_command contract", () => {
       />,
     );
     const card = container.querySelector('[data-testid="exec-card"]');
-    expect(card).toHaveAttribute("data-exec-status", "error");
-    expect(getByText("Project changed before mutation.")).toBeInTheDocument();
+    expect(card).toHaveAttribute("data-exec-status", "failed");
     expect(card?.querySelector(".animate-spin")).toBeNull();
+    expect(card?.querySelector(".text-destructive")).not.toBeNull();
+
+    fireEvent.click(getByRole(container, "button"));
+
+    expect(getByText("Project changed before mutation.")).toBeInTheDocument();
   });
 
   it("treats a timed-out command as a failure", () => {
     const { container, getByText } = render(
-      <ExecCard
+      <ResearchToolCard
         tc={{
           name: "run_command",
           status: "done",
@@ -1009,15 +1059,15 @@ describe("ExecCard run_command contract", () => {
       />,
     );
     const card = container.querySelector('[data-testid="exec-card"]');
-    expect(card).toHaveAttribute("data-exec-status", "Timed out");
+    expect(card).toHaveAttribute("data-exec-status", "timed out");
     expect(getByText("Timed out")).toBeInTheDocument();
     expect(card?.querySelector(".animate-spin")).toBeNull();
     expect(card?.querySelector(".text-destructive")).not.toBeNull();
   });
 
-  it("treats a stopped command (null exit) as a failure, not a green check", () => {
+  it("treats a stopped command (null exit) as terminal, not a green check", () => {
     const { container, getByText } = render(
-      <ExecCard
+      <ResearchToolCard
         tc={{
           name: "run_command",
           status: "done",
@@ -1032,15 +1082,15 @@ describe("ExecCard run_command contract", () => {
       />,
     );
     const card = container.querySelector('[data-testid="exec-card"]');
-    expect(card).toHaveAttribute("data-exec-status", "Stopped");
+    expect(card).toHaveAttribute("data-exec-status", "stopped");
     expect(getByText("Stopped")).toBeInTheDocument();
-    expect(card?.querySelector(".text-destructive")).not.toBeNull();
+    expect(card?.querySelector(".animate-spin")).toBeNull();
     expect(card?.querySelector(".text-emerald-500")).toBeNull();
   });
 
   it("still spins while the call is running and its envelope is not yet parseable", () => {
     const { container } = render(
-      <ExecCard tc={{ name: "run_command", status: "running", output: "" }} />,
+      <ResearchToolCard tc={{ name: "run_command", status: "running", output: "" }} />,
     );
     const card = container.querySelector('[data-testid="exec-card"]');
     expect(card).toHaveAttribute("data-exec-status", "running");

--- a/src/components/ai/chat-parts.tsx
+++ b/src/components/ai/chat-parts.tsx
@@ -12,7 +12,6 @@ import {
   Info,
   Loader2,
   Paperclip,
-  Terminal,
   XCircle,
 } from "lucide-react";
 import type { ChatMessage, SubagentEntry, ToolEntry } from "@/store/chats";
@@ -32,7 +31,6 @@ import { usePersistentExpansion } from "@/components/ai/activity/expansion-state
 import {
   projectToolEntry,
   splitAgentNotices,
-  stripAnsi,
   type ResearchChatActions,
 } from "@/lib/chat-activity";
 import { tokenizeComposer } from "@/lib/composer-tokens";
@@ -550,148 +548,6 @@ export function explorationSummary(tools: ToolEntry[]): string {
   return parts.length === 0 ? "Explored" : `Explored ${parts.join(", ")}`;
 }
 
-// The terminal result of a run_command tool call, derived from both the
-// entry status and the envelope. A finished call whose envelope is a decline
-// or an error must resolve to a terminal state, never a perpetual spinner.
-type ExecView =
-  | {
-      kind: "exec";
-      command: string;
-      body: string;
-      status: string;
-      exitCode: number | null;
-      timedOut: boolean;
-    }
-  | { kind: "declined"; command: string }
-  | { kind: "error"; message: string }
-  | { kind: "pending" };
-
-function parseExecView(
-  output: string | undefined,
-  entryStatus: ToolEntry["status"],
-): ExecView {
-  const settled = entryStatus !== "running";
-  if (!output) {
-    return settled ? { kind: "error", message: "No result was returned." } : { kind: "pending" };
-  }
-  let parsed: {
-    exec?: boolean;
-    command?: string;
-    output?: string;
-    status?: string;
-    exit_code?: number | null;
-    timed_out?: boolean;
-    declined?: boolean;
-    error?: unknown;
-  };
-  try {
-    parsed = JSON.parse(output);
-  } catch {
-    // A partial envelope mid-stream is still pending; a finished call whose
-    // output will not parse is a genuine error worth surfacing.
-    return settled ? { kind: "error", message: output.slice(0, 300) } : { kind: "pending" };
-  }
-  if (parsed.exec && typeof parsed.command === "string") {
-    return {
-      kind: "exec",
-      command: parsed.command,
-      body: parsed.output ?? "",
-      status: parsed.status ?? (settled ? "Done" : "Running"),
-      exitCode: parsed.exit_code ?? null,
-      timedOut: Boolean(parsed.timed_out),
-    };
-  }
-  if (parsed.declined) {
-    return { kind: "declined", command: typeof parsed.command === "string" ? parsed.command : "" };
-  }
-  if (parsed.error != null) return { kind: "error", message: String(parsed.error) };
-  return settled
-    ? { kind: "error", message: "The command returned an unrecognized result." }
-    : { kind: "pending" };
-}
-
-// Command card for run_command results: `$ command`, aggregated output, and a
-// status pill (Success / Failed with exit code N / Stopped / Declined / an
-// error), per the reference exec item.
-export function ExecCard({ tc, expansionKey }: { tc: ToolEntry; expansionKey?: string }) {
-  const [expanded, setExpanded] = usePersistentExpansion(expansionKey, false);
-  const view = parseExecView(tc.output, tc.status);
-  const running = view.kind === "pending";
-  // A finished command succeeds only on a clean exit code 0. A null exit
-  // (stopped or killed) or a timeout is a failure, not a green check.
-  const failed =
-    view.kind === "error" ||
-    view.kind === "declined" ||
-    (view.kind === "exec" && (view.timedOut || view.exitCode !== 0));
-  const command =
-    view.kind === "exec" || view.kind === "declined" ? view.command : "";
-  const body = view.kind === "exec" ? stripAnsi(view.body) : "";
-  const statusLine =
-    view.kind === "exec"
-      ? view.status
-      : view.kind === "declined"
-        ? "Declined"
-        : view.kind === "error"
-          ? view.message
-          : null;
-  const dataStatus =
-    view.kind === "exec"
-      ? view.status
-      : view.kind === "declined"
-        ? "declined"
-        : view.kind === "error"
-          ? "error"
-          : "running";
-  return (
-    <div
-      data-testid="exec-card"
-      data-exec-status={dataStatus}
-      className="max-w-[85%] overflow-hidden rounded-md border bg-muted text-xs"
-    >
-      <button
-        type="button"
-        onClick={() => body && setExpanded((v) => !v)}
-        className={cn(
-          "flex w-full items-center gap-2 px-2.5 py-1.5 text-left",
-          body && "cursor-pointer hover:bg-accent/50",
-        )}
-      >
-        <Terminal className="size-3.5 shrink-0 text-muted-foreground" />
-        <code className="min-w-0 flex-1 truncate font-mono text-[11px]">
-          $ {command || tc.name}
-        </code>
-        {running ? (
-          <Loader2 className="size-3 shrink-0 animate-spin" />
-        ) : failed ? (
-          <XCircle className="size-3 shrink-0 text-destructive" />
-        ) : (
-          <CheckCircle2 className="size-3 shrink-0 text-emerald-500" />
-        )}
-        {body && (
-          <ChevronRight
-            className={cn("size-3 shrink-0 text-muted-foreground transition-transform", expanded && "rotate-90")}
-          />
-        )}
-      </button>
-      {statusLine && !running && (
-        <div
-          className={cn(
-            "border-t px-2.5 py-1 text-[10px] text-muted-foreground",
-            failed && "text-destructive",
-          )}
-        >
-          {statusLine}
-        </div>
-      )}
-      {expanded && body && (
-        <pre className="max-h-56 animate-in fade-in overflow-auto whitespace-pre-wrap break-words border-t px-2.5 py-1.5 font-mono text-[10px] text-muted-foreground duration-150 motion-reduce:animate-none">
-          {body}
-        </pre>
-      )}
-    </div>
-  );
-}
-
 // A collapsed run of read-only tool calls: "Explored 3 files, 2 searches",
 // expandable to the individual tool badges. Mirrors the reference exploration
 // grouping so a long read-heavy turn stays scannable.
@@ -1183,25 +1039,15 @@ export const MessageItem = memo(function MessageItem({
       }
       const tool = tools[i];
       const key = tool.id ?? `legacy-tool-${i}`;
-      if (tool.name === "run_command") {
-        rows.push(
-          <ExecCard
-            key={key}
-            tc={tool}
-            expansionKey={expansionScope ? `${expansionScope}:tool:${key}` : undefined}
-          />,
-        );
-      } else {
-        rows.push(
-          <ToolBadge
-            key={key}
-            tc={tool}
-            actions={actions}
-            expansionKey={expansionScope ? `${expansionScope}:tool:${key}` : undefined}
-            live={live}
-          />,
-        );
-      }
+      rows.push(
+        <ToolBadge
+          key={key}
+          tc={tool}
+          actions={actions}
+          expansionKey={expansionScope ? `${expansionScope}:tool:${key}` : undefined}
+          live={live}
+        />,
+      );
     }
   }
   for (const entry of msg.subagents ?? []) {

--- a/src/lib/chat-activity.test.ts
+++ b/src/lib/chat-activity.test.ts
@@ -138,6 +138,17 @@ describe("research chat activity", () => {
     expect(command.output).toBe("failed");
   });
 
+  it("reads a command that printed nothing as empty, not as its own envelope", () => {
+    const quiet = projectToolEntry({
+      name: "run_command",
+      status: "done",
+      output: JSON.stringify({ exec: true, command: "touch notes.tex", output: "", exit_code: 0 }),
+    });
+
+    expect(quiet.status).toBe("completed");
+    expect(quiet.output).toBe("");
+  });
+
   it("accepts only web links and strips terminal control sequences", () => {
     expect(safeWebUrl("javascript:alert(1)")).toBeUndefined();
     expect(safeWebUrl("file:///tmp/paper.pdf")).toBeUndefined();

--- a/src/lib/chat-activity.ts
+++ b/src/lib/chat-activity.ts
@@ -224,8 +224,7 @@ function readableOutput(raw: string | undefined, value: unknown): string {
   if (!raw) return "";
   if (typeof value === "string") return stripAnsi(value);
   const data = record(value);
-  const commandOutput = stringValue(data?.output);
-  if (commandOutput !== undefined) return stripAnsi(commandOutput);
+  if (typeof data?.output === "string") return stripAnsi(data.output);
   const content = stringValue(data?.content);
   if (content !== undefined) return stripAnsi(content);
   const log = stringValue(data?.log) ?? stringValue(data?.log_tail);


### PR DESCRIPTION
This started as "delete some dead code" and turned out not to be dead.

## What changed

`MessageItem` in `src/components/ai/chat-parts.tsx` had a `run_command` branch pointing at `ExecCard`, so command calls still rendered the old bordered card while every other tool rendered the flat `ResearchToolCard` row. `MessageItem` is live in `MessageList`, `SubagentActivity`, and `SessionTranscriptDialog`, so this was the card users actually saw for shell commands.

Both cards already emitted `data-testid="exec-card"` and `data-exec-status`, which is how two implementations sat behind one contract without anyone noticing.

Commands now go through `ToolBadge` like everything else. `ExecCard`, `parseExecView`, and the `ExecView` type are gone, 142 lines of them.

## Tests

`ResearchToolCard` had no command coverage at all, so the six `ExecCard` contract tests moved across instead of being deleted with the component. They assert against `ResearchToolCard`'s contract rather than the old one: `data-exec-status` is lowercased for any non-completed status, the status label lives in an `sr-only` span, and a stopped command gets a neutral halt icon instead of a red error.

Two states nobody had tested picked up cases too. One is a clean exit. The other is an approval the user rejected, which reaches the card as `approval: "rejected"` rather than as a decline inside the envelope.

## A projection fix that came with it

`readableOutput` in `src/lib/chat-activity.ts` now respects an explicit empty `output` field. `stringValue` throws away empty strings, so a command that printed nothing fell all the way through to the `JSON.stringify` fallback and offered the user its own envelope as expandable output. `ExecCard` showed nothing there. Moving commands over without this would have made quiet commands worse, not better.

## Verification

`pnpm lint`, `pnpm build`, and `pnpm test` all pass locally: 440 files, 3988 tests. The pre-commit hook ran the same gates on the commit.

Worth a look from someone who knows the assistant UI: this changes what a shell command looks like in chat, from the bordered card to the flat row. That is the intended direction, but it is a visible change and not just a deletion.
