### PR TITLE
fix(assistant): flush the debounced chat save when the panel unmounts

### DIFF
--- a/src/components/ai/ChatCore.agent-loop.test.tsx
+++ b/src/components/ai/ChatCore.agent-loop.test.tsx
@@ -1226,6 +1226,31 @@ describe("ChatCore agent turns", () => {
     expect(rendered.queryByText("Queued for the next turn: Reserve this follow-up")).toBeNull();
   });
 
+  it("flushes a debounced chat save on unmount instead of leaving it on a timer", async () => {
+    const rendered = await renderChat();
+    submit(rendered, "First request");
+    await waitFor(() => expect(mocks.runs).toHaveLength(1));
+    act(() => mocks.runs[0].options.handlers.onText("Streamed so far"));
+    await waitFor(() =>
+      expect(
+        useChatsStore.getState().live["chat-1"]?.at(-1)?.content,
+      ).toBe("Streamed so far"),
+    );
+    expect(useChatsStore.getState().byId("chat-1")?.messages.at(-1)?.content).toBe("");
+
+    rendered.unmount();
+    expect(useChatsStore.getState().byId("chat-1")?.messages.at(-1)?.content).toBe(
+      "Streamed so far",
+    );
+
+    const sentinel: ChatMessage[] = [
+      { id: "sentinel", role: "user", content: "written after unmount", createdAt: 2 },
+    ];
+    useChatsStore.getState().saveMessages("chat-1", sentinel);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(useChatsStore.getState().byId("chat-1")?.messages).toEqual(sentinel);
+  });
+
   it("keeps a queued follow-up when backend startup fails before acceptance", async () => {
     const rendered = await renderChat();
     submit(rendered, "First request");

--- a/src/components/ai/ChatCore.tsx
+++ b/src/components/ai/ChatCore.tsx
@@ -1042,6 +1042,7 @@ export function ChatCore() {
   }, [openSkillsSettings, queryClient]);
   // Trailing-debounce timer for persisting the streaming conversation.
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const persistPendingRef = useRef<{ chatId: string; msgs: ChatMessage[] } | null>(null);
   // Two-tier stream flushing: text deltas ride the frame cadence (rAF while
   // visible, a timer otherwise), structural output rides a 50 ms interval,
   // and terminal events drain both before applying. Patches batch into one
@@ -1310,17 +1311,42 @@ export function ChatCore() {
   // Coalesce to ~1 write/400ms (disk via Tauri, or localStorage in browser).
   const persistDebounced = useCallback(
     (chatId: string | null, msgs: ChatMessage[]) => {
+      persistPendingRef.current = chatId ? { chatId, msgs } : null;
       persistTimerRef.current = scheduleChatPersistence(
         persistTimerRef.current,
         chatId,
         msgs,
         (id, value) => {
           persistTimerRef.current = null;
+          persistPendingRef.current = null;
           persist(id, value);
         },
       );
     },
     [persist]
+  );
+
+  const dropPendingPersist = useCallback(() => {
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    persistTimerRef.current = null;
+    persistPendingRef.current = null;
+  }, []);
+
+  const flushPendingPersist = useCallback(() => {
+    const pending = persistPendingRef.current;
+    dropPendingPersist();
+    if (pending) persist(pending.chatId, pending.msgs);
+  }, [dropPendingPersist, persist]);
+
+  useEffect(
+    () => () => {
+      streamQueuesRef.current?.dispose();
+      streamQueuesRef.current = null;
+      streamPatchesRef.current = { text: [], output: [] };
+      streamDrainQueuedRef.current = { text: false, output: false };
+      flushPendingPersist();
+    },
+    [flushPendingPersist],
   );
 
   // Open an existing chat from history. Guarded by `streaming` (like newChat)
@@ -2621,10 +2647,7 @@ ${sandboxedCustom}`;
         if (runIsCurrent()) {
           setStreaming(false);
           setRunThinking(null);
-          if (persistTimerRef.current) {
-            clearTimeout(persistTimerRef.current);
-            persistTimerRef.current = null;
-          }
+          dropPendingPersist();
           if (runChatId) {
             useChatsStore.getState().saveMessages(runChatId, messagesRef.current);
           }
@@ -2658,7 +2681,7 @@ ${sandboxedCustom}`;
         }
       }
     }
-  }, [streaming, apiKey, provider, model, providerModelsMap, projectId, projectName, currentHead, figureToolsAvailable, engineLoaded, documentEngine, projectKind, openAISettings, flushStreamPatches, updateLast, setMessages, setInput, activeProviderName, activeChatId, trackRunRequestId, markRunSteerable, persistDebounced]);
+  }, [streaming, apiKey, provider, model, providerModelsMap, projectId, projectName, currentHead, figureToolsAvailable, engineLoaded, documentEngine, projectKind, openAISettings, flushStreamPatches, updateLast, setMessages, setInput, activeProviderName, activeChatId, trackRunRequestId, markRunSteerable, persistDebounced, dropPendingPersist]);
 
   const stop = useCallback(() => {
     pendingImagesRef.current = [];
@@ -2799,7 +2822,7 @@ ${sandboxedCustom}`;
         streamPatchesRef.current = { text: [], output: [] };
         streamDrainQueuedRef.current = { text: false, output: false };
       });
-      persistTimerRef.current = null;
+      dropPendingPersist();
       trackRunRequestId(null);
       runOwnerRef.current = false;
       endChatRun(run);
@@ -2814,7 +2837,7 @@ ${sandboxedCustom}`;
     setGoalEditorProjectId(null);
     setGoalDraft("");
     setInputState(savedDraft(projectId));
-  }, [projectId, trackRunRequestId]);
+  }, [projectId, trackRunRequestId, dropPendingPersist]);
 
   useEffect(() => {
     const sync = () => {


### PR DESCRIPTION
## The bug

`ChatCore` persists a streaming conversation on a 400 ms trailing debounce, so a
run does not rewrite the whole chat once per token. Nothing cancelled or flushed
that timer when the component unmounted, and nothing stopped the stream-queue
drains that arm it. So a write scheduled by one mounted panel could land up to
400 ms after that panel was gone, overwriting whichever chat now holds the same
id with a snapshot taken before the run finished.

`useChatsStore.saveMessages` does guard against a project switch: it skips a
write whose chat id is absent from the current project's chat list. That guard
does nothing when the id survives the switch, which is exactly what the chat
tests do. Each one builds a fresh project and reuses the id `chat-1`.

## How it showed up

`ChatCore.agent-loop.test.tsx > keeps a queued follow-up when backend startup
fails before acceptance` failed roughly one full-suite run in three, and blocked
two unrelated pre-commit runs. The assertion is a `waitFor` on the saved
messages; the error was a deep-equal mismatch on a two-element array.

The store was not late. It was wrong. Tracing every `saveMessages` call during a
failing run shows the test reaching the right state and then losing it:

    +46ms   [user "First request", assistant "First response", user "Keep this…", assistant ""]
    +54ms   [user "First request", assistant "First response"]    <- rollback, correct
    +64ms   [user "First request", assistant ""]                  <- stale timer from an earlier test
    +1073ms waitFor gives up, still [user "First request", assistant ""]

Tagging each scheduled timer with the test that created it found the culprit: a
timer scheduled in one test fired inside a later one and wrote the earlier
test's messages into the later test's chat. When that lands after the target
test's last legitimate write, the chat keeps the stale value and the `waitFor`
can never pass. It burns its full 1000 ms, and the test finishes at about
1100 ms.

Which is also why the flake looked the way it did. It needs earlier tests in the
file to have run, and it needs the target test to get through its own flow
inside the 400 ms window. That is why it came and went with machine load rather
than with any change in the tree.

## The fix

`ChatCore` now keeps the pending payload next to the timer and, on unmount,
disposes the stream queues and flushes that payload. Order matters here: a drain
already scheduled on the frame or on the 50 ms output interval would otherwise
run after unmount and arm a fresh timer, so the queues have to go first.
Flushing rather than dropping keeps the last streamed tokens. Close the panel
moments after a run and the write still happens, just immediately instead of on
a timer that outlives its owner. The run's finalizer and the project-switch path
drop the pending write through the same helper, same as before.

## Verification

- New test: `flushes a debounced chat save on unmount instead of leaving it on a
  timer`. It fails without the fix (`expected '' to be 'Streamed so far'`), and
  it caught the second leak path as well: it kept failing under full-suite load
  until the queue dispose went in. It also asserts nothing writes to the chat in
  the 600 ms after unmount.
- `pnpm test` end to end, eight times: 3986 passed, 0 failed, every run.
- `pnpm lint` and `pnpm build` clean.

## Noted, not fixed

Two unrelated wall-clock flakes turned up in `pnpm test` while measuring this
one: `project-intelligence.test.ts > keeps malformed repeated unclosed TeX
groups near-linear and explicitly partial` (asserts a 60 ms budget, measured
61.1 ms) and `mermaid-diagram.failure.test.tsx > does not retry a failed diagram
when it scrolls out of view and back`.
