### PR TITLE
fix(updater): join a running update check instead of reporting "up to date"

### DIFF
--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/store/files", () => ({
   useFilesStore: { getState: () => ({ flushForQuit }) },
 }));
 
-import { findUpdate, installUpdate, openUpdateWindow } from "./updater";
+import { findUpdate, installUpdate, openUpdateWindow, runUpdateCheck } from "./updater";
 
 beforeEach(() => {
   flushForQuit.mockReset().mockResolvedValue(undefined);
@@ -142,6 +142,42 @@ describe("installUpdate", () => {
     // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
     await expect(installUpdate(update as any)).rejects.toThrow("network down");
     expect(relaunch).not.toHaveBeenCalled();
+  });
+});
+
+describe("runUpdateCheck", () => {
+  it("hands a caller that arrives mid-check the real result, not a false 'up to date'", async () => {
+    let resolveCheck!: (u: unknown) => void;
+    check.mockImplementation(() => new Promise((resolve) => { resolveCheck = resolve; }));
+
+    const startup = runUpdateCheck();
+    await vi.waitFor(() => expect(check).toHaveBeenCalledTimes(1));
+    const manual = runUpdateCheck({ rethrow: true });
+
+    const update = { version: "0.2.0", currentVersion: "0.1.1" };
+    resolveCheck(update);
+
+    expect(await startup).toBe(update);
+    expect(await manual).toBe(update);
+    expect(check).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a failing in-flight check to the joining manual caller", async () => {
+    check.mockRejectedValue(new Error("network down"));
+
+    const startup = runUpdateCheck();
+    const manual = runUpdateCheck({ rethrow: true });
+
+    expect(await startup).toBeNull();
+    await expect(manual).rejects.toThrow("network down");
+    expect(check).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the guard so a later check runs for real", async () => {
+    check.mockResolvedValue(null);
+    expect(await runUpdateCheck()).toBeNull();
+    expect(await runUpdateCheck()).toBeNull();
+    expect(check).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -20,8 +20,10 @@ const UPDATE_WINDOW_LABEL = "update";
 // server (`isTauri()` is false) every entry point is a no-op so nothing
 // throws.
 
-// Guard against overlapping checks (startup tick racing a manual click).
-let inFlight = false;
+// Single-flight: overlapping checks (startup tick racing a manual click) join
+// the running one instead of being dropped, so every caller gets the real
+// result rather than a bare `null` it would read as "up to date".
+let inFlight: Promise<Update | null> | null = null;
 
 // In the browser dev server (`!isTauri()`) there is no updater, so this
 // resolves to `null` just like "already up to date" - callers that need to
@@ -68,11 +70,9 @@ export async function installUpdate(
 
 // Records the outcome in the updates store so the in-app prompt
 // (`UpdateNotice`) and the About "last check failed" indicator stay in sync.
-// Failures are rethrown only when `rethrow` is set, which the manual checker
-// uses to render its own inline error state.
-export async function runUpdateCheck({ rethrow = false }: { rethrow?: boolean } = {}): Promise<Update | null> {
-  if (inFlight) return null;
-  inFlight = true;
+// Runs at most once per overlapping burst; the outcome is shared, and each
+// caller applies its own `rethrow` policy to it.
+async function performUpdateCheck(): Promise<Update | null> {
   const store = useUpdatesStore.getState();
   try {
     const update = await findUpdate();
@@ -82,10 +82,23 @@ export async function runUpdateCheck({ rethrow = false }: { rethrow?: boolean } 
   } catch (e) {
     await logError("updater", e);
     store.setFailed();
+    throw e;
+  }
+}
+
+// Failures are rethrown only when `rethrow` is set, which the manual checker
+// uses to render its own inline error state.
+export async function runUpdateCheck({ rethrow = false }: { rethrow?: boolean } = {}): Promise<Update | null> {
+  if (!inFlight) {
+    inFlight = performUpdateCheck().finally(() => {
+      inFlight = null;
+    });
+  }
+  try {
+    return await inFlight;
+  } catch (e) {
     if (rethrow) throw e;
     return null;
-  } finally {
-    inFlight = false;
   }
 }
 


### PR DESCRIPTION
## The bug

`runUpdateCheck` returns `null` for two different things:

- a check ran and found no update
- a check was skipped because one was already running

`UpdateChecker` can't tell them apart, so it renders "You're on the latest version" for both.

`App.tsx` fires an automatic check 3 seconds after mount. Open About or Settings inside that window, click "Check for updates", and the UI says you're current without having checked anything. If an update does exist, you get told the opposite of the truth.

Repro: launch the app, open About within the first few seconds, click "Check for updates" while the startup check is still running.

## The fix

Overlapping callers now share the running promise instead of getting dropped. The second caller waits a moment and gets the real answer.

The store writes and the error log stay with a single owner (`performUpdateCheck`), and `rethrow` is applied per caller. That split matters on the failure path: a startup check that fails still resolves to `null`, while a manual caller joining that same failed check still gets the throw it needs for its inline error state. Without it, joining a failed startup check would just swap one wrong "up to date" for another.

`UpdateWindow` still calls `findUpdate()` directly. Its comment explains why: a separate window is a separate JS context and can't share the main window's `Update` handle.

## Tests

Three cases added to `src/lib/updater.test.ts`. The first two fail against the old code with exactly the reported symptom (`expected null to be { version: '0.2.0' }`, and `promise resolved "null" instead of rejecting`) and pass with the fix. The third checks that `inFlight` is released so a later check actually runs.

## Verification

`pnpm lint && pnpm build && pnpm test` all pass: 440 files, 3999 tests. Lint reports one warning in `App.tsx` that predates this change and is unrelated to it.
