### PR TITLE
fix(updater): bound the update download and give a stalled one a way out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A stalled update download no longer freezes the update window. If a
+  minute goes by with no data arriving, the download gives up and the
+  window says so, with a close button and a link to the releases page.
+  Before, it sat on a progress bar that never moved and could not be
+  dismissed.
 - Steer now on a queued message waits until the run has actually started.
   A quick click used to fail with "The running turn could not be steered"
   and the message went out as a separate turn once the run ended.

--- a/src/components/layout/UpdateWindow.test.tsx
+++ b/src/components/layout/UpdateWindow.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findUpdate: vi.fn(),
+  installUpdate: vi.fn(),
+  isDownloadStalled: vi.fn(),
+  close: vi.fn(),
+  invoke: vi.fn(),
+  openUrl: vi.fn(),
+  logError: vi.fn(),
+  celebrate: vi.fn(),
+  appVersion: vi.fn(),
+}));
+
+vi.mock("@/lib/updater", () => ({
+  findUpdate: mocks.findUpdate,
+  installUpdate: mocks.installUpdate,
+  isDownloadStalled: mocks.isDownloadStalled,
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ close: mocks.close }),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: mocks.openUrl }));
+vi.mock("@/lib/log", () => ({ logError: mocks.logError }));
+vi.mock("@/lib/confetti", () => ({ celebrate: mocks.celebrate }));
+vi.mock("@/lib/tauri", () => ({ appVersion: mocks.appVersion }));
+
+import { UpdateWindow } from "./UpdateWindow";
+
+describe("UpdateWindow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.appVersion.mockResolvedValue("0.3.13");
+    mocks.invoke.mockResolvedValue(true);
+    mocks.openUrl.mockResolvedValue(undefined);
+    mocks.logError.mockResolvedValue(undefined);
+    mocks.isDownloadStalled.mockReturnValue(false);
+    mocks.findUpdate.mockResolvedValue({
+      version: "0.3.14",
+      currentVersion: "0.3.13",
+      body: "notes",
+    });
+  });
+
+  it("hides the close button only while the download is healthy", async () => {
+    let finish!: () => void;
+    mocks.installUpdate.mockImplementation(
+      () => new Promise<void>((resolve) => { finish = resolve; }),
+    );
+    render(<UpdateWindow />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Update now" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Downloading/)).toBeInTheDocument();
+    finish();
+  });
+
+  it("offers a way out when the download stalls", async () => {
+    mocks.installUpdate.mockRejectedValue(new Error("stalled"));
+    mocks.isDownloadStalled.mockReturnValue(true);
+    render(<UpdateWindow />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Update now" }));
+
+    expect(await screen.findByText("Download stalled")).toBeInTheDocument();
+    expect(screen.getByText(/The download stopped responding/)).toBeInTheDocument();
+
+    const closers = screen.getAllByRole("button", { name: "Close" });
+    expect(closers).toHaveLength(2);
+    for (const closer of closers) {
+      fireEvent.click(closer);
+      expect(mocks.close).toHaveBeenCalled();
+      mocks.close.mockClear();
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "View release" }));
+    await waitFor(() => {
+      expect(mocks.openUrl).toHaveBeenCalledWith(
+        "https://github.com/Oleafly/Oleafly/releases/latest",
+      );
+    });
+  });
+
+  it("keeps the generic error screen for a failure that is not a stall", async () => {
+    mocks.installUpdate.mockRejectedValue(new Error("network down"));
+    render(<UpdateWindow />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Update now" }));
+
+    expect(await screen.findByText(/Something went wrong/)).toBeInTheDocument();
+    expect(screen.queryByText("Download stalled")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/UpdateWindow.tsx
+++ b/src/components/layout/UpdateWindow.tsx
@@ -7,7 +7,7 @@ import { AlertTriangle, CheckCircle2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LeafLogo } from "@/components/layout/LeafLogo";
 import { Markdown } from "@/components/ui/markdown";
-import { findUpdate, installUpdate } from "@/lib/updater";
+import { findUpdate, installUpdate, isDownloadStalled } from "@/lib/updater";
 import { Progress } from "@/components/ui/progress";
 import { logError } from "@/lib/log";
 import { appVersion } from "@/lib/tauri";
@@ -15,7 +15,7 @@ import { celebrate } from "@/lib/confetti";
 
 const RELEASES_URL = "https://github.com/Oleafly/Oleafly/releases/latest";
 
-type Phase = "checking" | "available" | "upToDate" | "downloading" | "error";
+type Phase = "checking" | "available" | "upToDate" | "downloading" | "stalled" | "error";
 
 // Runs its own update check on mount, because a separate window is a separate
 // JS context and cannot share the main window's `Update` handle. `?manual=1`
@@ -84,7 +84,7 @@ export function UpdateWindow() {
       // installUpdate relaunches the app on success; unreachable afterward.
     } catch (e) {
       await logError("updater", e);
-      setPhase("error");
+      setPhase(isDownloadStalled(e) ? "stalled" : "error");
     }
   };
 
@@ -93,9 +93,11 @@ export function UpdateWindow() {
       ? "Checking for updates…"
       : phase === "upToDate"
         ? "You're up to date"
-        : update
-          ? `Update available · v${update.version}`
-          : "Oleafly";
+        : phase === "stalled"
+          ? "Download stalled"
+          : update
+            ? `Update available · v${update.version}`
+            : "Oleafly";
 
   const notes = update?.body?.trim();
 
@@ -144,6 +146,15 @@ export function UpdateWindow() {
             </div>
           </div>
         )}
+        {phase === "stalled" && (
+          <p className="inline-flex items-start gap-1.5 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>
+              The download stopped responding. Check your connection and try again later, or
+              get this version from the releases page.
+            </span>
+          </p>
+        )}
         {phase === "error" && (
           <p className="inline-flex items-center gap-1.5 text-sm text-destructive">
             <AlertTriangle className="size-4" />
@@ -188,6 +199,15 @@ export function UpdateWindow() {
             </Button>
             <Button size="sm" onClick={install}>
               Update now
+            </Button>
+          </div>
+        ) : phase === "stalled" ? (
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={close}>
+              Close
+            </Button>
+            <Button size="sm" onClick={() => void openUrl(RELEASES_URL)}>
+              View release
             </Button>
           </div>
         ) : phase === "upToDate" || phase === "error" ? (

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 
 // Mock the Tauri surface the updater primitives touch. isTauri is toggled per
 // test via the exported ref so we can exercise the browser (no-updater) path.
@@ -32,7 +32,14 @@ vi.mock("@/store/files", () => ({
   useFilesStore: { getState: () => ({ flushForQuit }) },
 }));
 
-import { findUpdate, installUpdate, openUpdateWindow } from "./updater";
+import {
+  DOWNLOAD_STALL_TIMEOUT_MS,
+  DOWNLOAD_TIMEOUT_MS,
+  findUpdate,
+  installUpdate,
+  isDownloadStalled,
+  openUpdateWindow,
+} from "./updater";
 
 beforeEach(() => {
   flushForQuit.mockReset().mockResolvedValue(undefined);
@@ -142,6 +149,102 @@ describe("installUpdate", () => {
     // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
     await expect(installUpdate(update as any)).rejects.toThrow("network down");
     expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it("caps the request itself so an abandoned download can't run forever", async () => {
+    const update = {
+      downloadAndInstall: vi.fn(async (cb: (e: unknown) => void) => {
+        cb({ event: "Finished", data: {} });
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
+    await installUpdate(update as any);
+    expect(update.downloadAndInstall).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ timeout: DOWNLOAD_TIMEOUT_MS }),
+    );
+  });
+});
+
+describe("installUpdate stall detection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gives up when no byte arrives at all", async () => {
+    const update = { downloadAndInstall: vi.fn(() => new Promise<void>(() => {})) };
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
+    const installing = installUpdate(update as any);
+    const settled = expect(installing).rejects.toSatisfy(isDownloadStalled);
+    await vi.advanceTimersByTimeAsync(DOWNLOAD_STALL_TIMEOUT_MS);
+    await settled;
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it("gives up when the bytes stop mid-download", async () => {
+    let emit!: (e: unknown) => void;
+    const update = {
+      downloadAndInstall: vi.fn((cb: (e: unknown) => void) => {
+        emit = cb;
+        return new Promise<void>(() => {});
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
+    const installing = installUpdate(update as any);
+    const settled = expect(installing).rejects.toSatisfy(isDownloadStalled);
+    emit({ event: "Started", data: { contentLength: 1000 } });
+    emit({ event: "Progress", data: { chunkLength: 100 } });
+    await vi.advanceTimersByTimeAsync(DOWNLOAD_STALL_TIMEOUT_MS);
+    await settled;
+  });
+
+  it("keeps waiting while chunks keep arriving", async () => {
+    let emit!: (e: unknown) => void;
+    let finish!: () => void;
+    const update = {
+      downloadAndInstall: vi.fn((cb: (e: unknown) => void) => {
+        emit = cb;
+        return new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
+    const installing = installUpdate(update as any);
+    emit({ event: "Started", data: { contentLength: 1000 } });
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(DOWNLOAD_STALL_TIMEOUT_MS - 1000);
+      emit({ event: "Progress", data: { chunkLength: 100 } });
+    }
+    emit({ event: "Finished", data: {} });
+    finish();
+    await installing;
+    expect(relaunch).toHaveBeenCalledOnce();
+  });
+
+  it("stops watching once the bytes are in, so a slow install is not a stall", async () => {
+    let emit!: (e: unknown) => void;
+    let finish!: () => void;
+    const update = {
+      downloadAndInstall: vi.fn((cb: (e: unknown) => void) => {
+        emit = cb;
+        return new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the Update type
+    const installing = installUpdate(update as any);
+    emit({ event: "Started", data: { contentLength: 1000 } });
+    emit({ event: "Finished", data: {} });
+    await vi.advanceTimersByTimeAsync(DOWNLOAD_STALL_TIMEOUT_MS * 10);
+    finish();
+    await installing;
+    expect(relaunch).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -34,6 +34,20 @@ export async function findUpdate(): Promise<Update | null> {
   return update ?? null;
 }
 
+export const DOWNLOAD_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+export const DOWNLOAD_STALL_TIMEOUT_MS = 60_000;
+
+export class UpdateDownloadStalledError extends Error {
+  constructor() {
+    super("The update download stopped responding.");
+    this.name = "UpdateDownloadStalledError";
+  }
+}
+
+export function isDownloadStalled(e: unknown): boolean {
+  return e instanceof UpdateDownloadStalledError;
+}
+
 // When the release doesn't advertise a content length, `onProgress` stays at
 // 0 until the download finishes (then jumps to 100).
 export async function installUpdate(
@@ -42,21 +56,49 @@ export async function installUpdate(
 ): Promise<void> {
   let total = 0;
   let downloaded = 0;
-  await update.downloadAndInstall((event) => {
-    switch (event.event) {
-      case "Started":
-        total = event.data.contentLength ?? 0;
-        onProgress?.(0);
-        break;
-      case "Progress":
-        downloaded += event.data.chunkLength;
-        if (total > 0) onProgress?.(Math.min(100, Math.round((downloaded / total) * 100)));
-        break;
-      case "Finished":
-        onProgress?.(100);
-        break;
-    }
+  let stallTimer: ReturnType<typeof setTimeout> | undefined;
+  let reportStall: (() => void) | undefined;
+  const stalled = new Promise<never>((_, reject) => {
+    reportStall = () => reject(new UpdateDownloadStalledError());
   });
+  const disarm = () => {
+    if (stallTimer !== undefined) clearTimeout(stallTimer);
+    stallTimer = undefined;
+  };
+  const arm = () => {
+    disarm();
+    stallTimer = setTimeout(() => reportStall?.(), DOWNLOAD_STALL_TIMEOUT_MS);
+  };
+
+  arm();
+  try {
+    await Promise.race([
+      update.downloadAndInstall(
+        (event) => {
+          switch (event.event) {
+            case "Started":
+              total = event.data.contentLength ?? 0;
+              arm();
+              onProgress?.(0);
+              break;
+            case "Progress":
+              downloaded += event.data.chunkLength;
+              arm();
+              if (total > 0) onProgress?.(Math.min(100, Math.round((downloaded / total) * 100)));
+              break;
+            case "Finished":
+              disarm();
+              onProgress?.(100);
+              break;
+          }
+        },
+        { timeout: DOWNLOAD_TIMEOUT_MS },
+      ),
+      stalled,
+    ]);
+  } finally {
+    disarm();
+  }
   // Relaunch tears the webview down exactly like a quit, so it must go
   // through the same durable flush as window close, Cmd+Q, and Restart. A
   // failed save blocks the relaunch (the installed update simply applies on


### PR DESCRIPTION
## The gap

The updater's check phase is bounded (`check({ timeout: 15000 })` in
`src/lib/updater.ts`), but the download phase was not. `installUpdate`
called `downloadAndInstall(cb)` with no options, and
`tauri-plugin-updater` 2.10.1 builds the `Update` with `timeout: None`,
overriding it only when the frontend sends one. So reqwest ran the
download with no deadline.

A download that stopped receiving bytes never rejected. `UpdateWindow`
hides its close button while a download is in progress, so the result was
a frozen progress bar in a frameless window with no way to dismiss it.

Worth noting for anyone tracing this: there is no updater download
wrapper in `src-tauri/src/commands.rs`. The only updater code there is
`updater_self_installable`. The frontend calls the plugin's
`download_and_install` command directly, so the fix is entirely on the JS
side.

## Two bounds, because the plugin's knob is the wrong shape alone

`DownloadOptions.timeout` maps to reqwest's client timeout, a total
deadline covering connect through the last body byte. Our updater
artifacts run 86 to 190 MB (v0.3.13: 86 MB arm64 deb, 190 MB amd64
AppImage), so any total cap tight enough to notice a stall would cut off
a genuinely slow download. It is set to two hours and exists only as a
ceiling, so an abandoned request cannot outlive the app.

The bound a user actually hits is an idle timeout in the download
callback. Every `Started` and `Progress` event re-arms a 60 second timer;
if it fires, the install rejects with `UpdateDownloadStalledError`.
`Finished` disarms it, because verifying and installing a 150 MB package
is legitimately quiet for a while and a slow install is not a stall.

## The way out

A `stalled` phase in the update window. The close button comes back, the
window says the download stopped responding, and there is a link to the
releases page.

No retry button, on purpose. The plugin gives us no way to abort a
request already in flight, so a second `downloadAndInstall` would race
the first over the same install.

## Tests

`src/lib/updater.test.ts` covers the timeout reaching the plugin, a
download that never delivers a byte, one that stops mid-stream, one that
keeps trickling and finishes, and a slow install after `Finished`. The
two stall tests were checked against the unfixed code by neutering the
timer callback: both fail there, so they are not vacuous.

`src/components/layout/UpdateWindow.test.tsx` is new. It covers the close
button being hidden during a healthy download and back on a stall, both
close affordances working, the releases link, and a non-stall failure
still landing on the generic error screen.

## Gates

`pnpm lint`, `pnpm build`, `pnpm test` (441 files, 4004 tests),
`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test --workspace` all pass. No Rust changed. Lint reports one
warning in `src/App.tsx:412` that is also present on `main` and unrelated
to this change.
