### PR TITLE
fix: harden Windows performance and process lifecycles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,54 @@ app binary receives the manifest that Tauri normally embeds. Leave the
 variable unset for `cargo build` and `pnpm tauri` commands so the app binary
 keeps its single embedded manifest.
 
+The ACP protocol tests also need Python 3 on `PATH` (`python.exe` on Windows,
+`python3` on Unix). On Windows without Developer Mode, tests that require
+creating symbolic links report that the session lacks that permission.
+
+### Windows native and compiler checks
+
+`powershell -File scripts/e2e.ps1` drives the real WebView2 app, with one
+temporary library shared across fresh app launches. To test bundled frontend
+assets instead of the Vite development server:
+
+```powershell
+$env:VITE_E2E_HOOKS = "1"
+pnpm tauri build --debug --features e2e-testing --no-bundle
+Remove-Item Env:VITE_E2E_HOOKS
+$env:OLEAFLY_E2E_APP_BINARY = (Resolve-Path src-tauri/target/debug/oleafly.exe).Path
+powershell -File scripts/e2e.ps1
+Remove-Item Env:OLEAFLY_E2E_APP_BINARY
+```
+
+This binary contains test hooks and must not be distributed. The packaged
+runner explicitly lists the three browser harness specs that require Vite;
+run those separately in development mode. Live provider tests are opt-in
+through the variables in `e2e/.env.example`. Keep credentials outside Git.
+Use `--from-spec=<filename>.spec.ts` to resume the Windows sweep at an exact
+spec filename; the runner first creates the shared document in a fresh library.
+
+For the browser harnesses, start Vite with `OLEAFLY_E2E_DISABLE_HMR=1`
+(PowerShell: `$env:OLEAFLY_E2E_DISABLE_HMR="1"; pnpm dev`). This also disables
+HMR sockets in PDF module workers, avoiding a Playwright Firefox transport
+assertion before selection tests can run. Normal development keeps HMR on.
+The Windows native E2E runner sets this flag automatically for its dev server.
+
+The standalone compiler matrix checks valid PDFs, included source files,
+math, references, font selection, and errors without touching user projects:
+
+```powershell
+node scripts/smoke-document-engines.mjs
+# Optionally include installed TeX Live engines:
+$env:OLEAFLY_TEX_BIN_DIR = "C:/path/to/TinyTeX/bin/windows"
+node scripts/smoke-document-engines.mjs
+```
+
+It always checks the bundled Tectonic and Typst sidecars; setting the TeX
+directory adds pdfLaTeX, XeLaTeX, and LuaLaTeX. Logs and source fixtures are
+preserved in the temporary directory printed at completion. Run performance
+checks separately from builds and broad test suites to avoid measuring CPU
+and disk contention.
+
 Backend logic that touches the filesystem, git, or user paths **must** have a
 test. The path-sandboxing helpers (`resolve_within`, `validate_project_id`) and
 log/URL parsers are covered in `#[cfg(test)]` modules - extend them when you

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,6 +2855,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.8.2",
+ "webview2-com",
  "window-vibrancy",
  "windows-sys 0.61.2",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
 name = "oleafly-core"
 version = "0.1.0"
 dependencies = [
+ "fs4",
  "regex",
  "serde",
  "serde_json",
@@ -2908,6 +2909,7 @@ dependencies = [
  "fastcdc",
  "fs4",
  "libc",
+ "oleafly-core",
  "rand 0.8.7",
  "rusqlite",
  "same-file",

--- a/crates/oleafly-cli/src/native.rs
+++ b/crates/oleafly-cli/src/native.rs
@@ -691,6 +691,7 @@ async fn run_command(
         .env("openout_any", "p")
         .env("openin_any", "p")
         .env("shell_escape", "f")
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
@@ -711,7 +712,7 @@ async fn run_command(
         Ok(containment) => containment,
         Err(error) => {
             let _ = child.start_kill();
-            let _ = child.wait().await;
+            let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
             return Err(Error::new(
                 ErrorKind::Build,
                 format!("failed to contain compiler process: {error}"),
@@ -726,32 +727,36 @@ async fn run_command(
         .stderr
         .take()
         .ok_or_else(|| Error::new(ErrorKind::Build, "compiler stderr was not captured"))?;
-    let out_sink = sink.clone();
-    let err_sink = sink.clone();
-    let stdout_task = tokio::spawn(read_stream(stdout, out_sink));
-    let stderr_task = tokio::spawn(read_stream(stderr, err_sink));
-    let status = match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(result) => result.map_err(|error| Error::new(ErrorKind::Build, error.to_string()))?,
-        Err(_) => {
-            drop(containment);
-            let _ = child.wait().await;
-            let _ = stdout_task.await;
-            let _ = stderr_task.await;
-            return Err(Error::new(
-                ErrorKind::Build,
-                format!("compiler timed out after {} seconds", timeout.as_secs()),
-            ));
+    let mut containment = Some(containment);
+    // Readers belong to this future, so cancellation closes them rather than
+    // leaving detached log tasks and pipe handles behind.
+    let result = tokio::time::timeout(timeout, async {
+        let wait = async {
+            let status = child.wait().await?;
+            drop(containment.take());
+            Ok::<_, std::io::Error>(status)
+        };
+        tokio::try_join!(
+            wait,
+            read_stream(stdout, sink.clone()),
+            read_stream(stderr, sink.clone())
+        )
+    })
+    .await;
+    drop(containment);
+    let (status, mut log, stderr) = match result {
+        Ok(Ok(output)) => output,
+        error => {
+            let _ = child.start_kill();
+            let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
+            let message = match error {
+                Ok(Err(error)) => error.to_string(),
+                Err(_) => format!("compiler timed out after {} seconds", timeout.as_secs()),
+                Ok(Ok(_)) => unreachable!(),
+            };
+            return Err(Error::new(ErrorKind::Build, message));
         }
     };
-    drop(containment);
-    let mut log = stdout_task
-        .await
-        .map_err(|error| Error::new(ErrorKind::Build, error.to_string()))?
-        .map_err(|error| Error::new(ErrorKind::Build, error.to_string()))?;
-    let stderr = stderr_task
-        .await
-        .map_err(|error| Error::new(ErrorKind::Build, error.to_string()))?
-        .map_err(|error| Error::new(ErrorKind::Build, error.to_string()))?;
     append_bounded(&mut log, stderr.as_bytes());
     Ok((log, status.code()))
 }
@@ -1384,6 +1389,47 @@ mod tests {
     #[test]
     fn contained_command_child() {
         print!("core-ok");
+    }
+
+    #[tokio::test]
+    async fn compiler_deadline_covers_a_process_with_closed_output_on_windows_too() {
+        let directory = TempDir::new().unwrap();
+        let started = Instant::now();
+        let arguments = [
+            OsString::from("-e"),
+            OsString::from(
+                "require('fs').closeSync(1);require('fs').closeSync(2);setInterval(()=>{},1000)",
+            ),
+        ];
+        let error = run_command(
+            Path::new("node"),
+            &arguments,
+            directory.path(),
+            Duration::from_millis(250),
+            &CompilerLog::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn compiler_completion_stops_descendants_holding_log_pipes() {
+        let directory = TempDir::new().unwrap();
+        let arguments = [OsString::from("-e"), OsString::from(
+            "require('child_process').spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{stdio:['ignore',1,2]});process.stdout.write('compiled');process.exit(0)")];
+        let (output, status) = run_command(
+            Path::new("node"),
+            &arguments,
+            directory.path(),
+            Duration::from_secs(5),
+            &CompilerLog::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status, Some(0));
+        assert_eq!(output, "compiled");
     }
 
     #[cfg(unix)]

--- a/crates/oleafly-core/Cargo.toml
+++ b/crates/oleafly-core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 rust-version = "1.77"
 
 [dependencies]
+fs4 = "1.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/oleafly-core/src/compile_log.rs
+++ b/crates/oleafly-core/src/compile_log.rs
@@ -242,7 +242,9 @@ pub fn parse_latex_log(log: &str, root_file: Option<&str>) -> Vec<LogDiagnostic>
         out: Vec::new(),
     };
     for line in head(log).split('\n') {
-        parser.parse_line(line);
+        // Windows compiler pipes use CRLF. Keep the line terminator out of
+        // anchored patterns and diagnostic context, matching the LF path.
+        parser.parse_line(line.strip_suffix('\r').unwrap_or(line));
     }
     if let Some(current) = parser.current.take() {
         if !patterns().bib_empty.is_match(&current.text) {

--- a/crates/oleafly-core/src/lib.rs
+++ b/crates/oleafly-core/src/lib.rs
@@ -1,6 +1,7 @@
 mod build;
 mod compile_log;
 mod error;
+pub mod locking;
 mod manifest;
 mod tree;
 mod workspace;

--- a/crates/oleafly-core/src/locking.rs
+++ b/crates/oleafly-core/src/locking.rs
@@ -1,0 +1,108 @@
+//! Bounded admission to storage transactions. A busy store must return an
+//! error without stealing its owner's lock or changing any stored data.
+use std::fs::File;
+use std::io;
+use std::sync::{Mutex, MutexGuard, TryLockError};
+use std::time::{Duration, Instant};
+
+pub const STORAGE_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn retry<T>(budget: Duration, mut attempt: impl FnMut() -> io::Result<Option<T>>) -> io::Result<T> {
+    let started = Instant::now();
+    let mut delay = Duration::from_millis(2);
+    loop {
+        if let Some(value) = attempt()? {
+            return Ok(value);
+        }
+        let remaining = budget.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "storage is busy with another operation; retry when it finishes",
+            ));
+        }
+        std::thread::sleep(delay.min(remaining));
+        delay = (delay * 2).min(Duration::from_millis(100));
+    }
+}
+
+pub fn lock_file(file: &File, exclusive: bool, budget: Duration) -> io::Result<()> {
+    retry(budget, || {
+        let result = if exclusive {
+            fs4::FileExt::try_lock(file)
+        } else {
+            fs4::FileExt::try_lock_shared(file)
+        };
+        match result {
+            Ok(()) => Ok(Some(())),
+            Err(fs4::TryLockError::WouldBlock) => Ok(None),
+            Err(fs4::TryLockError::Error(error)) => Err(error),
+        }
+    })
+}
+
+pub fn lock_mutex<T>(mutex: &Mutex<T>, budget: Duration) -> io::Result<MutexGuard<'_, T>> {
+    retry(budget, || match mutex.try_lock() {
+        Ok(guard) => Ok(Some(guard)),
+        Err(TryLockError::Poisoned(error)) => Ok(Some(error.into_inner())),
+        Err(TryLockError::WouldBlock) => Ok(None),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn busy_file_lock_times_out_and_preserves_ownership() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("transaction.lock");
+        let first = File::create(&path).unwrap();
+        let second = File::options().read(true).write(true).open(&path).unwrap();
+        lock_file(&first, true, Duration::ZERO).unwrap();
+        for exclusive in [false, true] {
+            let started = Instant::now();
+            let error = lock_file(&second, exclusive, Duration::from_millis(25)).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+            assert!(started.elapsed() < Duration::from_secs(2));
+        }
+        fs4::FileExt::unlock(&first).unwrap();
+        lock_file(&second, true, Duration::ZERO).unwrap();
+    }
+
+    #[test]
+    fn shared_readers_can_coexist_and_a_waiter_recovers_after_release() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("transaction.lock");
+        let first = File::options()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        let second = File::options().read(true).write(true).open(&path).unwrap();
+        lock_file(&first, false, Duration::ZERO).unwrap();
+        lock_file(&second, false, Duration::ZERO).unwrap();
+        fs4::FileExt::unlock(&second).unwrap();
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            fs4::FileExt::unlock(&first).unwrap();
+        });
+        lock_file(&second, true, Duration::from_secs(2)).unwrap();
+        release.join().unwrap();
+    }
+
+    #[test]
+    fn busy_mutex_has_a_deadline_and_can_be_retried() {
+        let mutex = Mutex::new(7);
+        let guard = mutex.lock().unwrap();
+        assert_eq!(
+            lock_mutex(&mutex, Duration::from_millis(10))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::TimedOut
+        );
+        drop(guard);
+        assert_eq!(*lock_mutex(&mutex, Duration::ZERO).unwrap(), 7);
+    }
+}

--- a/crates/oleafly-core/tests/compile_log.rs
+++ b/crates/oleafly-core/tests/compile_log.rs
@@ -338,8 +338,16 @@ fn assert_golden(log_path: &Path, expected_path: &Path) {
     )
     .unwrap();
     let root_file = expected["rootFile"].as_str();
+    let unix_log = log.replace("\r\n", "\n");
+    let windows_log = unix_log.replace('\n', "\r\n");
     let started = Instant::now();
     let diagnostics = parse_latex_log(&log, root_file);
+    assert_eq!(
+        parse_latex_log(&unix_log, root_file),
+        parse_latex_log(&windows_log, root_file),
+        "{}: LF and CRLF diagnostics differ",
+        log_path.display()
+    );
     eprintln!(
         "{}: {} bytes, {} diagnostics in {:?}",
         log_path.display(),

--- a/crates/oleafly-history/Cargo.toml
+++ b/crates/oleafly-history/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 rust-version = "1.77"
 
 [dependencies]
+oleafly-core = { path = "../oleafly-core" }
 blake3 = "=1.5.5"
 fastcdc = "3"
 fs4 = "1.1"

--- a/crates/oleafly-history/src/lib.rs
+++ b/crates/oleafly-history/src/lib.rs
@@ -618,7 +618,11 @@ impl PublicationStore {
 
         let parent = store_parent(&self.target_root)?;
         let namespace_lock = open_namespace_lock(parent, true)?;
-        fs4::FileExt::lock(&namespace_lock)?;
+        oleafly_core::locking::lock_file(
+            &namespace_lock,
+            true,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         if self.target_root.try_exists()? {
             return Err(HistoryError::Corrupt(format!(
                 "checkpoint store appeared while its first publication was being installed: {}",
@@ -711,7 +715,11 @@ impl Store {
         })?;
         let root = parent.join(name);
         let namespace_lock = open_namespace_lock(&parent, true)?;
-        fs4::FileExt::lock_shared(&namespace_lock)?;
+        oleafly_core::locking::lock_file(
+            &namespace_lock,
+            false,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         fs::create_dir_all(&root)?;
         validate_real_directory(&root, "checkpoint store root")?;
         set_private_directory_permissions(&root)?;
@@ -722,7 +730,11 @@ impl Store {
         let operation_lock = open_with_no_follow(&mut operation_options, &operation_lock_path)?;
         validate_regular_file(&operation_lock_path, "checkpoint operation lock")?;
         set_private_file_permissions(&root.join(OPERATION_LOCK_FILE))?;
-        fs4::FileExt::lock(&operation_lock)?;
+        oleafly_core::locking::lock_file(
+            &operation_lock,
+            true,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         initialize_format(&root)?;
         fs::create_dir_all(root.join("packs"))?;
         fs::create_dir_all(root.join("staging"))?;
@@ -822,7 +834,11 @@ impl Store {
             )));
         }
         let namespace_lock = open_namespace_lock(&parent, false)?;
-        fs4::FileExt::lock_shared(&namespace_lock)?;
+        oleafly_core::locking::lock_file(
+            &namespace_lock,
+            false,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         if !root.try_exists()? {
             return Ok(None);
         }
@@ -895,7 +911,11 @@ impl Store {
         };
         let namespace_lock = open_namespace_lock(&parent, true)?;
         if wait_for_namespace {
-            fs4::FileExt::lock(&namespace_lock)?;
+            oleafly_core::locking::lock_file(
+                &namespace_lock,
+                true,
+                oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+            )?;
         } else {
             match fs4::FileExt::try_lock(&namespace_lock) {
                 Ok(()) => {}
@@ -2675,7 +2695,11 @@ impl Store {
         options.read(true).write(true);
         let file = open_with_no_follow(&mut options, &path)?;
         validate_regular_file(&path, "checkpoint operation lock")?;
-        fs4::FileExt::lock_shared(&file)?;
+        oleafly_core::locking::lock_file(
+            &file,
+            false,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         Ok(file)
     }
 
@@ -2685,13 +2709,17 @@ impl Store {
         options.read(true).write(true);
         let file = open_with_no_follow(&mut options, &path)?;
         validate_regular_file(&path, "checkpoint operation lock")?;
-        fs4::FileExt::lock(&file)?;
+        oleafly_core::locking::lock_file(&file, true, oleafly_core::locking::STORAGE_LOCK_TIMEOUT)?;
         Ok(file)
     }
 
     fn acquire_shared_locks(&self) -> Result<StoreLocks> {
         let namespace = open_namespace_lock(store_parent(&self.root)?, false)?;
-        fs4::FileExt::lock_shared(&namespace)?;
+        oleafly_core::locking::lock_file(
+            &namespace,
+            false,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         let operation = self.acquire_shared_operation_lock()?;
         Ok(StoreLocks {
             _namespace: namespace,
@@ -2701,7 +2729,11 @@ impl Store {
 
     fn acquire_exclusive_locks(&self) -> Result<StoreLocks> {
         let namespace = open_namespace_lock(store_parent(&self.root)?, false)?;
-        fs4::FileExt::lock_shared(&namespace)?;
+        oleafly_core::locking::lock_file(
+            &namespace,
+            false,
+            oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+        )?;
         let operation = self.acquire_exclusive_operation_lock()?;
         Ok(StoreLocks {
             _namespace: namespace,
@@ -3793,7 +3825,7 @@ fn lock_initialization(parent: &Path, name: &std::ffi::OsStr, wait: bool) -> Res
         )));
     }
     if wait {
-        fs4::FileExt::lock(&file)?;
+        oleafly_core::locking::lock_file(&file, true, oleafly_core::locking::STORAGE_LOCK_TIMEOUT)?;
     } else {
         match fs4::FileExt::try_lock(&file) {
             Ok(()) => {}

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -17,6 +17,8 @@ The references below are for contributors, integrators, and release maintainers.
 | [Releasing](../releasing.md) | Release workflow and artifact checks |
 | [Code signing](../signing.md) | Platform signing requirements |
 | [Auto-updates](../updates.md) | Update manifests, signatures, and rollback |
+| [Windows v0.4 validation](windows-v0.4-validation.md) | The flow inventory run against a packaged Windows build |
+| [Windows lifecycle audit](windows-lifecycle-audit.md) | Process, storage, and terminal lifetimes and their bounds |
 
 ## Build from source
 

--- a/docs/developer/windows-lifecycle-audit.md
+++ b/docs/developer/windows-lifecycle-audit.md
@@ -1,0 +1,77 @@
+# Windows lifecycle and contention audit
+
+This extends the [v0.4.0 flow validation](windows-v0.4-validation.md) with a
+source audit of process ownership, cancellation, storage contention, and UI
+teardown. The focus is work that can survive its owner or keep another action
+waiting indefinitely. Tests use synthetic libraries on Windows x64.
+
+## Source coverage
+
+- Process creation and waits: desktop `proc`, Git, compiler adapters, TeX
+  utilities, CLI compilation, agent execution, task execution, ACP, MCP, and
+  language-server runtimes. Reviewed Job Object ownership and pipe cleanup.
+- Storage coordination: project worktree admission, settings and secret
+  transactions, checkpoint initialization/namespace/operation locks, atomic
+  replacement, restore recovery, and durable cleanup.
+- UI lifetime: terminal startup/input/resize/output/disposal, project analysis
+  and worker clients, compile cancellation, PDF worker/render cancellation,
+  and update/quit gates.
+
+Repository-wide searches identified blocking process calls, file locks,
+spawned readers, timers, and worker teardown paths. The targeted review and
+regressions below establish specific guarantees; they do not prove that all
+possible driver, filesystem, external tool, and network failures are absent.
+
+## Changes
+
+| Failure path | Resulting behavior |
+| --- | --- |
+| Git waits forever for a stalled process or inherited output pipe | A shared asynchronous reactor collects output with a 120-second command deadline, or 300 seconds for authenticated remote operations; the owned process tree closes when its leader exits |
+| An external command floods memory | Collection rejects more than 64 MiB per pipe, stops the process tree, and reports an error instead of returning silently truncated file content |
+| Pandoc version probes never exit | Discovery and downloaded-binary validation stop the owned process tree after five seconds |
+| Storage locks wait indefinitely behind another process | Worktree, config, secrets, and checkpoint locks have a 30-second admission budget per lock; contention returns an error without stealing the lock or modifying its owner's data |
+| Config/secret callers queue indefinitely behind an in-process transaction | Their mutex admission also has a 30-second budget, preserving existing poison recovery behavior |
+| MCP cancellation detaches its diagnostics reader | Transport disposal aborts the reader and closes the owned process tree; uncooperative shutdown has bounded cleanup |
+| MCP discovery starts `icacls` and depends on account-name environment variables | Native current-user SID ACL installation runs before credential bytes are written and propagates failure |
+| Temporary Windows readers prevent settings/discovery replacement | Both publications use the existing eight-second bounded atomic-replacement retry |
+| ConPTY resize blocks the UI and the global session registry | Resize runs on a blocking worker and holds only that terminal's master lock |
+| Resize events accumulate while ConPTY is slow | The renderer keeps one active request and only the latest queued size, suppresses unchanged sizes, and drops queued work on disposal |
+| A shell finishes starting after its renderer reloads | An admission generation rejects and closes the stale session before registering it |
+| Agent/task cleanup waits indefinitely after cancellation or timeout | Cleanup closes the owned tree before a bounded child wait |
+| CLI cancellation detaches compiler log readers | Both readers belong to the command future; its deadline covers output collection and child execution, with bounded cleanup |
+| Disposed project analysis publishes a late result | Disposal clears pending diagnostic references and prevents late result/error publication and new indexing |
+
+Explicitly detached user-requested services and successful background agent
+commands retain their established behavior. Cleanup targets processes owned
+by the operation, never unrelated installed services or user terminals.
+
+## Regression evidence
+
+The added tests cover stalled children, output flooding, descendants holding
+both log pipes, closed-output compiler deadlines, storage contention and
+recovery, MCP disposal and uncooperative shutdown, terminal reload admission,
+and a blocked terminal master while the global registry remains available.
+A renderer regression sends 220 intervening resize sizes while the first
+request is stalled and observes only the first and final sizes reaching IPC.
+Editor analysis tests reject a late response after disposal without changing
+the store snapshot.
+
+The native application inventory contains 1,330 passing tests across the broad
+run and clean reruns, with five existing ignored cases. The broad run passed
+1,322 tests; three startup-timeout cases and five cases affected by an overlapping
+rebuild were covered by a clean, sequential 310-test rerun. No failed case remains
+in the consolidated inventory. Workspace Clippy passed with warnings denied.
+
+Core, history, and CLI validation passed 154 unit and integration tests. The
+frontend lifecycle set passed 64 tests across terminal panes/queues, project
+analysis, worker recovery, and stale PDF work. Typecheck and lint passed; lint
+retains the pre-existing dependency warning in `App.tsx`.
+
+All three editor performance gates passed without a simultaneous local build
+or native test sweep. P95 was 85.44 ms for 6,200-line source analysis, 56.84 ms
+for 200-file project analysis, and 5.11 ms for end-of-book completion. The existing
+budgets are 750 ms, 750 ms, and 100 ms respectively. These measurements cover
+synchronous editor work on this host, not total startup or compiler latency.
+
+The pull request records the final production build and targeted native UI
+follow-up results alongside the original 350-case flow inventory.

--- a/docs/developer/windows-lifecycle-audit.md
+++ b/docs/developer/windows-lifecycle-audit.md
@@ -40,6 +40,7 @@ possible driver, filesystem, external tool, and network failures are absent.
 | Agent/task cleanup waits indefinitely after cancellation or timeout | Cleanup closes the owned tree before a bounded child wait |
 | CLI cancellation detaches compiler log readers | Both readers belong to the command future; its deadline covers output collection and child execution, with bounded cleanup |
 | Disposed project analysis publishes a late result | Disposal clears pending diagnostic references and prevents late result/error publication and new indexing |
+| Returning focus from a toolbar overwrites a source navigation with the old browser selection | Source navigation uses CodeMirror's focus API to synchronize the DOM selection while preventing ancestor scrolling |
 
 Explicitly detached user-requested services and successful background agent
 commands retain their established behavior. Cleanup targets processes owned
@@ -55,6 +56,12 @@ A renderer regression sends 220 intervening resize sizes while the first
 request is stalled and observes only the first and final sizes reaching IPC.
 Editor analysis tests reject a late response after disposal without changing
 the store snapshot.
+
+A Windows CI failure in toolbar definition navigation reproduced locally. The
+analysis and caret were correct before the action, but direct content-DOM focus
+restored the old browser selection after navigation. A regression reproduces the
+DOM/state mismatch before the fix; all 11 core and application editor-controller
+tests pass after using CodeMirror's synchronized, scroll-preserving focus API.
 
 The native application inventory contains 1,330 passing tests across the broad
 run and clean reruns, with five existing ignored cases. The broad run passed

--- a/docs/developer/windows-v0.4-validation.md
+++ b/docs/developer/windows-v0.4-validation.md
@@ -31,6 +31,10 @@ is Windows x64, build 26200, with Node 22.23.1 and WebView2.
 - CRLF compiler output missed anchored diagnostic patterns in the Rust log
   parser. It now removes the carriage-return line terminator before parsing;
   every golden log is checked with both LF and CRLF endings.
+- Windows browser shortcuts stopped reaching the toolbar when a webpage had
+  focus. Native WebView2 accelerators now route Ctrl+L/T/W/R to the trusted
+  toolbar without granting remote pages IPC access. Other editing shortcuts
+  remain with the page.
 
 Windows test corrections cover CRLF fixture offsets, platform-specific
 shortcuts and shell commands, Python executable discovery, locale-dependent
@@ -51,6 +55,7 @@ false results, rejected promises, eventual success, and timeout behavior.
 | Windows atomic save | 11 sandbox tests passed, including a three-second held-reader regression |
 | Settings persistence | 66 native tests passed, including encrypted-secret retention and endpoint changes |
 | Browser preview | Nine checks passed across Chromium, Firefox, and WebKit for PDF selection, Markdown math/fonts, and detached preview |
+| Native browser | 29 Rust tests passed, including shortcut mapping and existing browser security/lifecycle tests; the normal production app passed physical Ctrl+L/T/R/W checks from webpage focus |
 | Source Control concurrency | 31 frontend tests passed, including 20 rapid refresh and staging clicks |
 | Native regression sweep | 41 cases passed across create/compile, Git, editor toolbar, preview controls, library, SyncTeX, file collisions, and Git restore, including isolated reruns of two corrected Git waits; one remote-publish case skipped |
 | Template compilation | All 26 cases passed across the gallery and image/export checks, including the Markdown regression rerun |
@@ -63,9 +68,9 @@ false results, rejected promises, eventual success, and timeout behavior.
 | Compiler log integration | 22 passed after fixing CRLF diagnostic parsing; golden logs now check both line-ending forms |
 | Live Z.AI assistant | Nine passed: model discovery, real streamed replies, usage, reasoning, file tools, delegated task and transcript, custom gateway, selection persistence, catalog refresh, and rejected key handling |
 | Local Ollama | Six passed using `llama3.2:3b`: discovery, real response, usage, file tool, trailing slash, and host persistence |
-| Manual native UI | Visual LaTeX edit, undo/redo, source round trip, compile and PDF text; detached preview fit, rotation, inversion, reader mode and close; project fork, staging, local commit and Git history; terminal pane startup |
+| Manual native UI | Visual LaTeX edit, undo/redo, source round trip, compile and PDF text; detached preview fit, rotation, inversion, reader mode and close; project fork, staging, local commit and Git history; terminal Ctrl+backtick open/close; browser Ctrl+Shift+B, address navigation, back/forward, tab controls, and page-focused shortcuts |
 | Focused frontend regressions | 79 chat/Markdown/diagram/project-setup tests, 118 assistant-loop tests, six dock tests, and 37 compile-store tests passed |
-| Frontend suite | The broad Windows run passed 3,737 tests but encountered worker startup failures and platform/test-fixture failures. All 60 affected files passed in a clean 358-test rerun after corrections; CI passed all 4,027 tests on the preceding product revision |
+| Frontend suite | The broad Windows run passed 3,737 tests but encountered worker startup failures and platform/test-fixture failures. All 60 affected files passed in a clean 358-test rerun after corrections; CI passed all 4,028 tests on the completed flow-validation revision |
 | Git diff reload | A real CodeMirror component regression passed for staging and unstaging with a fast asynchronous Git backend |
 | Checkpoint UI and archives | Tectonic, Typst, and Markdown passed compile deduplication, labels, source restore/recompile, encrypted export/import, password validation, and keep-latest retention; archive import preserved the working document |
 | Compiler selection | Six native UI checks passed for Tectonic, explicit pdfLaTeX/XeLaTeX/LuaLaTeX, Auto, and project reopen persistence |
@@ -121,8 +126,8 @@ application startup or compiler timings.
 ## Scope and exclusions
 
 Three browser-only specs were run separately across Chromium, Firefox, and
-WebKit. Native keyboard accelerators and the separate browser window cannot
-be inspected through the app bridge and need computer-use checks. The native
+WebKit. Native keyboard accelerators and the separate browser window were
+checked through computer use on the normal production build. The native
 sweep leaves those two bridge-only cases explicitly skipped, along with remote
 GitHub publishing without its dedicated test credentials.
 

--- a/docs/developer/windows-v0.4-validation.md
+++ b/docs/developer/windows-v0.4-validation.md
@@ -45,7 +45,10 @@ a packaged test binary instead of rebuilding the development app per spec.
 | Settings persistence | 66 native tests passed, including encrypted-secret retention and endpoint changes |
 | Browser preview | Nine checks passed across Chromium, Firefox, and WebKit for PDF selection, Markdown math/fonts, and detached preview |
 | Source Control concurrency | 31 frontend tests passed, including 20 rapid refresh and staging clicks |
+| Native regression sweep | 41 cases passed across create/compile, Git, editor toolbar, preview controls, library, SyncTeX, file collisions, and Git restore, including isolated reruns of two corrected Git waits; one remote-publish case skipped |
+| Template compilation | All 26 cases passed across the gallery and image/export checks, including the Markdown regression rerun |
 | Research task storage and recovery | 42 passed after the worker change, including a regression that checks execution leaves the calling thread and preserves errors |
+| Research command boundary | Task create/list/edit/cancel-retry, transcript reads, and preview error preservation passed through the asynchronous commands |
 | Command-line integration | 11 passed, including build output contracts and watch recovery |
 | Language services | TexLab 5.26.0 and Tinymist 0.15.2 passed seven rapid document revisions with no stale diagnostic regression |
 | Other Rust workspace crates | 312 passed: agent 237, CLI 23, core 28, history 24 |

--- a/docs/developer/windows-v0.4-validation.md
+++ b/docs/developer/windows-v0.4-validation.md
@@ -28,6 +28,9 @@ is Windows x64, build 26200, with Node 22.23.1 and WebView2.
   still fail compilation.
 - An open working-tree diff retained its old INDEX baseline after staging or
   committing. Both working and staged diffs now refresh when Git changes.
+- CRLF compiler output missed anchored diagnostic patterns in the Rust log
+  parser. It now removes the carriage-return line terminator before parsing;
+  every golden log is checked with both LF and CRLF endings.
 
 Windows test corrections cover CRLF fixture offsets, platform-specific
 shortcuts and shell commands, Python executable discovery, locale-dependent
@@ -52,6 +55,8 @@ a packaged test binary instead of rebuilding the development app per spec.
 | Command-line integration | 11 passed, including build output contracts and watch recovery |
 | Language services | TexLab 5.26.0 and Tinymist 0.15.2 passed seven rapid document revisions with no stale diagnostic regression |
 | Other Rust workspace crates | 312 passed: agent 237, CLI 23, core 28, history 24 |
+| Checkpoint storage integration | 41 passed, including atomic archive import/export, duplicate imports, corruption rejection, retention, and cancellation |
+| Compiler log integration | 22 passed after fixing CRLF diagnostic parsing; golden logs now check both line-ending forms |
 | Live Z.AI assistant | Nine passed: model discovery, real streamed replies, usage, reasoning, file tools, delegated task and transcript, custom gateway, selection persistence, catalog refresh, and rejected key handling |
 | Local Ollama | Six passed using `llama3.2:3b`: discovery, real response, usage, file tool, trailing slash, and host persistence |
 | Manual native UI | Visual LaTeX edit, undo/redo, source round trip, compile and PDF text; detached preview fit, rotation, inversion, reader mode and close; project fork, staging, local commit and Git history; terminal pane startup |

--- a/docs/developer/windows-v0.4-validation.md
+++ b/docs/developer/windows-v0.4-validation.md
@@ -36,6 +36,10 @@ Windows test corrections cover CRLF fixture offsets, platform-specific
 shortcuts and shell commands, Python executable discovery, locale-dependent
 timestamps, and cold lazy-module imports. The native runner can also exercise
 a packaged test binary instead of rebuilding the development app per spec.
+The vendored native test bridge also returned early for asynchronous predicates:
+it treated a Promise as truthy before the result arrived. It now awaits the
+predicate before deciding whether to poll again. A real-app regression checks
+false results, rejected promises, eventual success, and timeout behavior.
 
 ## Completed checks
 
@@ -61,10 +65,20 @@ a packaged test binary instead of rebuilding the development app per spec.
 | Local Ollama | Six passed using `llama3.2:3b`: discovery, real response, usage, file tool, trailing slash, and host persistence |
 | Manual native UI | Visual LaTeX edit, undo/redo, source round trip, compile and PDF text; detached preview fit, rotation, inversion, reader mode and close; project fork, staging, local commit and Git history; terminal pane startup |
 | Focused frontend regressions | 79 chat/Markdown/diagram/project-setup tests, 118 assistant-loop tests, six dock tests, and 37 compile-store tests passed |
+| Frontend suite | The broad Windows run passed 3,737 tests but encountered worker startup failures and platform/test-fixture failures. All 60 affected files passed in a clean 358-test rerun after corrections; CI passed all 4,027 tests on the preceding product revision |
+| Git diff reload | A real CodeMirror component regression passed for staging and unstaging with a fast asynchronous Git backend |
+| Checkpoint UI and archives | Tectonic, Typst, and Markdown passed compile deduplication, labels, source restore/recompile, encrypted export/import, password validation, and keep-latest retention; archive import preserved the working document |
+| Compiler selection | Six native UI checks passed for Tectonic, explicit pdfLaTeX/XeLaTeX/LuaLaTeX, Auto, and project reopen persistence |
+| Complete native flow coverage | 350 distinct cases passed across the broad sweep and corrected reruns. The final 20-case set passed with asynchronous bridge waits, including Git, assistant settings/history/instructions, live file tools, and all five ACP cases |
+| Terminal | Six passed: real shell output and exit, multiple tabs, rename, close-others, ten-session limit, and configured shortcut routes |
+| Research and ACP | Task execution/review, linked-folder access and unlink, project setup, conflict-preserving apply, ACP sign-in/model/permissions, history/reconnect, cooperative stop, and forced child-process termination passed |
 
 The live checks assert assistant output rather than matching text in the user
 prompt. Credentials stay outside the repository and are not included in test
 artifacts or this report.
+The Ollama file-tool check uses the app's tool picker to expose `read_file`
+alone. An unconstrained repeat with the small local model selected a shell
+command and waited for approval; this was model behavior, not an app hang.
 
 ## Compiler matrix
 
@@ -87,11 +101,30 @@ false pass. These are representative font and engine cases, not every font
 installed on every Windows machine. Build and test contention makes timings
 from the functional matrix unsuitable as performance benchmarks.
 
-## Remaining validation record
+## Editor performance
 
-The packaged full-flow sweep, browser-only harness checks, final frontend and
-workspace totals, and production/performance gates are recorded here when
-their runs finish.
+The existing performance gate passed all three tests with no concurrent local
+build or native test sweep. Each measurement uses three warmups and 20 measured
+runs. These are synchronous editor-operation timings on this host, not total
+application startup or compiler timings.
+
+| Operation | P95 | Existing budget |
+| --- | ---: | ---: |
+| 6,200-line document analysis | 69.71 ms | 750 ms |
+| Syntax lint | 3.50 ms | 50 ms |
+| Proofreading extraction | 95.29 ms | 2,000 ms |
+| Inline math scan | 30.91 ms | 500 ms |
+| 200-file project analysis | 52.44 ms | 750 ms |
+| Citation completion | 0.033 ms | 250 ms |
+| End-of-book command completion | 4.85 ms | 100 ms |
+
+## Scope and exclusions
+
+Three browser-only specs were run separately across Chromium, Firefox, and
+WebKit. Native keyboard accelerators and the separate browser window cannot
+be inspected through the app bridge and need computer-use checks. The native
+sweep leaves those two bridge-only cases explicitly skipped, along with remote
+GitHub publishing without its dedicated test credentials.
 
 The test binary deliberately includes E2E hooks and must not be distributed.
 Windows symlink-creation tests require Developer Mode or the relevant privilege;

--- a/docs/developer/windows-v0.4-validation.md
+++ b/docs/developer/windows-v0.4-validation.md
@@ -1,0 +1,91 @@
+# Windows v0.4.0 validation
+
+This audit started from `65bfadcd1` after updating to the published v0.4.0
+line. Tests use temporary project libraries and synthetic documents. The host
+is Windows x64, build 26200, with Node 22.23.1 and WebView2.
+
+## Fixes found during validation
+
+- Secret-file hardening launched `icacls` for each lock-file access. Native
+  Windows ACL calls now install the same protected, current-user-only access
+  without a child process or environment-based account-name lookup. Tests
+  inspect the resulting ACL and preserve Unicode paths and file contents.
+- Template listing and preview reads could block the UI thread on disk I/O.
+  They now run on blocking workers.
+- Research task list, create, edit, retry, transcript, and preview commands
+  also performed synchronous storage work on the UI thread. Blocking workers
+  preserve their validation, errors, and event notifications.
+- Settings persistence and project renaming now leave the UI thread before
+  waiting for filesystem locks and writing metadata.
+- Windows atomic saves now tolerate temporary non-delete-sharing readers for
+  up to eight seconds without truncating or removing the previous document.
+  A native regression holds such a reader for three seconds.
+- Repeated Git refreshes coalesce, and staging admits one pending action at
+  a time, preventing a growing queue of worktree lock requests.
+- Markdown compilation incorrectly rejected a valid PDF because Pandoc
+  forwarded a nonfatal Tectonic Fontconfig initialization message. That
+  message remains visible as a warning; PDF errors and failed exit codes
+  still fail compilation.
+- An open working-tree diff retained its old INDEX baseline after staging or
+  committing. Both working and staged diffs now refresh when Git changes.
+
+Windows test corrections cover CRLF fixture offsets, platform-specific
+shortcuts and shell commands, Python executable discovery, locale-dependent
+timestamps, and cold lazy-module imports. The native runner can also exercise
+a packaged test binary instead of rebuilding the development app per spec.
+
+## Completed checks
+
+| Area | Evidence |
+| --- | --- |
+| Production frontend | Typecheck and build passed; bundle budget passed with one PDF worker, 59 KaTeX fonts, and zero development hook tokens |
+| Static checks | Biome lint passed with one pre-existing warning; Rust formatting and workspace Clippy passed |
+| Native application unit tests | 1,315 passed in the broad run; two startup-timeout cases passed on isolated rerun; five existing ignored tests |
+| Windows atomic save | 11 sandbox tests passed, including a three-second held-reader regression |
+| Settings persistence | 66 native tests passed, including encrypted-secret retention and endpoint changes |
+| Browser preview | Nine checks passed across Chromium, Firefox, and WebKit for PDF selection, Markdown math/fonts, and detached preview |
+| Source Control concurrency | 31 frontend tests passed, including 20 rapid refresh and staging clicks |
+| Research task storage and recovery | 42 passed after the worker change, including a regression that checks execution leaves the calling thread and preserves errors |
+| Command-line integration | 11 passed, including build output contracts and watch recovery |
+| Language services | TexLab 5.26.0 and Tinymist 0.15.2 passed seven rapid document revisions with no stale diagnostic regression |
+| Other Rust workspace crates | 312 passed: agent 237, CLI 23, core 28, history 24 |
+| Live Z.AI assistant | Nine passed: model discovery, real streamed replies, usage, reasoning, file tools, delegated task and transcript, custom gateway, selection persistence, catalog refresh, and rejected key handling |
+| Local Ollama | Six passed using `llama3.2:3b`: discovery, real response, usage, file tool, trailing slash, and host persistence |
+| Manual native UI | Visual LaTeX edit, undo/redo, source round trip, compile and PDF text; detached preview fit, rotation, inversion, reader mode and close; project fork, staging, local commit and Git history; terminal pane startup |
+| Focused frontend regressions | 79 chat/Markdown/diagram/project-setup tests, 118 assistant-loop tests, six dock tests, and 37 compile-store tests passed |
+
+The live checks assert assistant output rather than matching text in the user
+prompt. Credentials stay outside the repository and are not included in test
+artifacts or this report.
+
+## Compiler matrix
+
+`node scripts/smoke-document-engines.mjs` exercises actual compiler processes,
+checks PDF headers for valid documents, and checks diagnostic failures with no
+PDF for invalid documents. All 13 cases passed on this host. Setting
+`OLEAFLY_TEX_BIN_DIR` includes TeX Live.
+
+| Engine | Valid cases | Invalid case |
+| --- | --- | --- |
+| Tectonic 0.16.9 | Standard document and `fontspec` with Arial | Undefined command |
+| Typst 0.15.0 | Standard document, Libertinus Serif, and Windows Arial | Unknown function |
+| pdfLaTeX | Standard document through latexmk | Undefined command |
+| XeLaTeX | Arial through fontspec and latexmk | Undefined command |
+| LuaLaTeX | Arial through fontspec and latexmk | Undefined command |
+
+Valid fixtures include another source file, equations, references, and tables.
+Typst font checks reject an unknown-font warning so fallback cannot produce a
+false pass. These are representative font and engine cases, not every font
+installed on every Windows machine. Build and test contention makes timings
+from the functional matrix unsuitable as performance benchmarks.
+
+## Remaining validation record
+
+The packaged full-flow sweep, browser-only harness checks, final frontend and
+workspace totals, and production/performance gates are recorded here when
+their runs finish.
+
+The test binary deliberately includes E2E hooks and must not be distributed.
+Windows symlink-creation tests require Developer Mode or the relevant privilege;
+this host does not grant it. Remote publishing and account integrations need
+their respective credentials and are separate from local Git versioning.

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,8 +1,8 @@
 # Opt-in secrets/flags for the e2e suite. Copy to e2e/.env (gitignored) and
 # fill in real values; anything set in your shell takes precedence.
 
-# GitHub personal access token (classic, `repo` scope). Enables the
-# source-control stage/diff/commit test, which connects the app with this PAT.
+# GitHub personal access token (classic, `repo` scope) for remote publishing.
+# Local initialization, staging, diffs, commits, and restores need no token.
 E2E_GITHUB_TOKEN=
 
 # Set to 1 to run the push-to-origin test. Configure the project's remote

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -128,16 +128,25 @@ export async function reloadNativePage(page: TauriPage) {
 }
 
 async function ensureNativePageReady(page: TauriPage) {
-  try {
-    await page.waitForFunction(
-      productionE2e
-        ? 'document.readyState !== "loading" && (document.querySelector("#root")?.childElementCount ?? 0) > 0'
-        : 'document.readyState !== "loading" && !!window.__PW_ACTIVE__ && (document.querySelector("#root")?.childElementCount ?? 0) > 0',
-      10_000,
-    );
-  } catch {
-    await reloadNativePage(page);
+  // The TCP listener precedes WebView2 navigation and Vite's cold transforms.
+  // Reloading after ten seconds restarts a healthy boot and can discard an
+  // in-flight bridge result. Poll read-only readiness before any page access.
+  const deadline = Date.now() + 90_000;
+  let lastError: unknown = "the app root has not mounted";
+  while (Date.now() < deadline) {
+    try {
+      const ready = await page.evaluate<boolean>(
+        productionE2e
+          ? 'document.readyState !== "loading" && (document.querySelector("#root")?.childElementCount ?? 0) > 0'
+          : 'document.readyState !== "loading" && !!window.__PW_ACTIVE__ && (document.querySelector("#root")?.childElementCount ?? 0) > 0',
+      );
+      if (ready) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
   }
+  throw new Error(`Native app did not become ready: ${String(lastError)}`);
 }
 
 async function focusNativeWindow(page: TauriPage) {
@@ -250,6 +259,7 @@ function createNativeTest(dismissTours: boolean) {
       if (!ping.ok) throw new Error("plugin ping failed");
       const page = adaptForPackagedRuntime(new TauriPage(client));
       page.setDefaultTimeout(20_000);
+      await ensureNativePageReady(page);
       const firstPage = !nativePageOpened;
       const inheritedProject = firstPage && await page.evaluate<boolean>(
         `document.querySelector('button[aria-label="Home"]') !== null`,

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1093,6 +1093,15 @@ export async function ensureGithubConnected(page: Page) {
 // switched the active provider (HTTP 401s).
 export async function expandProviderCard(page: Page) {
   const provider = process.env.E2E_AI_PROVIDER || "Z.AI";
+  const providers = page.locator('[data-testid="ai-settings-tab-providers"]');
+  await expect(providers).toBeVisible({ timeout: 15_000 });
+  await providers.focus();
+  await providers.press("Enter");
+  await page.waitForFunction(
+    `Array.from(document.querySelectorAll('button[aria-expanded]')).some(
+      button => (button.textContent || '').includes(${JSON.stringify(provider)}))`,
+    15_000,
+  );
   await page.evaluate(
     `(() => {
       const modal = document.querySelector('[aria-label="Close settings"]')?.closest('.fixed');
@@ -1123,10 +1132,8 @@ export async function ensureAiConnected(page: Page) {
   const token = process.env.E2E_AI_TOKEN;
   if (!token) throw new Error("ensureAiConnected: E2E_AI_TOKEN not set");
   await openRailTab(page, "Research Assistant");
-  const ready = await page.evaluate<boolean>(
-    `!!document.querySelector('textarea[placeholder*="Ask AI"], textarea[placeholder*="Describe a figure"]')`,
-  );
-  if (ready) return;
+  // A composer can belong to a previous spec's mock provider. Reconnect the
+  // requested provider through settings before sending a live request.
   await openSettings(page, "ai");
   await expandProviderCard(page);
   await page.evaluate(
@@ -1180,6 +1187,15 @@ export async function ensureAiConnected(page: Page) {
     );
   }
   await page.click('[aria-label="Close settings"]');
+  const model = process.env.E2E_AI_MODEL;
+  if (model) {
+    await page.evaluate(`(async () => {
+      const { getConfig, setConfig } = await import("/src/lib/tauri.ts");
+      const config = await getConfig();
+      await setConfig({ ...config, ai_model: ${JSON.stringify(model)} });
+      window.dispatchEvent(new CustomEvent("oleafly:ai-config-changed"));
+    })()`);
+  }
   await openRailTab(page, "Research Assistant");
   await page.waitForFunction(
     `!!document.querySelector('textarea[placeholder*="Ask AI"], textarea[placeholder*="Describe a figure"]')`,
@@ -1804,4 +1820,15 @@ export async function stageAllGitChanges(page: Page) {
     })()`,
     60_000,
   );
+}
+
+/** Inspect a completed tool card, never a tool name echoed in the user prompt. */
+export async function expectCompletedReadFile(page: Page) {
+  await page.waitForFunction(`(() => {
+    const message = Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1);
+    const worked = Array.from(message?.querySelectorAll('button') ?? [])
+      .find(button => /^Worked (for|through)/.test(button.textContent.trim()));
+    if (worked?.getAttribute('aria-expanded') === 'false') worked.click();
+    return !!message?.querySelector('[data-tool-name="read_file"][data-tool-status="done"]');
+  })()`, 20_000);
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1779,6 +1779,14 @@ export async function clickTabByText(page: Page, scope: string, name: string, ti
 }
 
 export async function stageAllGitChanges(page: Page) {
+  await page.waitForFunction(
+    `import("/src/store/files.ts").then(({ useFilesStore }) =>
+      Object.values(useFilesStore.getState().files).every((file) => !file.dirty))`,
+    60_000,
+  );
+  // The rail may already be open from a previous commit. Request the current
+  // saved working tree instead of relying on a mount-time status snapshot.
+  await page.click('[aria-label="Refresh"]');
   // The control is hover-revealed. Wait for Git's initial status, then invoke
   // the real button once; polling must not enqueue more stage/refresh work.
   await page.waitForFunction(

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1777,3 +1777,23 @@ export async function clickTabByText(page: Page, scope: string, name: string, ti
   })()`);
   await page.waitForFunction(`(${match})?.getAttribute("aria-selected") === "true"`, timeoutMs);
 }
+
+export async function stageAllGitChanges(page: Page) {
+  // The control is hover-revealed. Wait for Git's initial status, then invoke
+  // the real button once; polling must not enqueue more stage/refresh work.
+  await page.waitForFunction(
+    `(() => {
+      const button = document.querySelector('[aria-label="Stage all"]');
+      return button instanceof HTMLButtonElement && !button.disabled;
+    })()`,
+    30_000,
+  );
+  await page.evaluate(`document.querySelector('[aria-label="Stage all"]').click()`);
+  await page.waitForFunction(
+    `(() => {
+      const button = document.querySelector('[aria-label="Unstage all"]');
+      return button instanceof HTMLButtonElement && !button.disabled;
+    })()`,
+    60_000,
+  );
+}

--- a/e2e/tests/00-bridge.spec.ts
+++ b/e2e/tests/00-bridge.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "../fixtures";
+
+test("asynchronous app predicates are polled until they resolve true", async ({ tauriPage }) => {
+  await tauriPage.evaluate("window.__e2eAsyncPollCount = 0");
+  await tauriPage.waitForFunction("Promise.resolve(++window.__e2eAsyncPollCount >= 3)", 5_000);
+  expect(await tauriPage.evaluate("window.__e2eAsyncPollCount")).toBe(3);
+
+  await tauriPage.evaluate("window.__e2eAsyncPollCount = 0");
+  await tauriPage.waitForFunction(`(++window.__e2eAsyncPollCount < 3)
+    ? Promise.reject(new Error('not ready')) : Promise.resolve(true)`, 5_000);
+  expect(await tauriPage.evaluate("window.__e2eAsyncPollCount")).toBe(3);
+  await expect(tauriPage.waitForFunction("Promise.resolve(false)", 250)).rejects.toThrow(/timeout/);
+  await tauriPage.evaluate("delete window.__e2eAsyncPollCount");
+});

--- a/e2e/tests/12-git.spec.ts
+++ b/e2e/tests/12-git.spec.ts
@@ -4,6 +4,7 @@ import {
   ensureGithubConnected,
   openProject,
   openRailTab,
+  stageAllGitChanges,
   pressGlobal,
   typeInEditorAfter,
   type Page,
@@ -35,22 +36,7 @@ async function initializeRepository(page: Page) {
 
 async function stageAllAndCommit(page: Page, message: string) {
   await openRailTab(page, "Source Control");
-  let stagedVisible = false;
-  for (let i = 0; i < 25 && !stagedVisible; i++) {
-    await page.evaluate(
-      `(() => {
-        const b = document.querySelector('[aria-label="Stage all"]');
-        if (b) b.click();
-        return 1;
-      })()`,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 800));
-    stagedVisible = await page.evaluate<boolean>(
-      `!!document.querySelector('[aria-label="Unstage all"]')`,
-    );
-    if (!stagedVisible) await page.click('[aria-label="Refresh"]');
-  }
-  if (!stagedVisible) throw new Error("stageAllAndCommit: staging never became visible");
+  await stageAllGitChanges(page);
   await expect(page.locator('[data-testid="commit-title"]')).toBeVisible({ timeout: 10_000 });
   await page.fill('[data-testid="commit-title"]', message);
   const commit = page.locator('[data-testid="commit-button"]');
@@ -163,6 +149,22 @@ test("stage, diff, and commit without requiring a connected account", async ({ t
   await tauriPage.click('[data-testid="git-change-main.tex"]', { timeout: 5_000 });
   await tauriPage.waitForFunction(
     `!!document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText, .cm-merge-a, .cm-merge-b, .cm-mergeView')`,
+    15_000,
+  );
+
+  // Keep the working diff open while its INDEX baseline changes. The editor
+  // must remove staged additions and show them again after unstaging.
+  await tauriPage.click('[aria-label="Stage all"]');
+  await tauriPage.waitForFunction(
+    `!!document.querySelector('[aria-label="Unstage all"]') &&
+      !!document.querySelector('.cm-mergeView') &&
+      !document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')`,
+    15_000,
+  );
+  await tauriPage.click('[aria-label="Unstage all"]');
+  await tauriPage.waitForFunction(
+    `!!document.querySelector('[aria-label="Stage all"]') &&
+      !!document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')`,
     15_000,
   );
 

--- a/e2e/tests/12-git.spec.ts
+++ b/e2e/tests/12-git.spec.ts
@@ -136,17 +136,17 @@ test("stage, diff, and commit without requiring a connected account", async ({ t
   await typeInEditorAfter(tauriPage, "here.", ` ${marker}`);
 
   await openRailTab(tauriPage, "Source Control");
-  // The autosave may still be landing and the panel refreshes on mount, not
-  // on file saves, so refresh until the change shows.
-  for (let i = 0; i < 20; i++) {
-    await tauriPage.click('[aria-label="Refresh"]');
-    const ready = await tauriPage.evaluate<boolean>(
-      `!!document.querySelector('[data-testid="git-change-main.tex"]')`,
-    );
-    if (ready) break;
-    await new Promise((r) => setTimeout(r, 1000));
-  }
-  await tauriPage.click('[data-testid="git-change-main.tex"]', { timeout: 5_000 });
+  // Observe autosave before requesting one final Git snapshot. Repeated
+  // refresh clicks invalidate in-flight snapshots on a slow Windows host.
+  await tauriPage.waitForFunction(
+    `import("/src/store/files.ts").then(({ useFilesStore }) =>
+      useFilesStore.getState().files["main.tex"]?.dirty === false)`,
+    60_000,
+  );
+  await tauriPage.click('[aria-label="Refresh"]');
+  await expect(tauriPage.getByTestId("git-change-main.tex")).toBeVisible({ timeout: 30_000 });
+  await tauriPage.click('[data-testid="git-change-main.tex"]');
+  await tauriPage.click('[aria-label="Split view"]');
   await tauriPage.waitForFunction(
     `!!document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText, .cm-merge-a, .cm-merge-b, .cm-mergeView')`,
     15_000,
@@ -154,18 +154,18 @@ test("stage, diff, and commit without requiring a connected account", async ({ t
 
   // Keep the working diff open while its INDEX baseline changes. The editor
   // must remove staged additions and show them again after unstaging.
-  await tauriPage.click('[aria-label="Stage all"]');
+  await stageAllGitChanges(tauriPage);
   await tauriPage.waitForFunction(
     `!!document.querySelector('[aria-label="Unstage all"]') &&
       !!document.querySelector('.cm-mergeView') &&
       !document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')`,
-    15_000,
+    30_000,
   );
-  await tauriPage.click('[aria-label="Unstage all"]');
+  await tauriPage.evaluate(`document.querySelector('[aria-label="Unstage all"]').click()`);
   await tauriPage.waitForFunction(
     `!!document.querySelector('[aria-label="Stage all"]') &&
       !!document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')`,
-    15_000,
+    30_000,
   );
 
   const message = `e2e: commit ${marker}`;

--- a/e2e/tests/12-git.spec.ts
+++ b/e2e/tests/12-git.spec.ts
@@ -155,12 +155,30 @@ test("stage, diff, and commit without requiring a connected account", async ({ t
   // Keep the working diff open while its INDEX baseline changes. The editor
   // must remove staged additions and show them again after unstaging.
   await stageAllGitChanges(tauriPage);
-  await tauriPage.waitForFunction(
-    `!!document.querySelector('[aria-label="Unstage all"]') &&
-      !!document.querySelector('.cm-mergeView') &&
-      !document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')`,
-    30_000,
-  );
+  try {
+    await tauriPage.waitForFunction(
+      `!!document.querySelector('[aria-label="Unstage all"]') &&
+        !!document.querySelector('.cm-mergeView') &&
+        !document.querySelector('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')`,
+      30_000,
+    );
+  } catch (error) {
+    const snapshot = await tauriPage.evaluate<string>(`(async () => {
+      const { useFilesStore } = await import('/src/store/files.ts');
+      const { gitShow } = await import('/src/lib/tauri.ts');
+      const files = useFilesStore.getState();
+      return JSON.stringify({
+        mode: localStorage.getItem('oleafly.diffMode'),
+        unstage: !!document.querySelector('[aria-label="Unstage all"]'),
+        mergeViews: document.querySelectorAll('.cm-mergeView').length,
+        changes: Array.from(document.querySelectorAll('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')).map(el => ({ className: el.className, text: el.textContent })),
+        sides: Array.from(document.querySelectorAll('.cm-merge-a, .cm-merge-b')).map(el => el.textContent),
+        file: files.files['main.tex'],
+        index: await gitShow(files.projectId, 'INDEX', 'main.tex'),
+      });
+    })()`);
+    throw new Error(`Working diff remained changed after staging: ${snapshot}`, { cause: error });
+  }
   await tauriPage.evaluate(`document.querySelector('[aria-label="Unstage all"]').click()`);
   await tauriPage.waitForFunction(
     `!!document.querySelector('[aria-label="Stage all"]') &&

--- a/e2e/tests/12-git.spec.ts
+++ b/e2e/tests/12-git.spec.ts
@@ -164,11 +164,12 @@ test("stage, diff, and commit without requiring a connected account", async ({ t
     );
   } catch (error) {
     const snapshot = await tauriPage.evaluate<string>(`(async () => {
-      const { useFilesStore } = await import('/src/store/files.ts');
-      const { gitShow } = await import('/src/lib/tauri.ts');
+      const { useFilesStore } = await import("/src/store/files.ts");
+      const { gitShow } = await import("/src/lib/tauri.ts");
       const files = useFilesStore.getState();
       return JSON.stringify({
         mode: localStorage.getItem('oleafly.diffMode'),
+        workingDiff: document.body.innerText.includes('Working ↔ Index'),
         unstage: !!document.querySelector('[aria-label="Unstage all"]'),
         mergeViews: document.querySelectorAll('.cm-mergeView').length,
         changes: Array.from(document.querySelectorAll('.cm-changedLine, .cm-insertedLine, .cm-deletedChunk, .cm-changedText')).map(el => ({ className: el.className, text: el.textContent })),

--- a/e2e/tests/17-preview-controls.spec.ts
+++ b/e2e/tests/17-preview-controls.spec.ts
@@ -338,11 +338,12 @@ test("invert colors toggles on and off", async ({ tauriPage }) => {
   // Toggle through whichever form the toolbar is showing and assert the pane's
   // own state: the collapsed menu item carries no aria-pressed.
   const pane = tauriPage.getByTestId("preview-pane");
-  await expect(pane).toHaveAttribute("data-preview-inverted", "false");
+  const initial = await pane.getAttribute("data-preview-inverted");
+  expect(["true", "false"]).toContain(initial);
   await activatePreviewControl(tauriPage, "Invert PDF preview colors");
-  await expect(pane).toHaveAttribute("data-preview-inverted", "true");
+  await expect(pane).toHaveAttribute("data-preview-inverted", initial === "true" ? "false" : "true");
   await activatePreviewControl(tauriPage, "Invert PDF preview colors");
-  await expect(pane).toHaveAttribute("data-preview-inverted", "false");
+  await expect(pane).toHaveAttribute("data-preview-inverted", initial!);
   await expect(tauriPage.locator(".pdf-canvas")).toBeVisible();
 });
 

--- a/e2e/tests/21-library.spec.ts
+++ b/e2e/tests/21-library.spec.ts
@@ -102,7 +102,7 @@ test("the bookmark stacks above the hover preview overlay", async ({ tauriPage }
     70_000,
   );
 
-  const stacked = await tauriPage.evaluate<boolean>(
+  const layers = await tauriPage.evaluate<{ bookmark: number; preview: number } | null>(
     `(() => {
       const el = Array.from(document.querySelectorAll('button[aria-label^="Open "]'))
         .find((b) => b.textContent.includes('E2E Doc'));
@@ -110,12 +110,13 @@ test("the bookmark stacks above the hover preview overlay", async ({ tauriPage }
       const img = el && el.querySelector('img[draggable="false"]');
       const overlay = img && img.parentElement;
       const bookmarkLayer = btn?.parentElement;
-      if (!bookmarkLayer || !overlay) return false;
+      if (!bookmarkLayer || !overlay) return null;
       const z = (n) => parseInt(getComputedStyle(n).zIndex || '0', 10) || 0;
-      return z(bookmarkLayer) > z(overlay);
+      return { bookmark: z(bookmarkLayer), preview: z(overlay) };
     })()`,
   );
-  expect(stacked).toBe(true);
+  expect(layers).not.toBeNull();
+  expect(layers!.bookmark).toBeGreaterThan(layers!.preview);
 });
 
 test("fork a project from the context menu", async ({ tauriPage }) => {

--- a/e2e/tests/24-pdf-selection-browser.spec.ts
+++ b/e2e/tests/24-pdf-selection-browser.spec.ts
@@ -8,44 +8,15 @@ import {
   webkit,
 } from "@playwright/test";
 
-const VITE_CLIENT_WITHOUT_TRANSPORT = String.raw`
-const styles = new Map();
-export class ErrorOverlay extends HTMLElement {}
-export function createHotContext() {
-  return {
-    accept() {},
-    acceptExports() {},
-    decline() {},
-    dispose() {},
-    invalidate() {},
-    on() {},
-    off() {},
-    prune() {},
-    send() {},
-  };
-}
-export function updateStyle(id, content) {
-  let style = styles.get(id);
-  if (!style) {
-    style = document.createElement("style");
-    style.dataset.viteDevId = id;
-    document.head.appendChild(style);
-    styles.set(id, style);
-  }
-  style.textContent = content;
-}
-export function removeStyle(id) {
-  styles.get(id)?.remove();
-  styles.delete(id);
-}
-export function injectQuery(url) { return url; }
-`;
+import { VITE_CLIENT_WITHOUT_TRANSPORT } from "../vite-client-without-transport";
 
 async function dragAcrossProductionPdf(page: Page) {
   // This fixture verifies Oleafly's production PDF renderer, not Vite's
   // development transport. Playwright Firefox can receive Vite's HMR socket
   // events out of order and abort inside its adapter. Keep Vite's CSS module
   // contract while removing only that unrelated WebSocket.
+  // Start Vite with OLEAFLY_E2E_DISABLE_HMR=1 to cover module-worker sockets
+  // as well; page routes cannot intercept the worker's Vite client.
   await page.context().route("**/@vite/client", (route) =>
     route.fulfill({
       status: 200,

--- a/e2e/tests/24-synctex-inverse.spec.ts
+++ b/e2e/tests/24-synctex-inverse.spec.ts
@@ -676,12 +676,12 @@ test("PDF selection geometry is exact for mixed pages, rotation, UserUnit and tr
   })()`;
   const baseline = await tauriPage.evaluate<PageGeometry[]>(inspectPages);
 
-  expect(baseline[0].width).toBeCloseTo(612, 2);
-  expect(baseline[0].height).toBeCloseTo(792, 2);
+  expectCssSubpixel(baseline[0].width, 612);
+  expectCssSubpixel(baseline[0].height, 792);
   expect(baseline[0].canvasWidth).toBe(765);
   expect(baseline[0].canvasHeight).toBe(990);
-  expect(baseline[1].width).toBeCloseTo(900, 2);
-  expect(baseline[1].height).toBeCloseTo(628, 2);
+  expectCssSubpixel(baseline[1].width, 900);
+  expectCssSubpixel(baseline[1].height, 628);
   expect(baseline[1].canvasWidth).toBe(1_125);
   expect(baseline[1].canvasHeight).toBe(785);
   expect(baseline[1].rotation).toBe("90");
@@ -807,10 +807,10 @@ test("PDF selection geometry is exact for mixed pages, rotation, UserUnit and tr
 
   expect(transient[0].rasterScale).toBe("1");
   expect(transient[1].rasterScale).toBe("1");
-  expect(transient[0].width).toBeCloseTo(1_224, 2);
-  expect(transient[0].height).toBeCloseTo(1_584, 2);
-  expect(transient[1].width).toBeCloseTo(1_800, 2);
-  expect(transient[1].height).toBeCloseTo(1_260, 2);
+  expectCssSubpixel(transient[0].width, 1_224);
+  expectCssSubpixel(transient[0].height, 1_584);
+  expectCssSubpixel(transient[1].width, 1_800);
+  expectCssSubpixel(transient[1].height, 1_260);
   for (let index = 0; index < transient.length; index++) {
     expect(transient[index].layerEdgeError).toBeLessThanOrEqual(0.05);
   }

--- a/e2e/tests/29-history-restore.spec.ts
+++ b/e2e/tests/29-history-restore.spec.ts
@@ -3,6 +3,7 @@ import {
   createBlankProject,
   fillCommandPalette,
   openRailTab,
+  stageAllGitChanges,
   pressGlobal,
   typeInEditorAfter,
 } from "../helpers";
@@ -35,25 +36,7 @@ async function initializeRepository(page: import("../helpers").Page) {
 
 async function commitAll(page: import("../helpers").Page, message: string) {
   await openRailTab(page, "Source Control");
-  // Stage all is hover-revealed (opacity-0): the plugin's own click waits for
-  // visibility and never fires, so click the real button via the DOM. Keep
-  // refreshing + staging until the STAGED section is actually visible.
-  let stagedVisible = false;
-  for (let i = 0; i < 25 && !stagedVisible; i++) {
-    await page.evaluate(
-      `(() => {
-        const b = document.querySelector('[aria-label="Stage all"]');
-        if (b) b.click();
-        return 1;
-      })()`,
-    );
-    await new Promise((r) => setTimeout(r, 800));
-    stagedVisible = await page.evaluate<boolean>(
-      `!!document.querySelector('[aria-label="Unstage all"]')`,
-    );
-    if (!stagedVisible) await page.click('[aria-label="Refresh"]');
-  }
-  if (!stagedVisible) throw new Error("commitAll: staging never became visible");
+  await stageAllGitChanges(page);
   await expect(page.locator('[data-testid="commit-title"]')).toBeVisible({ timeout: 10_000 });
   await page.fill('[data-testid="commit-title"]', message);
   const commit = page.locator('[data-testid="commit-button"]');

--- a/e2e/tests/30-project-kinds.spec.ts
+++ b/e2e/tests/30-project-kinds.spec.ts
@@ -28,6 +28,7 @@ const TEX_TEMPLATES = [
   "thesis",
 ];
 const NETWORK_TEMPLATES = ["modern-resume"];
+const OTHER_TEMPLATES = ["blank-typst", "typst-report", "typst-resume", "blank-markdown"];
 
 async function createFromTemplate(page: import("../helpers").Page, id: string, name: string) {
   await createProjectFromTemplate(page, id, name);
@@ -36,7 +37,10 @@ async function createFromTemplate(page: import("../helpers").Page, id: string, n
 async function compileClean(page: import("../helpers").Page) {
   await page.click('[data-testid="compile-button"]');
   await expect(page.locator(".pdf-canvas")).toBeVisible({ timeout: 150_000 });
-  await expect(page.getByTestId("compile-status")).toHaveAttribute("data-severity", "ok");
+  await page.waitForFunction(
+    `["ok", "warning"].includes(document.querySelector('[data-testid="compile-status"]')?.getAttribute('data-severity'))`,
+    10_000,
+  );
 }
 
 async function exportMenuItems(page: import("../helpers").Page): Promise<string> {
@@ -49,7 +53,7 @@ async function exportMenuItems(page: import("../helpers").Page): Promise<string>
   return page.evaluate<string>(`document.body.innerText`);
 }
 
-for (const id of TEX_TEMPLATES) {
+for (const id of [...TEX_TEMPLATES, ...OTHER_TEMPLATES]) {
   test(`template ${id}: create and compile with zero errors`, async ({ tauriPage }) => {
     test.setTimeout(240_000);
     await createFromTemplate(tauriPage, id, `E2E T ${id} ${RUN}`);

--- a/e2e/tests/30-project-kinds.spec.ts
+++ b/e2e/tests/30-project-kinds.spec.ts
@@ -34,11 +34,17 @@ async function createFromTemplate(page: import("../helpers").Page, id: string, n
   await createProjectFromTemplate(page, id, name);
 }
 
-async function compileClean(page: import("../helpers").Page) {
+// TeX templates must still land on "ok". Only the Typst and Markdown ones
+// legitimately report warnings, so widen the accepted severity per template
+// rather than for the whole matrix.
+async function compileClean(
+  page: import("../helpers").Page,
+  severities: readonly string[] = ["ok"],
+) {
   await page.click('[data-testid="compile-button"]');
   await expect(page.locator(".pdf-canvas")).toBeVisible({ timeout: 150_000 });
   await page.waitForFunction(
-    `["ok", "warning"].includes(document.querySelector('[data-testid="compile-status"]')?.getAttribute('data-severity'))`,
+    `${JSON.stringify(severities)}.includes(document.querySelector('[data-testid="compile-status"]')?.getAttribute('data-severity'))`,
     10_000,
   );
 }
@@ -57,7 +63,10 @@ for (const id of [...TEX_TEMPLATES, ...OTHER_TEMPLATES]) {
   test(`template ${id}: create and compile with zero errors`, async ({ tauriPage }) => {
     test.setTimeout(240_000);
     await createFromTemplate(tauriPage, id, `E2E T ${id} ${RUN}`);
-    await compileClean(tauriPage);
+    await compileClean(
+      tauriPage,
+      OTHER_TEMPLATES.includes(id) ? ["ok", "warning"] : ["ok"],
+    );
   });
 }
 

--- a/e2e/tests/35-refs-chat.spec.ts
+++ b/e2e/tests/35-refs-chat.spec.ts
@@ -124,6 +124,8 @@ test("custom instructions steer a real reply", async ({ tauriPage }) => {
   // before that resolves gets clobbered back to the saved text, leaving
   // Save disabled - hence the wait below before clearing.
   await openSettings(tauriPage, "ai");
+  await tauriPage.locator('[data-testid="ai-settings-tab-instructions"]').focus();
+  await tauriPage.locator('[data-testid="ai-settings-tab-instructions"]').press("Enter");
   await tauriPage.waitForFunction(
     `((document.querySelector(${JSON.stringify(instructionTa)}) || {}).value || '').includes(${JSON.stringify(prefix)})`,
     10_000,

--- a/e2e/tests/38-git-history.spec.ts
+++ b/e2e/tests/38-git-history.spec.ts
@@ -4,6 +4,7 @@ import {
   createBlankProject,
   fillCommandPalette,
   openRailTab,
+  stageAllGitChanges,
   pressGlobal,
   typeInEditorAfter,
   type Page,
@@ -39,22 +40,7 @@ async function initializeRepository(page: Page) {
 
 async function commitAll(page: Page, message: string) {
   await openRailTab(page, "Source Control");
-  let stagedVisible = false;
-  for (let i = 0; i < 25 && !stagedVisible; i++) {
-    await page.evaluate(
-      `(() => {
-        const b = document.querySelector('[aria-label="Stage all"]');
-        if (b) b.click();
-        return 1;
-      })()`,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 800));
-    stagedVisible = await page.evaluate<boolean>(
-      `!!document.querySelector('[aria-label="Unstage all"]')`,
-    );
-    if (!stagedVisible) await page.click('[aria-label="Refresh"]');
-  }
-  if (!stagedVisible) throw new Error("commitAll: staging never became visible");
+  await stageAllGitChanges(page);
   await expect(page.locator('[data-testid="commit-title"]')).toBeVisible({ timeout: 10_000 });
   await page.fill('[data-testid="commit-title"]', message);
   const commit = page.locator('[data-testid="commit-button"]');

--- a/e2e/tests/66-checkpoints.spec.ts
+++ b/e2e/tests/66-checkpoints.spec.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test, expect } from "../fixtures";
-import { compileAndWait, createProjectFromTemplate, typeInEditorAfter } from "../helpers";
+import { compileAndWait, createProjectFromTemplate, setNextImportPaths, setNextSavePath, typeInEditorAfter } from "../helpers";
 
 const RUN = Date.now().toString(36);
 const EDIT = `chkedit${RUN}`;
@@ -50,6 +53,41 @@ async function clickHoverRevealed(page: Page, selector: string) {
 
 async function waitUntilIdle(page: Page) {
   await expect(page.getByTestId("checkpoint-publishing")).toHaveCount(0, { timeout: 150_000 });
+}
+
+async function archiveRoundTrip(page: Page, template: string) {
+  await page.getByTestId("checkpoints-advanced").click();
+  const password = "checkpoint-regression-password";
+  const archive = join(mkdtempSync(join(tmpdir(), "oleafly-checkpoint-e2e-")), `${template}.oleafly-checkpoints`);
+  await page.getByText("Export", { exact: true }).click();
+  await expect(page.getByText("Password needs at least 8 characters.", { exact: true })).toBeVisible();
+  await page.fill("#checkpoint-archive-password", password);
+  await setNextSavePath(page, archive);
+  await page.getByText("Export", { exact: true }).click();
+  await page.waitForFunction(
+    `document.querySelector('#checkpoint-archive-password')?.value === ''`,
+    60_000,
+  );
+  const bytes = readFileSync(archive);
+  expect(bytes.subarray(0, 16).toString("ascii")).toBe("OLEAFLYCPARCHIVE");
+  expect(bytes.length).toBeGreaterThan(100);
+
+  await page.getByText("Keep latest", { exact: true }).click();
+  await page.getByText("Delete older checkpoints", { exact: true }).click();
+  await expect(page.getByTestId("checkpoint-entry")).toHaveCount(1, { timeout: 60_000 });
+  await page.fill("#checkpoint-archive-password", password);
+  await setNextImportPaths(page, [archive]);
+  await page.getByText("Import", { exact: true }).click();
+  await page.waitForFunction(
+    `document.querySelector('#checkpoint-archive-password')?.value === ''`,
+    60_000,
+  );
+  await expect(page.getByTestId("checkpoint-entry")).toHaveCount(2, { timeout: 30_000 });
+  // Import restores history, while the working document stays on the V1
+  // revision restored above. Archive import must never apply sources.
+  const source = await page.locator(".cm-content").textContent();
+  expect(source).toContain("here.");
+  expect(source).not.toContain(EDIT);
 }
 
 for (const template of ["blank", "blank-typst", "blank-markdown"]) {
@@ -156,6 +194,7 @@ for (const template of ["blank", "blank-typst", "blank-markdown"]) {
     await openCheckpoints(tauriPage);
     await waitUntilIdle(tauriPage);
     await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(2);
+    await archiveRoundTrip(tauriPage, template);
     await closeCheckpoints(tauriPage);
   });
 }

--- a/e2e/tests/66-checkpoints.spec.ts
+++ b/e2e/tests/66-checkpoints.spec.ts
@@ -1,16 +1,17 @@
 import { test, expect } from "../fixtures";
-import { createBlankProject, pressGlobal, typeInEditorAfter } from "../helpers";
+import { compileAndWait, createProjectFromTemplate, typeInEditorAfter } from "../helpers";
 
 const RUN = Date.now().toString(36);
 const EDIT = `chkedit${RUN}`;
 
-type Page = Parameters<typeof createBlankProject>[0];
+type Page = Parameters<typeof createProjectFromTemplate>[0];
 
 async function compileOk(page: Page) {
-  await pressGlobal(page, "Enter", { meta: true });
-  await expect(page.getByTestId("compile-status")).toHaveAttribute("data-severity", "ok", {
-    timeout: 120_000,
-  });
+  await compileAndWait(page);
+  await page.waitForFunction(
+    `["ok", "warning"].includes(document.querySelector('[data-testid="compile-status"]')?.getAttribute('data-severity'))`,
+    120_000,
+  );
 }
 
 async function openCheckpoints(page: Page) {
@@ -51,108 +52,110 @@ async function waitUntilIdle(page: Page) {
   await expect(page.getByTestId("checkpoint-publishing")).toHaveCount(0, { timeout: 150_000 });
 }
 
-test("a successful compile stores one checkpoint and unchanged sources add nothing", async ({
-  tauriPage,
-}) => {
-  test.setTimeout(600_000);
-  await createBlankProject(tauriPage, `Checkpoints ${RUN}`);
-  await expect(tauriPage.locator(".cm-content")).toBeVisible({ timeout: 20_000 });
+for (const template of ["blank", "blank-typst", "blank-markdown"]) {
+  test(`${template}: successful compiles deduplicate checkpoints and restore source`, async ({
+    tauriPage,
+  }) => {
+    test.setTimeout(600_000);
+    await createProjectFromTemplate(tauriPage, template, `Checkpoints ${template} ${RUN}`);
+    await expect(tauriPage.locator(".cm-content")).toBeVisible({ timeout: 20_000 });
 
-  await compileOk(tauriPage);
-  await openCheckpoints(tauriPage);
-  await waitForVersion(tauriPage, "V1");
-  await waitUntilIdle(tauriPage);
-  await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(1);
-  const firstRoot = await tauriPage.evaluate<string>(
-    `document.querySelector('[data-testid="checkpoint-entry"]')?.getAttribute('data-root') || ''`,
-  );
-  expect(firstRoot).toMatch(/^[0-9a-f]{64}$/);
+    await compileOk(tauriPage);
+    await openCheckpoints(tauriPage);
+    await waitForVersion(tauriPage, "V1");
+    await waitUntilIdle(tauriPage);
+    await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(1);
+    const firstRoot = await tauriPage.evaluate<string>(
+      `document.querySelector('[data-testid="checkpoint-entry"]')?.getAttribute('data-root') || ''`,
+    );
+    expect(firstRoot).toMatch(/^[0-9a-f]{64}$/);
 
-  await clickHoverRevealed(tauriPage, '[aria-label="Edit label for V1"]');
-  await tauriPage.fill('[aria-label="Checkpoint label"]', "Stable draft");
-  await tauriPage.press('[aria-label="Checkpoint label"]', "Enter");
-  await expect(
-    tauriPage.locator('[data-testid="checkpoint-entry"][data-label="Stable draft"]'),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(tauriPage.getByText("Stable draft", { exact: true })).toBeVisible({
-    timeout: 10_000,
+    await clickHoverRevealed(tauriPage, '[aria-label="Edit label for V1"]');
+    await tauriPage.fill('[aria-label="Checkpoint label"]', "Stable draft");
+    await tauriPage.press('[aria-label="Checkpoint label"]', "Enter");
+    await expect(
+      tauriPage.locator('[data-testid="checkpoint-entry"][data-label="Stable draft"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(tauriPage.getByText("Stable draft", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await closeCheckpoints(tauriPage);
+    await openCheckpoints(tauriPage);
+    await expect(
+      tauriPage.locator('[data-testid="checkpoint-entry"][data-label="Stable draft"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await clickHoverRevealed(tauriPage, '[aria-label="Remove label Stable draft"]');
+    await expect(tauriPage.locator('[data-testid="checkpoint-entry"][data-label]')).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await expect(
+      tauriPage.locator('[data-testid="checkpoint-entry"][data-version="V1"]'),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const advanced = tauriPage.getByTestId("checkpoints-advanced");
+    await expect(advanced).toHaveAttribute("aria-expanded", "false", { timeout: 10_000 });
+    await expect(tauriPage.getByText("Keep latest", { exact: true })).toBeHidden({ timeout: 5_000 });
+    await advanced.click();
+    await expect(advanced).toHaveAttribute("aria-expanded", "true", { timeout: 10_000 });
+    await expect(tauriPage.getByText("Keep latest", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(tauriPage.getByText("Export", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(tauriPage.getByText("Import", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(
+      tauriPage.locator('[data-testid="versioning-panel-checkpoints"] code'),
+    ).toBeVisible({ timeout: 20_000 });
+    await advanced.click();
+    await expect(advanced).toHaveAttribute("aria-expanded", "false", { timeout: 10_000 });
+    await expect(tauriPage.getByText("Keep latest", { exact: true })).toBeHidden({ timeout: 5_000 });
+
+    await closeCheckpoints(tauriPage);
+
+    await compileOk(tauriPage);
+    await openCheckpoints(tauriPage);
+    await waitUntilIdle(tauriPage);
+    await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(1);
+    await closeCheckpoints(tauriPage);
+
+    await typeInEditorAfter(tauriPage, "here.", ` ${EDIT}`);
+    await compileOk(tauriPage);
+    await openCheckpoints(tauriPage);
+    await waitForVersion(tauriPage, "V2");
+    await waitUntilIdle(tauriPage);
+    await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(2);
+    const versions = await tauriPage.evaluate<string[]>(
+      `Array.from(document.querySelectorAll('[data-testid="checkpoint-entry"]')).map((row) => row.getAttribute('data-version') || '')`,
+    );
+    expect(versions).toEqual(["V2", "V1"]);
+
+    await tauriPage.click('[aria-label="Show files for V2"]');
+    await expect(
+      tauriPage.locator('[data-testid="checkpoint-file"][data-path="project.json"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    const filePaths = await tauriPage.evaluate<string[]>(
+      `Array.from(document.querySelectorAll('[data-testid="checkpoint-file"]')).map((row) => row.getAttribute('data-path') || '')`,
+    );
+
+    expect(filePaths.some((path) => /\.(tex|typ|md)$/.test(path))).toBe(true);
+    expect(filePaths.some((path) => /\.(log|pdf|aux)$/.test(path))).toBe(false);
+
+    await tauriPage.click('[aria-label="Restore V1"]');
+    await tauriPage.getByText("Restore files", { exact: true }).click();
+    await tauriPage.waitForFunction(
+      `(() => {
+        const text = document.querySelector('.cm-content')?.textContent || '';
+        return text.includes('here.') && !text.includes(${JSON.stringify(EDIT)});
+      })()`,
+      30_000,
+    );
+    await expect(tauriPage.locator('[role="dialog"][aria-labelledby="versioning-title"]')).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    await compileOk(tauriPage);
+    await openCheckpoints(tauriPage);
+    await waitUntilIdle(tauriPage);
+    await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(2);
+    await closeCheckpoints(tauriPage);
   });
-
-  await closeCheckpoints(tauriPage);
-  await openCheckpoints(tauriPage);
-  await expect(
-    tauriPage.locator('[data-testid="checkpoint-entry"][data-label="Stable draft"]'),
-  ).toBeVisible({ timeout: 15_000 });
-
-  await clickHoverRevealed(tauriPage, '[aria-label="Remove label Stable draft"]');
-  await expect(tauriPage.locator('[data-testid="checkpoint-entry"][data-label]')).toHaveCount(0, {
-    timeout: 15_000,
-  });
-  await expect(
-    tauriPage.locator('[data-testid="checkpoint-entry"][data-version="V1"]'),
-  ).toBeVisible({ timeout: 10_000 });
-
-  const advanced = tauriPage.getByTestId("checkpoints-advanced");
-  await expect(advanced).toHaveAttribute("aria-expanded", "false", { timeout: 10_000 });
-  await expect(tauriPage.getByText("Keep latest", { exact: true })).toBeHidden({ timeout: 5_000 });
-  await advanced.click();
-  await expect(advanced).toHaveAttribute("aria-expanded", "true", { timeout: 10_000 });
-  await expect(tauriPage.getByText("Keep latest", { exact: true })).toBeVisible({ timeout: 10_000 });
-  await expect(tauriPage.getByText("Export", { exact: true })).toBeVisible({ timeout: 10_000 });
-  await expect(tauriPage.getByText("Import", { exact: true })).toBeVisible({ timeout: 10_000 });
-  await expect(
-    tauriPage.locator('[data-testid="versioning-panel-checkpoints"] code'),
-  ).toBeVisible({ timeout: 20_000 });
-  await advanced.click();
-  await expect(advanced).toHaveAttribute("aria-expanded", "false", { timeout: 10_000 });
-  await expect(tauriPage.getByText("Keep latest", { exact: true })).toBeHidden({ timeout: 5_000 });
-
-  await closeCheckpoints(tauriPage);
-
-  await compileOk(tauriPage);
-  await openCheckpoints(tauriPage);
-  await waitUntilIdle(tauriPage);
-  await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(1);
-  await closeCheckpoints(tauriPage);
-
-  await typeInEditorAfter(tauriPage, "here.", ` ${EDIT}`);
-  await compileOk(tauriPage);
-  await openCheckpoints(tauriPage);
-  await waitForVersion(tauriPage, "V2");
-  await waitUntilIdle(tauriPage);
-  await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(2);
-  const versions = await tauriPage.evaluate<string[]>(
-    `Array.from(document.querySelectorAll('[data-testid="checkpoint-entry"]')).map((row) => row.getAttribute('data-version') || '')`,
-  );
-  expect(versions).toEqual(["V2", "V1"]);
-
-  await tauriPage.click('[aria-label="Show files for V2"]');
-  await expect(
-    tauriPage.locator('[data-testid="checkpoint-file"][data-path="project.json"]'),
-  ).toBeVisible({ timeout: 15_000 });
-  const filePaths = await tauriPage.evaluate<string[]>(
-    `Array.from(document.querySelectorAll('[data-testid="checkpoint-file"]')).map((row) => row.getAttribute('data-path') || '')`,
-  );
-
-  expect(filePaths.some((path) => /\.(tex|typ|md)$/.test(path))).toBe(true);
-  expect(filePaths.some((path) => /\.(log|pdf|aux)$/.test(path))).toBe(false);
-
-  await tauriPage.click('[aria-label="Restore V1"]');
-  await tauriPage.getByText("Restore files", { exact: true }).click();
-  await tauriPage.waitForFunction(
-    `(() => {
-      const text = document.querySelector('.cm-content')?.textContent || '';
-      return text.includes('here.') && !text.includes(${JSON.stringify(EDIT)});
-    })()`,
-    30_000,
-  );
-  await expect(tauriPage.locator('[role="dialog"][aria-labelledby="versioning-title"]')).toHaveCount(0, {
-    timeout: 10_000,
-  });
-
-  await compileOk(tauriPage);
-  await openCheckpoints(tauriPage);
-  await waitUntilIdle(tauriPage);
-  await expect(tauriPage.getByTestId("checkpoint-entry")).toHaveCount(2);
-  await closeCheckpoints(tauriPage);
-});
+}

--- a/e2e/tests/69-agent-live.spec.ts
+++ b/e2e/tests/69-agent-live.spec.ts
@@ -104,7 +104,7 @@ test.describe("live provider", () => {
     await ask(tauriPage, "Reply with exactly this token and nothing else: LIVEPROVIDER7");
     await waitLong(
       tauriPage,
-      `document.body.innerText.includes("LIVEPROVIDER7") && !document.querySelector('[aria-label="Stop"]')`,
+      `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1)?.textContent.includes("LIVEPROVIDER7") && !document.querySelector('[aria-label="Stop"]')`,
       REPLY_TIMEOUT,
     );
 
@@ -127,13 +127,21 @@ test.describe("live provider", () => {
     await ask(tauriPage, "Think step by step, then answer: what is 17 times 23?");
     await waitForRun(tauriPage);
 
+    // Finished turns fold reasoning behind the Worked header.
+    await tauriPage.evaluate(`(() => {
+      const message = Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1);
+      const worked = Array.from(message?.querySelectorAll('button') ?? [])
+        .find((button) => /^Worked (for|through)/.test(button.textContent.trim()));
+      if (worked?.getAttribute('aria-expanded') === 'false') worked.click();
+    })()`);
+
     const sawReasoning = await tauriPage.evaluate<boolean>(
-      `/Thought for|Reasoning/i.test(document.body.innerText)`,
+      `/Thought for|Reasoning/i.test(Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1)?.innerText ?? '')`,
     );
     expect(sawReasoning, "no thinking phase was rendered").toBe(true);
 
     const answered = await tauriPage.evaluate<boolean>(
-      `document.body.innerText.includes("391")`,
+      `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1)?.textContent.includes("391") ?? false`,
     );
     expect(answered, "the answer should survive the thinking phase").toBe(true);
   });
@@ -155,6 +163,29 @@ test.describe("live provider", () => {
     expect(transcript, "the model should report what it read").toMatch(/article/i);
   });
 
+  test("a real delegated agent completes and exposes its recorded conversation", async ({ tauriPage }) => {
+    test.setTimeout(240_000);
+    await openLiveProject(tauriPage);
+    await connectLive(tauriPage, PROVIDER);
+    await openChat(tauriPage);
+
+    await ask(
+      tauriPage,
+      "Use spawn_agent to create exactly one helper named manuscript_check. " +
+        "Tell it to read main.tex with read_file and report the documentclass. " +
+        "Wait for the helper to finish with wait_agent, then report its answer. " +
+        "Do not edit any files. This request explicitly requires delegation.",
+    );
+    await waitForRun(tauriPage, 180_000);
+    const card = tauriPage.locator('[data-testid="subagent-card"][data-subagent-state="done"]');
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    expect(await card.textContent()).toMatch(/article/i);
+    await tauriPage.getByText("Open task", { exact: true }).click();
+    await expect(tauriPage.getByTestId("session-transcript-dialog")).toBeVisible({ timeout: 15_000 });
+    await waitLong(tauriPage, `document.querySelector('[data-testid="session-transcript-dialog"]')?.textContent.includes('main.tex')`, 15_000);
+    expect(await tauriPage.getByTestId("session-transcript-dialog").textContent()).toMatch(/read_file|main\.tex/i);
+  });
+
   test("the same key works through a custom provider entry", async ({ tauriPage }) => {
     test.skip(
       !OPENAI_COMPATIBLE,
@@ -171,7 +202,7 @@ test.describe("live provider", () => {
     await ask(tauriPage, "Reply with exactly this token and nothing else: LIVECUSTOM9");
     await waitLong(
       tauriPage,
-      `document.body.innerText.includes("LIVECUSTOM9") && !document.querySelector('[aria-label="Stop"]')`,
+      `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1)?.textContent.includes("LIVECUSTOM9") && !document.querySelector('[aria-label="Stop"]')`,
       REPLY_TIMEOUT,
     );
   });

--- a/e2e/tests/69-agent-live.spec.ts
+++ b/e2e/tests/69-agent-live.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures";
 import {
   createBlankProject,
+  expectCompletedReadFile,
   fillTextarea,
   openProject,
   openRailTab,
@@ -158,9 +159,11 @@ test.describe("live provider", () => {
     );
     await waitForRun(tauriPage);
 
-    const transcript = await tauriPage.evaluate<string>(`document.body.innerText`);
-    expect(transcript, "the tool call should appear in the transcript").toContain("read_file");
-    expect(transcript, "the model should report what it read").toMatch(/article/i);
+    await expectCompletedReadFile(tauriPage);
+    const answer = await tauriPage.evaluate<string>(
+      `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1)?.textContent ?? ''`,
+    );
+    expect(answer, "the model should report what it read").toMatch(/article/i);
   });
 
   test("a real delegated agent completes and exposes its recorded conversation", async ({ tauriPage }) => {

--- a/e2e/tests/70-agent-ollama.spec.ts
+++ b/e2e/tests/70-agent-ollama.spec.ts
@@ -106,7 +106,7 @@ test.describe("local Ollama", () => {
     await ask(tauriPage, "Reply with exactly this token and nothing else: OLLAMALOCAL5");
     await waitLong(
       tauriPage,
-      `document.body.innerText.includes("OLLAMALOCAL5") && !document.querySelector('[aria-label="Stop"]')`,
+      `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).at(-1)?.textContent.includes("OLLAMALOCAL5") && !document.querySelector('[aria-label="Stop"]')`,
       REPLY_TIMEOUT,
     );
   });

--- a/e2e/tests/70-agent-ollama.spec.ts
+++ b/e2e/tests/70-agent-ollama.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures";
 import {
   createBlankProject,
+  expectCompletedReadFile,
   fillTextarea,
   openProject,
   openRailTab,
@@ -134,11 +135,18 @@ test.describe("local Ollama", () => {
     await connectOllama(tauriPage);
     await openChat(tauriPage);
 
+    // Small local models can choose a command instead and wait for command
+    // approval. Exercise the actual user tool picker to isolate file reading.
+    await tauriPage.click('[aria-label="Manage agent tools"]');
+    await tauriPage.getByText("Disable all", { exact: true }).click();
+    await tauriPage.click('[aria-label="Enable read_file"]');
+    await tauriPage.click('[aria-label="Manage agent tools"]');
     await ask(tauriPage, "Use the read_file tool to read main.tex. Then say DONE.");
     await waitForRun(tauriPage);
-
-    const transcript = await tauriPage.evaluate<string>(`document.body.innerText`);
-    expect(transcript, "the tool call should appear in the transcript").toContain("read_file");
+    await expectCompletedReadFile(tauriPage);
+    await tauriPage.click('[aria-label="Manage agent tools"]');
+    await tauriPage.getByText("Enable all", { exact: true }).click();
+    await tauriPage.click('[aria-label="Manage agent tools"]');
   });
 
   test("a host pasted with a trailing slash still reaches the daemon", async ({ tauriPage }) => {

--- a/e2e/vite-client-without-transport.ts
+++ b/e2e/vite-client-without-transport.ts
@@ -1,0 +1,34 @@
+// Static Vite client for browser tests: retain CSS imports without hot-reload sockets.
+export const VITE_CLIENT_WITHOUT_TRANSPORT = String.raw`
+const styles = new Map();
+const ElementBase = globalThis.HTMLElement ?? class {};
+export class ErrorOverlay extends ElementBase {}
+export function createHotContext() {
+  return {
+    accept() {},
+    acceptExports() {},
+    decline() {},
+    dispose() {},
+    invalidate() {},
+    on() {},
+    off() {},
+    prune() {},
+    send() {},
+  };
+}
+export function updateStyle(id, content) {
+  let style = styles.get(id);
+  if (!style) {
+    style = document.createElement("style");
+    style.dataset.viteDevId = id;
+    document.head.appendChild(style);
+    styles.set(id, style);
+  }
+  style.textContent = content;
+}
+export function removeStyle(id) {
+  styles.get(id)?.remove();
+  styles.delete(id);
+}
+export function injectQuery(url) { return url; }
+`;

--- a/packages/editor/src/controller.test.ts
+++ b/packages/editor/src/controller.test.ts
@@ -9,6 +9,7 @@ import {
   editorUndo,
   gotoLine,
   insertTemplate,
+  revealEditorRange,
   setEditorView,
 } from "./controller";
 
@@ -44,6 +45,26 @@ describe("editor controller history", () => {
 });
 
 describe("editor controller navigation", () => {
+  it("synchronizes the DOM selection when navigation returns focus from a toolbar", () => {
+    const parent = document.createElement("div");
+    const toolbar = document.createElement("button");
+    document.body.append(parent, toolbar);
+    view = new EditorView({
+      parent,
+      state: EditorState.create({ doc: "original reference\nselected definition" }),
+    });
+    view.focus();
+    toolbar.focus();
+
+    revealEditorRange(view, 19, 38);
+
+    const selection = window.getSelection()!;
+    expect(view.state.selection.main.from).toBe(19);
+    expect(view.state.selection.main.to).toBe(38);
+    expect(view.posAtDOM(selection.anchorNode!, selection.anchorOffset)).toBe(19);
+    expect(view.posAtDOM(selection.focusNode!, selection.focusOffset)).toBe(38);
+  });
+
   it("centers a distant source line without scrolling the application shell", () => {
     const parent = document.createElement("div");
     document.body.append(parent);
@@ -84,6 +105,6 @@ describe("editor controller navigation", () => {
     expect(view.scrollDOM.scrollTop).toBeGreaterThan(0);
     expect(document.documentElement.scrollTop).toBe(47);
     expect(document.body.scrollTop).toBe(31);
-    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(focus).toHaveBeenCalled();
   });
 });

--- a/packages/editor/src/controller.ts
+++ b/packages/editor/src/controller.ts
@@ -142,10 +142,11 @@ export function revealEditorRange(
 
   scrollEditorPositionLocally(v, a);
 
-  // Focusing the content DOM directly lets us request the platform's
-  // prevent-scroll behavior. The selection and editor-local scroll have
-  // already been handled above.
-  v.contentDOM.focus({ preventScroll: true });
+  // CodeMirror prevents scrolling and synchronizes the DOM selection while
+  // suppressing its observer. Focusing contentDOM directly can restore the
+  // old browser selection and overwrite this navigation when focus returns
+  // from a toolbar or another editor on Windows.
+  v.focus();
 }
 
 export function gotoLine(line: number) {

--- a/packages/editor/src/syntax-highlighting.test.ts
+++ b/packages/editor/src/syntax-highlighting.test.ts
@@ -18,7 +18,7 @@ const fixture = (name: string): string =>
       import.meta.url,
     ),
     "utf8",
-  );
+  ).replace(/\r\n?/gu, "\n");
 
 function highlightedState(path: string, text: string): {
   state: EditorState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   decode-uri-component@<0.5.0: 0.5.0
-  '@tiptap/core': 3.30.4
+  '@tiptap/core': 3.30.5
   rehype-katex>katex: 0.18.1
   nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
@@ -158,20 +158,20 @@ importers:
         specifier: ^2.10.1
         version: 2.10.1
       '@tiptap/core':
-        specifier: 3.30.4
-        version: 3.30.4(@tiptap/pm@3.29.2)
+        specifier: 3.30.5
+        version: 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/extension-image':
         specifier: ^3.31.2
-        version: 3.31.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
+        version: 3.31.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
       '@tiptap/extension-table':
         specifier: ^3.31.2
-        version: 3.31.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+        version: 3.31.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
       '@tiptap/pm':
         specifier: 3.29.2
         version: 3.29.2
       '@tiptap/react':
         specifier: ^3.29.0
-        version: 3.29.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 3.29.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tiptap/starter-kit':
         specifier: ^3.29.0
         version: 3.29.0
@@ -273,7 +273,7 @@ importers:
         version: 2.6.1
       tiptap-markdown:
         specifier: ^0.9.0
-        version: 0.9.0(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
+        version: 0.9.0(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -503,14 +503,14 @@ importers:
   packages/wysiwyg:
     dependencies:
       '@tiptap/core':
-        specifier: 3.30.4
-        version: 3.30.4(@tiptap/pm@3.29.2)
+        specifier: 3.30.5
+        version: 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/extension-image':
         specifier: '*'
-        version: 3.31.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
+        version: 3.31.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
       '@tiptap/extension-table':
         specifier: '*'
-        version: 3.31.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+        version: 3.31.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
       '@tiptap/starter-kit':
         specifier: '*'
         version: 3.29.0
@@ -525,7 +525,7 @@ importers:
         version: 1.8.4
       tiptap-markdown:
         specifier: '*'
-        version: 0.9.0(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
+        version: 0.9.0(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
     devDependencies:
       vitest:
         specifier: '*'
@@ -2775,26 +2775,26 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tiptap/core@3.30.4':
-    resolution: {integrity: sha512-V9yKuUfV8qC9WBrnVxkFWmYLBomc3d1CwXoFSjED5DRu5q2oyxv07F+jOJSRogJAY+feHjuxvjhixwxeHm2DXQ==}
+  '@tiptap/core@3.30.5':
+    resolution: {integrity: sha512-3O7N0FyKIfuLV+xrdWyDM3V5eUY/q2CgLjhhMwOAbM1Pu7VPp9VP+TpEYOdH8aRyB+h1vj5hX5A747D8ZrPfHA==}
     peerDependencies:
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-blockquote@3.29.2':
     resolution: {integrity: sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-bold@3.29.2':
     resolution: {integrity: sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-bubble-menu@3.29.2':
     resolution: {integrity: sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-bullet-list@3.29.2':
@@ -2805,18 +2805,18 @@ packages:
   '@tiptap/extension-code-block@3.29.2':
     resolution: {integrity: sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-code@3.29.2':
     resolution: {integrity: sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-document@3.29.2':
     resolution: {integrity: sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-dropcursor@3.29.2':
     resolution: {integrity: sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==}
@@ -2827,7 +2827,7 @@ packages:
     resolution: {integrity: sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==}
     peerDependencies:
       '@floating-ui/dom': ^1.0.0
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-gapcursor@3.29.2':
@@ -2838,33 +2838,33 @@ packages:
   '@tiptap/extension-hard-break@3.29.2':
     resolution: {integrity: sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-heading@3.29.2':
     resolution: {integrity: sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-horizontal-rule@3.29.2':
     resolution: {integrity: sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-image@3.31.2':
     resolution: {integrity: sha512-xnv0QOL8VsZeSJimQWrVA1MBBvAi8iP94pORsLaqAT5TbK6ry6P1I4DA6uk33PnXjnZl56nZDWPvTLWQjFH4Dw==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-italic@3.29.2':
     resolution: {integrity: sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-link@3.29.2':
     resolution: {integrity: sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-list-item@3.29.2':
@@ -2880,7 +2880,7 @@ packages:
   '@tiptap/extension-list@3.29.2':
     resolution: {integrity: sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-ordered-list@3.29.2':
@@ -2891,33 +2891,33 @@ packages:
   '@tiptap/extension-paragraph@3.29.2':
     resolution: {integrity: sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-strike@3.29.2':
     resolution: {integrity: sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-table@3.31.2':
     resolution: {integrity: sha512-0LfcQG2YK2Q3q5BjvJqs8Zks1PuSdiNGYf2lnyC7ixtItuKXTL2xB5yzj53gMIdRfteqcUfbxIJjmU57W3F+Yg==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/extension-text@3.29.2':
     resolution: {integrity: sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extension-underline@3.29.2':
     resolution: {integrity: sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   '@tiptap/extensions@3.29.2':
     resolution: {integrity: sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
 
   '@tiptap/pm@3.29.2':
@@ -2926,7 +2926,7 @@ packages:
   '@tiptap/react@3.29.0':
     resolution: {integrity: sha512-HmZf9q5/HXg5M2t09WGEbk16vEBDUGPlkF3eXcQh6yG6PkzMZHq1SP+uA8lWku5H/Ggfmv4XKjI6dEQa5V8bwA==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
       '@tiptap/pm': 3.29.2
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5220,7 +5220,7 @@ packages:
   tiptap-markdown@0.9.0:
     resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
     peerDependencies:
-      '@tiptap/core': 3.30.4
+      '@tiptap/core': 3.30.5
 
   tldts-core@7.4.9:
     resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
@@ -7870,126 +7870,126 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tiptap/core@3.30.4(@tiptap/pm@3.29.2)':
+  '@tiptap/core@3.30.5(@tiptap/pm@3.29.2)':
     dependencies:
       '@tiptap/pm': 3.29.2
 
-  '@tiptap/extension-blockquote@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-blockquote@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
-  '@tiptap/extension-bold@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-bold@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-bubble-menu@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-bubble-menu@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
     optional: true
 
-  '@tiptap/extension-bullet-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-bullet-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-code-block@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-code-block@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
-  '@tiptap/extension-code@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-code@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-document@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-document@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-dropcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-dropcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/extensions': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extensions': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-floating-menu@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-floating-menu@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
     optional: true
 
-  '@tiptap/extension-gapcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-gapcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/extensions': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extensions': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-hard-break@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-hard-break@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-heading@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-heading@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-horizontal-rule@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-horizontal-rule@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
-  '@tiptap/extension-image@3.31.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-image@3.31.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-italic@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-italic@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-link@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-link@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
       linkifyjs: 4.3.3
 
-  '@tiptap/extension-list-item@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-list-item@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-list-keymap@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-list-keymap@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
-  '@tiptap/extension-ordered-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-ordered-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-paragraph@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-paragraph@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-strike@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-strike@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-table@3.31.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-table@3.31.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
-  '@tiptap/extension-text@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-text@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-underline@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))':
+  '@tiptap/extension-underline@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
 
-  '@tiptap/extensions@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extensions@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
   '@tiptap/pm@3.29.2':
@@ -8008,9 +8008,9 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.42.2
 
-  '@tiptap/react@3.29.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tiptap/react@3.29.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -8020,36 +8020,36 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
-      '@tiptap/extension-bubble-menu': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-floating-menu': 3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-bubble-menu': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-floating-menu': 3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
     transitivePeerDependencies:
       - '@floating-ui/dom'
 
   '@tiptap/starter-kit@3.29.0':
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
-      '@tiptap/extension-blockquote': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-bold': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-bullet-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
-      '@tiptap/extension-code': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-code-block': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-document': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-dropcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
-      '@tiptap/extension-gapcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
-      '@tiptap/extension-hard-break': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-heading': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-horizontal-rule': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-italic': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-link': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-list-item': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
-      '@tiptap/extension-list-keymap': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
-      '@tiptap/extension-ordered-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
-      '@tiptap/extension-paragraph': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-strike': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-text': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extension-underline': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))
-      '@tiptap/extensions': 3.29.2(@tiptap/core@3.30.4(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
+      '@tiptap/extension-blockquote': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-bold': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-bullet-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-code': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-code-block': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-document': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-dropcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-gapcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-hard-break': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-heading': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-horizontal-rule': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-italic': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-link': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-list-item': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-list-keymap': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-ordered-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))
+      '@tiptap/extension-paragraph': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-strike': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-text': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extension-underline': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))
+      '@tiptap/extensions': 3.29.2(@tiptap/core@3.30.5(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
 
   '@types/aria-query@5.0.4': {}
@@ -11027,9 +11027,9 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
-  tiptap-markdown@0.9.0(@tiptap/core@3.30.4(@tiptap/pm@3.29.2)):
+  tiptap-markdown@0.9.0(@tiptap/core@3.30.5(@tiptap/pm@3.29.2)):
     dependencies:
-      '@tiptap/core': 3.30.4(@tiptap/pm@3.29.2)
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.29.2)
       '@types/markdown-it': 13.0.9
       markdown-it: 14.3.0
       markdown-it-task-lists: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,10 @@ allowBuilds:
 # Force transitive build and test dependencies to patched versions.
 overrides:
   decode-uri-component@<0.5.0: "0.5.0"
-  "@tiptap/core": "3.30.4"
+  # Exact, so the editor extension types resolve against one core. Held at the
+  # patched release for GHSA-j95f-988m-3j2f: quadratic ReDoS in block and
+  # inline Markdown attribute parsing, fixed in 3.30.5.
+  "@tiptap/core": "3.30.5"
   "rehype-katex>katex": "0.18.1"
   nanoid@<3.3.18: "3.3.18"
   # GHSA-6g55-p6wh-862q: source map disclosure in postcss < 8.5.23.

--- a/scripts/e2e.ps1
+++ b/scripts/e2e.ps1
@@ -4,13 +4,33 @@
 $ErrorActionPreference = "Stop"
 Set-Location (Join-Path $PSScriptRoot "..")
 
+# E2E owns a fixed app build. Worker HMR sockets can fail inside Playwright's
+# Firefox transport even when the main-page Vite client is intercepted.
+if (-not $env:OLEAFLY_E2E_DISABLE_HMR) { $env:OLEAFLY_E2E_DISABLE_HMR = "1" }
+
+# Match the Unix runner: exercise bundled assets with a prebuilt e2e binary.
+# Build with VITE_E2E_HOOKS=1 and `tauri build --debug --features e2e-testing --no-bundle`.
+$appBinary = $env:OLEAFLY_E2E_APP_BINARY
+if ($appBinary) {
+  if (-not (Test-Path -LiteralPath $appBinary -PathType Leaf)) {
+    throw "e2e: OLEAFLY_E2E_APP_BINARY does not exist: $appBinary"
+  }
+  $appBinary = (Resolve-Path -LiteralPath $appBinary).Path
+  $env:OLEAFLY_E2E_PRODUCTION = "1"
+}
+
 $suiteMaxFailures = 0
+$fromSpec = ""
 $shardIndex = 0
 $shardTotal = 0
 $playwrightArgs = [System.Collections.Generic.List[string]]::new()
 for ($index = 0; $index -lt $args.Count; $index++) {
   $argument = [string]$args[$index]
-  if ($argument -match "^--suite-max-failures=(\d+)$") {
+  if ($argument -match "^--from-spec=([A-Za-z0-9._-]+\.spec\.ts)$") {
+    $fromSpec = $Matches[1]
+  } elseif ($argument -like "--from-spec*") {
+    throw "--from-spec requires an exact spec filename (e.g. --from-spec=31-ai-figure.spec.ts)"
+  } elseif ($argument -match "^--suite-max-failures=(\d+)$") {
     $suiteMaxFailures = [int]$Matches[1]
   } elseif ($argument -eq "--suite-max-failures") {
     $index++
@@ -52,7 +72,7 @@ if (-not $env:OLEAFLY_SKILLS_BASE_URL) { $env:OLEAFLY_SKILLS_BASE_URL = "http://
 function Start-OutputProcess([string]$command) {
   $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
   Start-Process -FilePath "powershell.exe" `
-    -ArgumentList "-NoProfile", "-EncodedCommand", $encoded `
+    -ArgumentList "-NoProfile", "-NonInteractive", "-OutputFormat", "Text", "-EncodedCommand", $encoded `
     -NoNewWindow -PassThru
 }
 
@@ -129,9 +149,30 @@ function Start-App([string]$label) {
   Write-Host "e2e: launching app for $label"
   Write-Host "e2e: app log $($script:log)"
   $env:OLEAFLY_DATA_DIR = $script:dataDir
-  $script:app = Start-Process -FilePath "cmd.exe" `
-    -ArgumentList "/c", "pnpm tauri dev --features e2e-testing > `"$($script:log)`" 2>&1" `
-    -PassThru -WindowStyle Hidden
+  if ($script:appBinary) {
+    $seed = @{
+      "oleafly.shortcuts" = $null
+      "oleafly.visualEditor" = "1"
+      "oleafly.latexTools" = "1"
+      "oleafly.webBrowser" = "1"
+      "oleafly.openInTree" = "0"
+      "oleafly:compile:mode" = "normal"
+      "oleafly.appFontSize" = "16"
+      "oleafly.appFont" = ""
+      "oleafly.assistant-runtime.v1" = '{"state":{"runtime":"built-in"},"version":0}'
+    }
+    if ($script:checkpointHints -notmatch "00-tours") {
+      $seed["oleafly.tours"] = '{"state":{"schemaVersion":1,"enabled":false,"tours":{}},"version":1}'
+    }
+    $env:OLEAFLY_E2E_BOOT_LOCALSTORAGE = ConvertTo-Json -InputObject $seed -Compress
+    $script:app = Start-Process -FilePath $script:appBinary `
+      -RedirectStandardError $script:log -RedirectStandardOutput "$($script:log).stdout" `
+      -PassThru -WindowStyle Hidden
+  } else {
+    $script:app = Start-Process -FilePath "cmd.exe" `
+      -ArgumentList "/c", "pnpm tauri dev --features e2e-testing > `"$($script:log)`" 2>&1" `
+      -PassThru -WindowStyle Hidden
+  }
 
   $escapedLog = $script:log.Replace("'", "''")
   $script:logStream = Start-OutputProcess @"
@@ -186,8 +227,12 @@ while (`$true) {
 
 function Preserve-RunArtifacts([string]$label) {
   $safeLabel = $label -replace "[^A-Za-z0-9._-]", "-"
-  $resultDir = Join-Path "e2e-artifacts" $safeLabel
-  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $resultDir
+  $artifactRoot = [System.IO.Path]::GetFullPath((Join-Path $PWD "e2e-artifacts"))
+  $resultDir = [System.IO.Path]::GetFullPath((Join-Path $artifactRoot $safeLabel))
+  if (-not $resultDir.StartsWith($artifactRoot + [System.IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "e2e: artifact path escaped its directory"
+  }
+  Remove-Item -LiteralPath $resultDir -Recurse -Force -ErrorAction SilentlyContinue
   New-Item -ItemType Directory -Force -Path $resultDir | Out-Null
   if (Test-Path "test-results") {
     $sourceRoot = (Resolve-Path "test-results").Path.TrimEnd([char[]]"\/")
@@ -202,6 +247,9 @@ function Preserve-RunArtifacts([string]$label) {
   }
   if ($null -ne $script:log -and (Test-Path $script:log)) {
     Copy-Item $script:log (Join-Path $resultDir "app.log") -Force
+    if (Test-Path -LiteralPath "$($script:log).stdout") {
+      Copy-Item -LiteralPath "$($script:log).stdout" -Destination (Join-Path $resultDir "app-stdout.log") -Force
+    }
   }
   $userLog = Join-Path $script:dataDir "app.log"
   if (Test-Path $userLog) {
@@ -241,6 +289,15 @@ try {
     $code = 0
     $failures = 0
     $specs = Get-ChildItem -Path "e2e/tests" -Filter "*.spec.ts" | Sort-Object Name
+    if ($appBinary) {
+      $devOnly = @("24-pdf-selection-browser.spec.ts", "27-markdown-rendering-browser.spec.ts", "56-preview-window-browser.spec.ts")
+      $specs = $specs | Where-Object {
+        if ($_.Name -in $devOnly) {
+          Write-Host "e2e: skipping $($_.Name) in packaged mode (requires the dev-server harness)"
+          $false
+        } else { $true }
+      }
+    }
     if ($shardTotal -gt 0) {
       # Round-robin split for parallel CI runners, matching scripts/e2e.sh.
       # Every shard gets 02-create-compile first: it creates the shared
@@ -259,6 +316,13 @@ try {
       }
       $specs = $selected
       Write-Host "e2e: shard $shardIndex/$shardTotal runs $($specs.Count) spec file(s)"
+    }
+    if ($fromSpec) {
+      if ($fromSpec -notin @($specs.Name)) {
+        throw "e2e: start spec is not in this suite: $fromSpec"
+      }
+      # A resumed sweep still needs the shared document created by the anchor.
+      $specs = $specs | Where-Object { $_.Name -ge $fromSpec -or $_.Name -eq "02-create-compile.spec.ts" }
     }
     foreach ($spec in $specs) {
       $label = $spec.Name

--- a/scripts/smoke-document-engines.mjs
+++ b/scripts/smoke-document-engines.mjs
@@ -8,11 +8,11 @@ import { spawnSync } from "node:child_process";
 
 const repo = dirname(dirname(fileURLToPath(import.meta.url)));
 const suffix = process.platform === "win32" ? ".exe" : "";
-const target = process.env.OLEAFLY_SIDECAR_TARGET ?? (
-  process.platform === "win32" ? "x86_64-pc-windows-msvc" :
-  process.platform === "darwin" ? `${process.arch === "arm64" ? "aarch64" : "x86_64"}-apple-darwin` :
-  `${process.arch === "arm64" ? "aarch64" : "x86_64"}-unknown-linux-gnu`
-);
+const architecture = process.arch === "arm64" ? "aarch64" : "x86_64";
+let defaultTarget = `${architecture}-unknown-linux-gnu`;
+if (process.platform === "win32") defaultTarget = "x86_64-pc-windows-msvc";
+if (process.platform === "darwin") defaultTarget = `${architecture}-apple-darwin`;
+const target = process.env.OLEAFLY_SIDECAR_TARGET ?? defaultTarget;
 const sidecar = (name) => join(repo, "src-tauri", "binaries", `${name}-${target}${suffix}`);
 const root = mkdtempSync(join(tmpdir(), "oleafly-engine-smoke-"));
 const texBin = process.env.OLEAFLY_TEX_BIN_DIR;
@@ -42,7 +42,8 @@ See @smoke.
 #table(columns: 2, [Case], [Result], [Base], [42])
 `;
 const cases = [];
-for (const [name, source] of [["base", latex()], ["fontspec", latex(fontspec)], ["invalid", "\\documentclass{article}\\begin{document}\\unknownsmokecommand\\end{document}"]]) {
+const invalidLatex = String.raw`\documentclass{article}\begin{document}\unknownsmokecommand\end{document}`;
+for (const [name, source] of [["base", latex()], ["fontspec", latex(fontspec)], ["invalid", invalidLatex]]) {
   cases.push({ name: `tectonic-${name}`, executable: sidecar("tectonic"), args: ["--keep-logs", "--synctex", "main.tex"], source, extension: "tex", invalid: name === "invalid" });
 }
 const typstCases = [["base", typst()], ["font", typst('#set text(font: "Libertinus Serif")')], ["invalid", "#unknownsmokecommand()"]];
@@ -52,8 +53,9 @@ for (const [name, source] of typstCases) {
 }
 if (texBin) {
   for (const [engine, flag] of [["pdflatex", "-pdf"], ["xelatex", "-xelatex"], ["lualatex", "-lualatex"]]) {
+    const validSource = latex(engine === "pdflatex" ? "" : fontspec);
     for (const invalid of [false, true]) {
-      cases.push({ name: `${engine}-${invalid ? "invalid" : "base"}`, executable: join(texBin, `latexmk${suffix}`), args: [flag, "-interaction=nonstopmode", "-halt-on-error", "-synctex=1", "main.tex"], source: invalid ? "\\documentclass{article}\\begin{document}\\unknownsmokecommand\\end{document}" : latex(engine === "pdflatex" ? "" : fontspec), extension: "tex", invalid });
+      cases.push({ name: `${engine}-${invalid ? "invalid" : "base"}`, executable: join(texBin, `latexmk${suffix}`), args: [flag, "-interaction=nonstopmode", "-halt-on-error", "-synctex=1", "main.tex"], source: invalid ? invalidLatex : validSource, extension: "tex", invalid });
     }
   }
 }

--- a/scripts/smoke-document-engines.mjs
+++ b/scripts/smoke-document-engines.mjs
@@ -1,0 +1,83 @@
+// Real compiler smoke tests. No user projects are read or modified.
+// Optional: OLEAFLY_TEX_BIN_DIR enables pdfLaTeX, XeLaTeX and LuaLaTeX.
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repo = dirname(dirname(fileURLToPath(import.meta.url)));
+const suffix = process.platform === "win32" ? ".exe" : "";
+const target = process.env.OLEAFLY_SIDECAR_TARGET ?? (
+  process.platform === "win32" ? "x86_64-pc-windows-msvc" :
+  process.platform === "darwin" ? `${process.arch === "arm64" ? "aarch64" : "x86_64"}-apple-darwin` :
+  `${process.arch === "arm64" ? "aarch64" : "x86_64"}-unknown-linux-gnu`
+);
+const sidecar = (name) => join(repo, "src-tauri", "binaries", `${name}-${target}${suffix}`);
+const root = mkdtempSync(join(tmpdir(), "oleafly-engine-smoke-"));
+const texBin = process.env.OLEAFLY_TEX_BIN_DIR;
+const env = { ...process.env };
+if (texBin) env.PATH = `${texBin}${process.platform === "win32" ? ";" : ":"}${env.PATH ?? ""}`;
+
+const latex = (font = "") => String.raw`\documentclass{article}
+\usepackage{amsmath,amssymb}
+${font}
+\begin{document}
+\section{Engine smoke test}\label{sec:smoke}
+Windows compilation, math, tables, and references.
+\input{chapter}
+\begin{equation}\label{eq:smoke}\sum_{i=1}^{n}i=\frac{n(n+1)}{2}\end{equation}
+Equation~\ref{eq:smoke} in Section~\ref{sec:smoke}.
+\begin{tabular}{lr}Case & Result\\Base & 42\end{tabular}
+\end{document}
+`;
+const fontspec = String.raw`\usepackage{fontspec}\setmainfont{${process.platform === "win32" ? "Arial" : "Latin Modern Roman"}}`;
+const typst = (font = "") => `#set page(margin: 1in)
+#set heading(numbering: "1.")
+${font}
+= Engine smoke test <smoke>
+Math: $ sum_(i=1)^n i = (n (n+1))/2 $.
+#include "chapter.typ"
+See @smoke.
+#table(columns: 2, [Case], [Result], [Base], [42])
+`;
+const cases = [];
+for (const [name, source] of [["base", latex()], ["fontspec", latex(fontspec)], ["invalid", "\\documentclass{article}\\begin{document}\\unknownsmokecommand\\end{document}"]]) {
+  cases.push({ name: `tectonic-${name}`, executable: sidecar("tectonic"), args: ["--keep-logs", "--synctex", "main.tex"], source, extension: "tex", invalid: name === "invalid" });
+}
+const typstCases = [["base", typst()], ["font", typst('#set text(font: "Libertinus Serif")')], ["invalid", "#unknownsmokecommand()"]];
+if (process.platform === "win32") typstCases.push(["system-font", typst('#set text(font: "Arial")')]);
+for (const [name, source] of typstCases) {
+  cases.push({ name: `typst-${name}`, executable: sidecar("typst"), args: ["compile", "main.typ", "main.pdf"], source, extension: "typ", invalid: name === "invalid" });
+}
+if (texBin) {
+  for (const [engine, flag] of [["pdflatex", "-pdf"], ["xelatex", "-xelatex"], ["lualatex", "-lualatex"]]) {
+    for (const invalid of [false, true]) {
+      cases.push({ name: `${engine}-${invalid ? "invalid" : "base"}`, executable: join(texBin, `latexmk${suffix}`), args: [flag, "-interaction=nonstopmode", "-halt-on-error", "-synctex=1", "main.tex"], source: invalid ? "\\documentclass{article}\\begin{document}\\unknownsmokecommand\\end{document}" : latex(engine === "pdflatex" ? "" : fontspec), extension: "tex", invalid });
+    }
+  }
+}
+const results = [];
+for (const item of cases) {
+  const cwd = join(root, item.name);
+  mkdirSync(cwd);
+  writeFileSync(join(cwd, `main.${item.extension}`), item.source);
+  writeFileSync(join(cwd, "chapter.tex"), "Included source with an accented word: caf\\'e.\n");
+  writeFileSync(join(cwd, "chapter.typ"), "Included source with Unicode: café.\n");
+  const start = performance.now();
+  const run = spawnSync(item.executable, item.args, { cwd, env, encoding: "utf8", timeout: 180_000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 });
+  const log = `${run.stdout ?? ""}\n${run.stderr ?? ""}\n${run.error ?? ""}`;
+  writeFileSync(join(cwd, "compiler.log"), log);
+  let pdf = false;
+  try { pdf = readFileSync(join(cwd, "main.pdf")).subarray(0, 5).toString() === "%PDF-"; } catch {}
+  const passed = !run.error && (item.invalid
+    ? run.status > 0 && run.status < 128 && !pdf && /unknownsmokecommand|Undefined control sequence/.test(log)
+    : run.status === 0 && pdf && !/unknown font family/i.test(log));
+  const result = { name: item.name, passed, exitCode: run.status, pdf, elapsedMs: Math.round(performance.now() - start) };
+  results.push(result);
+  console.log(JSON.stringify(result));
+}
+writeFileSync(join(root, "results.json"), JSON.stringify({ results, texLiveEnabled: Boolean(texBin) }, null, 2));
+console.log(`Compiler logs and fixtures: ${root}`);
+if (!texBin) console.log("TeX Live engines were not run: set OLEAFLY_TEX_BIN_DIR to enable them.");
+if (results.some((result) => !result.passed)) process.exitCode = 1;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ security-framework = "=2.11.1"
 windows-sys = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_Security",
+  "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_IO",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,6 +70,7 @@ tempfile = { workspace = true }
 security-framework = "=2.11.1"
 
 [target.'cfg(windows)'.dependencies]
+webview2-com = "0.38"
 windows-sys = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_Security",
@@ -79,6 +80,7 @@ windows-sys = { version = "0.61", features = [
   "Win32_System_IO",
   "Win32_System_JobObjects",
   "Win32_System_Threading",
+  "Win32_UI_Input_KeyboardAndMouse",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/acp/tests.rs
+++ b/src-tauri/src/acp/tests.rs
@@ -15,9 +15,13 @@ pub(crate) fn fixture_temp() -> tempfile::TempDir {
         .unwrap()
 }
 
-pub(crate) fn fixture_definition(extra: Vec<String>, root: &Path) -> AgentDefinition {
-    let python =
-        catalog::discover("python3").expect("Python 3 is required for ACP protocol fixtures");
+pub(crate) fn fixture_python() -> std::path::PathBuf {
+    // The official Windows installer exposes python.exe, not python3.exe.
+    #[cfg(windows)]
+    let python = catalog::discover("python").or_else(|| catalog::discover("python3"));
+    #[cfg(not(windows))]
+    let python = catalog::discover("python3");
+    let python = python.expect("Python 3 is required for ACP protocol fixtures");
     #[cfg(target_os = "macos")]
     let python = python
         .parent()
@@ -25,6 +29,11 @@ pub(crate) fn fixture_definition(extra: Vec<String>, root: &Path) -> AgentDefini
         .map(|prefix| prefix.join("Resources/Python.app/Contents/MacOS/Python"))
         .filter(|path| path.is_file())
         .unwrap_or(python);
+    python
+}
+
+pub(crate) fn fixture_definition(extra: Vec<String>, root: &Path) -> AgentDefinition {
+    let python = fixture_python();
     let script = Path::new(file!())
         .parent()
         .unwrap()

--- a/src-tauri/src/acp/tests/catalog.rs
+++ b/src-tauri/src/acp/tests/catalog.rs
@@ -824,7 +824,7 @@ fn malformed_and_truncated_archives_fail() {
 
 #[tokio::test]
 async fn local_install_commands_bound_output_and_hide_failed_command_details() {
-    let python = discover("python3").expect("Python 3 is required for ACP protocol fixtures");
+    let python = crate::acp::tests::fixture_python();
     let mut command = tokio::process::Command::new(&python);
     command.args(["-c", "import sys; sys.stdout.write('x' * 100000)"]);
     let output = bounded_command(command, Duration::from_secs(5))
@@ -851,7 +851,7 @@ async fn local_install_commands_handle_spawn_failure_and_timeout() {
         .await
         .unwrap_err()
         .contains("could not be started"));
-    let python = discover("python3").expect("Python 3 is required for ACP protocol fixtures");
+    let python = crate::acp::tests::fixture_python();
     let mut command = tokio::process::Command::new(python);
     command.args(["-c", "import time; time.sleep(30)"]);
     assert!(bounded_command(command, Duration::from_millis(100))

--- a/src-tauri/src/agent/task_runtime.rs
+++ b/src-tauri/src/agent/task_runtime.rs
@@ -641,8 +641,8 @@ async fn execute_command(
     let containment = match crate::proc::contain_process_tree(pid) {
         Ok(value) => value,
         Err(error) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            let _ = child.start_kill();
+            let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
             return Err(format!("The task command could not be contained: {error}"));
         }
     };
@@ -665,7 +665,10 @@ async fn execute_command(
     };
     drop(containment);
     let _ = child.start_kill();
-    let reaped = child.wait().await.ok();
+    let reaped = tokio::time::timeout(Duration::from_secs(2), child.wait())
+        .await
+        .ok()
+        .and_then(Result::ok);
     let read = async { tokio::join!(&mut stdout, &mut stderr) };
     let (mut output, errors) = match tokio::time::timeout(Duration::from_secs(2), read).await {
         Ok((stdout, stderr)) => (stdout.unwrap_or_default(), stderr.unwrap_or_default()),

--- a/src-tauri/src/agent_exec.rs
+++ b/src-tauri/src/agent_exec.rs
@@ -309,13 +309,8 @@ impl ExecLease<'_> {
             }
         }
     }
-}
 
-impl Drop for ExecLease<'_> {
-    fn drop(&mut self) {
-        if self.completed {
-            return;
-        }
+    fn stop_process_tree(&mut self) {
         let process = match self.unregister() {
             UnregisterResult::Removed(process) => process.and_then(|entry| entry.pid),
             UnregisterResult::RegistryUnavailable => self.pid,
@@ -323,6 +318,16 @@ impl Drop for ExecLease<'_> {
         if let Some(pid) = process {
             terminate_process(pid);
         }
+        self.pid = None;
+    }
+}
+
+impl Drop for ExecLease<'_> {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        self.stop_process_tree();
         self.finish_completion();
     }
 }
@@ -697,14 +702,15 @@ async fn execute_command_with_timeout(
         Ok(containment) => containment,
         Err(error) => {
             terminate_process(pid);
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            let _ = child.start_kill();
+            let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
             return Err(format!("failed to contain command process: {error}"));
         }
     };
     if let Err(error) = lease.activate(pid, containment) {
         terminate_process(pid);
-        let _ = child.wait().await;
+        let _ = child.start_kill();
+        let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
         return Err(error);
     }
 
@@ -733,17 +739,23 @@ async fn execute_command_with_timeout(
     .await;
     let timed_out = completion.is_err();
     let status = match completion {
-        Ok(status) => status,
+        Ok(status) => {
+            lease.complete();
+            status
+        }
         Err(_) => {
-            terminate_process(pid);
-            child.wait().await.ok()
+            // Close the owned Job Object before waiting, so grandchildren
+            // cannot outlive a timed-out command while cleanup is pending.
+            lease.stop_process_tree();
+            let _ = child.start_kill();
+            let status = tokio::time::timeout(Duration::from_secs(2), child.wait())
+                .await
+                .ok()
+                .and_then(Result::ok);
+            drop(lease);
+            status
         }
     };
-    if timed_out {
-        drop(lease);
-    } else {
-        lease.complete();
-    }
 
     let exit_code = status.and_then(|s| s.code());
     let mut combined = stdout_bytes;

--- a/src-tauri/src/agent_exec.rs
+++ b/src-tauri/src/agent_exec.rs
@@ -1419,7 +1419,11 @@ mod tests {
         let root = test_root("approval-replay");
         let cwd = root.join("projects/proj");
         let state = AgentExecState::default();
-        let command = "touch approved-once";
+        let command = if cfg!(windows) {
+            "type nul > approved-once"
+        } else {
+            "touch approved-once"
+        };
         let token = state.authorize("proj", command, "run-once").unwrap();
 
         let first = execute_command(
@@ -1445,7 +1449,7 @@ mod tests {
         let marker_exists = cwd.join("approved-once").exists();
 
         std::fs::remove_dir_all(&root).ok();
-        assert!(first.is_ok());
+        assert_eq!(first.unwrap().exit_code, Some(0));
         assert_eq!(
             second.err().as_deref(),
             Some("run_command approval is invalid or already used")

--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -10,6 +10,9 @@ use tauri::{
     Webview, WebviewUrl, Window, WindowEvent,
 };
 
+#[cfg(windows)]
+mod windows_shortcuts;
+
 pub const CHROME_HEIGHT_LOGICAL: f64 = 88.0;
 
 const WINDOW_TITLE: &str = "Oleafly Browser";
@@ -491,6 +494,11 @@ fn open_tab<R: Runtime>(
     let webview = window
         .add_child(builder, position, pane_size)
         .map_err(|e| format!("could not open the tab: {e}"))?;
+    #[cfg(windows)]
+    windows_shortcuts::install(
+        &webview,
+        with_window_state(&window_label, |state| state.chrome.clone())?,
+    );
     let _ = webview.hide();
     with_window_state(&window_label, |state| {
         state.tabs.push(BrowserTabInfo {

--- a/src-tauri/src/browser/windows_shortcuts.rs
+++ b/src-tauri/src/browser/windows_shortcuts.rs
@@ -1,0 +1,102 @@
+use tauri::{Manager, Runtime, Webview};
+use webview2_com::{
+    AcceleratorKeyPressedEventHandler,
+    Microsoft::Web::WebView2::Win32::{
+        COREWEBVIEW2_KEY_EVENT_KIND_KEY_DOWN, COREWEBVIEW2_PHYSICAL_KEY_STATUS,
+    },
+};
+use windows_sys::Win32::UI::Input::KeyboardAndMouse::{GetKeyState, VK_CONTROL, VK_MENU, VK_SHIFT};
+
+fn shortcut_key(key: u32, control: bool, shift: bool, alt: bool) -> Option<char> {
+    if !control || shift || alt {
+        return None;
+    }
+    match key {
+        0x4c => Some('l'),
+        0x54 => Some('t'),
+        0x57 => Some('w'),
+        0x52 => Some('r'),
+        _ => None,
+    }
+}
+
+pub(super) fn install<R: Runtime>(pane: &Webview<R>, chrome_label: String) {
+    let app = pane.app_handle().clone();
+    // Remote pages have a separate webview and cannot send privileged IPC.
+    // Handle actual native accelerators, then route only our four shortcuts
+    // to the existing handler in the trusted browser toolbar.
+    let result = pane.with_webview(move |platform| {
+        let callback = AcceleratorKeyPressedEventHandler::create(Box::new(move |_, args| {
+            let Some(args) = args else { return Ok(()) };
+            let mut kind = COREWEBVIEW2_KEY_EVENT_KIND_KEY_DOWN;
+            let mut key = 0;
+            unsafe {
+                args.KeyEventKind(&mut kind)?;
+                args.VirtualKey(&mut key)?;
+            }
+            if kind != COREWEBVIEW2_KEY_EVENT_KIND_KEY_DOWN {
+                return Ok(());
+            }
+            let key = unsafe {
+                shortcut_key(
+                    key,
+                    GetKeyState(VK_CONTROL as i32) < 0,
+                    GetKeyState(VK_SHIFT as i32) < 0,
+                    GetKeyState(VK_MENU as i32) < 0,
+                )
+            };
+            let Some(key) = key else { return Ok(()) };
+            let mut physical = COREWEBVIEW2_PHYSICAL_KEY_STATUS::default();
+            unsafe {
+                args.SetHandled(true)?;
+                args.PhysicalKeyStatus(&mut physical)?;
+            }
+            if physical.WasKeyDown.as_bool() {
+                return Ok(());
+            }
+            let app = app.clone();
+            let chrome_label = chrome_label.clone();
+            // Leave WebView2's synchronous accelerator callback before
+            // changing focus or evaluating script in another controller.
+            tauri::async_runtime::spawn(async move {
+                if let Some(chrome) = app.get_webview(&chrome_label) {
+                    let _ = chrome.set_focus();
+                    let _ = chrome.eval(format!(
+                        "window.dispatchEvent(new KeyboardEvent('keydown', {{key:'{key}',ctrlKey:true,bubbles:true,cancelable:true}}));"
+                    ));
+                }
+            });
+            Ok(())
+        }));
+        let mut token = 0;
+        if let Err(error) = unsafe {
+            platform
+                .controller()
+                .add_AcceleratorKeyPressed(&callback, &mut token)
+        } {
+            eprintln!("could not install browser shortcuts: {error}");
+        }
+        // The controller owns the callback until the tab is closed.
+    });
+    if let Err(error) = result {
+        eprintln!("could not access browser shortcut controller: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shortcut_key;
+
+    #[test]
+    fn routes_browser_accelerators_but_preserves_page_editing_shortcuts() {
+        for (key, expected) in [(0x4c, 'l'), (0x54, 't'), (0x57, 'w'), (0x52, 'r')] {
+            assert_eq!(shortcut_key(key, true, false, false), Some(expected));
+            assert_eq!(shortcut_key(key, false, false, false), None);
+            assert_eq!(shortcut_key(key, true, true, false), None);
+            assert_eq!(shortcut_key(key, true, false, true), None);
+        }
+        for key in [0x41, 0x43, 0x56, 0x58, 0x5a, 0x25, 0x27] {
+            assert_eq!(shortcut_key(key, true, false, false), None);
+        }
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -904,7 +904,13 @@ fn drop_probes_for_moved_endpoints(config: &mut AppConfig, stored: &AppConfig) {
 }
 
 #[tauri::command]
-pub fn set_config(mut config: AppConfig) -> Result<(), String> {
+pub async fn set_config(config: AppConfig) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || set_config_blocking(config))
+        .await
+        .map_err(|error| format!("configuration worker failed: {error}"))?
+}
+
+fn set_config_blocking(mut config: AppConfig) -> Result<(), String> {
     let _guard = lock_config_writes()?;
     let stored = read_config_unlocked()?;
     if config.github_token.is_empty() {
@@ -2016,7 +2022,7 @@ mod tests {
         incoming.github_user = "octocat".to_string();
         incoming.mcp_servers.clear();
 
-        set_config(incoming).unwrap();
+        tauri::async_runtime::block_on(set_config(incoming)).unwrap();
 
         let persisted = read_config().unwrap();
         assert_eq!(persisted.github_user, "octocat");
@@ -2038,7 +2044,7 @@ mod tests {
         incoming.checkpoints_enabled = false;
         incoming.checkpoint_notifications = false;
 
-        set_config(incoming).unwrap();
+        tauri::async_runtime::block_on(set_config(incoming)).unwrap();
 
         let persisted = read_config().unwrap();
         assert_eq!(persisted.github_user, "octocat");
@@ -2069,7 +2075,7 @@ mod tests {
             .insert("groq".to_string(), 41);
         incoming.ai_model_probes.clear();
 
-        set_config(incoming).unwrap();
+        tauri::async_runtime::block_on(set_config(incoming)).unwrap();
 
         let persisted = read_config().unwrap();
         assert_eq!(
@@ -2108,7 +2114,7 @@ mod tests {
         assert_eq!(incoming.ai_model_probes.len(), 2);
         incoming.ai_custom_providers[0].base_url = "http://other.test/v1".into();
 
-        set_config(incoming).unwrap();
+        tauri::async_runtime::block_on(set_config(incoming)).unwrap();
 
         let persisted = read_config().unwrap();
         assert!(!persisted
@@ -2134,7 +2140,7 @@ mod tests {
         incoming.github_user = "octocat".to_string();
         incoming.git_auto_init = false;
 
-        set_config(incoming).unwrap();
+        tauri::async_runtime::block_on(set_config(incoming)).unwrap();
 
         let persisted = read_config().unwrap();
         assert_eq!(persisted.github_user, "octocat");

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -5,6 +5,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use crate::paths;
 use crate::secrets;
+use oleafly_core::locking::{lock_file, lock_mutex, STORAGE_LOCK_TIMEOUT};
 
 static CONFIG_WRITE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -230,10 +231,11 @@ pub fn read_config() -> Result<AppConfig, String> {
 }
 
 fn lock_config_writes() -> Result<ConfigTransactionLock, String> {
-    let guard = CONFIG_WRITE_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let guard = lock_mutex(
+        CONFIG_WRITE_LOCK.get_or_init(|| Mutex::new(())),
+        STORAGE_LOCK_TIMEOUT,
+    )
+    .map_err(|error| format!("failed to lock config transaction: {error}"))?;
     let root = paths::oleafly_root()?;
     std::fs::create_dir_all(&root)
         .map_err(|error| format!("failed to create config directory: {error}"))?;
@@ -255,7 +257,7 @@ fn lock_config_writes() -> Result<ConfigTransactionLock, String> {
         .open(&path)
         .map_err(|error| format!("failed to open config transaction lock: {error}"))?;
     crate::fsperm::harden_file(&path);
-    fs4::FileExt::lock(&file)
+    lock_file(&file, true, STORAGE_LOCK_TIMEOUT)
         .map_err(|error| format!("failed to lock config transaction: {error}"))?;
     Ok(ConfigTransactionLock {
         _file: file,
@@ -598,7 +600,7 @@ fn write_config_at(path: &std::path::Path, config: &AppConfig) -> Result<(), Str
     }
     crate::fsperm::harden_file(&tmp);
 
-    std::fs::rename(&tmp, path).map_err(|e| {
+    crate::sandbox::replace_file(&tmp, path).map_err(|e| {
         let _ = std::fs::remove_file(&tmp);
         format!("failed to replace config: {e}")
     })

--- a/src-tauri/src/document_engine.rs
+++ b/src-tauri/src/document_engine.rs
@@ -1029,7 +1029,13 @@ fn parse_pandoc_diagnostics(log: &str) -> Vec<CompileError> {
                 return None;
             }
             let lower = trimmed.to_ascii_lowercase();
-            let kind = if lower.contains("warning") {
+            // Tectonic on Windows can emit this Fontconfig initialization
+            // message and still successfully resolve bundled fonts and write
+            // the PDF. Pandoc forwards it verbatim. Keep it visible without
+            // rejecting valid output; a nonzero exit still fails compilation.
+            let kind = if lower.contains("warning")
+                || lower.starts_with("fontconfig error: cannot load default config file:")
+            {
                 "warning"
             } else if lower.contains("error") || lower.starts_with("pandoc:") {
                 "error"
@@ -3908,6 +3914,18 @@ mod tests {
         assert_eq!(errors[0].kind, "warning");
         assert_eq!(errors[1].kind, "error");
         assert_eq!(errors[1].line, None);
+    }
+
+    #[test]
+    fn markdown_fontconfig_fallback_is_a_warning_but_pdf_errors_remain_errors() {
+        let diagnostics = MARKDOWN_ENGINE.parse_errors(
+            "Fontconfig error: Cannot load default config file: No such file: (null)\n\
+             Error producing PDF.\npandoc: PDF creation failed\n",
+        );
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].kind, "warning");
+        assert_eq!(diagnostics[1].kind, "error");
+        assert_eq!(diagnostics[2].kind, "error");
     }
 
     #[test]

--- a/src-tauri/src/fsperm.rs
+++ b/src-tauri/src/fsperm.rs
@@ -20,6 +20,13 @@ pub fn harden_file(path: &Path) {
     }
 }
 
+/// Discovery files must fail before writing credentials if ACL installation
+/// fails; other existing callers deliberately use best-effort hardening.
+#[cfg(windows)]
+pub fn harden_file_checked(path: &Path) -> std::io::Result<()> {
+    windows::harden(path)
+}
+
 #[cfg(windows)]
 mod windows {
     use std::io;

--- a/src-tauri/src/fsperm.rs
+++ b/src-tauri/src/fsperm.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 /// Restrict `path` so only the current user can read/write it (the unix `0600`
 /// equivalent). Best-effort: never fails the caller. On unix sets `0600`; on
-/// Windows resets inherited ACLs and grants only the current user Full control
-/// via `icacls`; on other targets it is a no-op.
+/// Windows installs a protected, current-user-only ACL using the native API;
+/// on other targets it is a no-op.
 pub fn harden_file(path: &Path) {
     #[cfg(unix)]
     {
@@ -12,32 +12,182 @@ pub fn harden_file(path: &Path) {
     }
     #[cfg(windows)]
     {
-        use crate::proc::NoConsole;
-        // Resolve "the current user" for icacls. Prefer DOMAIN\USER so the ACE
-        // resolves for both local and domain accounts; fall back to the bare
-        // name. If we can't determine it, skip (leaves the inherited ACLs; the
-        // file is still under the user-scoped %USERPROFILE%).
-        let name = match std::env::var("USERNAME") {
-            Ok(n) if !n.is_empty() => n,
-            _ => return,
-        };
-        let principal = match std::env::var("USERDOMAIN") {
-            Ok(dom) if !dom.is_empty() => format!("{dom}\\{name}"),
-            _ => name,
-        };
-        // /inheritance:r  -> drop inherited ACEs (removes any broader grant)
-        // /grant:r USER:(F) -> replace USER's ACE with Full control, so the
-        //                      current user is the only principal with access.
-        let _ = std::process::Command::new("icacls")
-            .no_console()
-            .arg(path)
-            .arg("/inheritance:r")
-            .arg("/grant:r")
-            .arg(format!("{principal}:(F)"))
-            .output();
+        let _ = windows::harden(path);
     }
     #[cfg(not(any(unix, windows)))]
     {
         let _ = path;
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::io;
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use std::path::Path;
+    use std::ptr::{null, null_mut};
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::{
+        SetEntriesInAclW, SetNamedSecurityInfoW, EXPLICIT_ACCESS_W, SET_ACCESS, SE_FILE_OBJECT,
+        TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+    };
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TokenUser, DACL_SECURITY_INFORMATION, NO_INHERITANCE,
+        PROTECTED_DACL_SECURITY_INFORMATION, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows_sys::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    fn user_token() -> io::Result<Vec<usize>> {
+        // Use the actual process identity, independent of mutable USERNAME and
+        // USERDOMAIN environment variables and domain-name resolution.
+        let mut raw = null_mut();
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut raw) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let token = unsafe { OwnedHandle::from_raw_handle(raw) };
+        let mut size = 0;
+        unsafe { GetTokenInformation(token.as_raw_handle(), TokenUser, null_mut(), 0, &mut size) };
+        if size == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // TOKEN_USER contains a pointer: keep its backing buffer aligned and
+        // alive until the ACL builder has copied the SID.
+        let mut buffer = vec![0usize; (size as usize).div_ceil(std::mem::size_of::<usize>())];
+        if unsafe {
+            GetTokenInformation(
+                token.as_raw_handle(),
+                TokenUser,
+                buffer.as_mut_ptr().cast(),
+                size,
+                &mut size,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(buffer)
+    }
+
+    pub(super) fn harden(path: &Path) -> io::Result<()> {
+        let mut path: Vec<u16> = path.as_os_str().encode_wide().collect();
+        if path.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path contains NUL",
+            ));
+        }
+        path.push(0);
+        let token = user_token()?;
+        let user = unsafe { &*token.as_ptr().cast::<TOKEN_USER>() };
+        let entry = EXPLICIT_ACCESS_W {
+            grfAccessPermissions: FILE_ALL_ACCESS,
+            grfAccessMode: SET_ACCESS,
+            grfInheritance: NO_INHERITANCE,
+            Trustee: TRUSTEE_W {
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_USER,
+                ptstrName: user.User.Sid.cast(),
+                ..Default::default()
+            },
+        };
+        let mut acl = null_mut();
+        let status = unsafe { SetEntriesInAclW(1, &entry, null(), &mut acl) };
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+        // Secret reads also harden their lock file. Avoid spawning icacls on
+        // this hot path: process startup can stall the UI for every read.
+        let status = unsafe {
+            SetNamedSecurityInfoW(
+                path.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                null_mut(),
+                null_mut(),
+                acl,
+                null(),
+            )
+        };
+        unsafe { LocalFree(acl.cast()) };
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+        use windows_sys::Win32::Security::{
+            EqualSid, GetAce, GetSecurityDescriptorControl, ACCESS_ALLOWED_ACE, SE_DACL_PROTECTED,
+        };
+
+        #[test]
+        fn hardening_installs_only_the_current_user_and_preserves_unicode_file() {
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("secret with spaces — 日本語.txt");
+            std::fs::write(&path, "synthetic secret").unwrap();
+            for _ in 0..2 {
+                harden(&path).unwrap();
+                let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+                let mut acl = null_mut();
+                let mut descriptor = null_mut();
+                assert_eq!(
+                    unsafe {
+                        GetNamedSecurityInfoW(
+                            wide.as_ptr(),
+                            SE_FILE_OBJECT,
+                            DACL_SECURITY_INFORMATION,
+                            null_mut(),
+                            null_mut(),
+                            &mut acl,
+                            null_mut(),
+                            &mut descriptor,
+                        )
+                    },
+                    0
+                );
+                let token = user_token().unwrap();
+                let user = unsafe { &*token.as_ptr().cast::<TOKEN_USER>() };
+                let mut control = 0;
+                let mut revision = 0;
+                let mut ace = null_mut();
+                unsafe {
+                    assert!(!acl.is_null());
+                    assert_eq!((*acl).AceCount, 1);
+                    assert_ne!(GetAce(acl, 0, &mut ace), 0);
+                    let ace = &*ace.cast::<ACCESS_ALLOWED_ACE>();
+                    assert_eq!(ace.Header.AceType, 0); // ACCESS_ALLOWED_ACE_TYPE
+                    assert_eq!(ace.Mask, FILE_ALL_ACCESS);
+                    assert_ne!(
+                        EqualSid(
+                            std::ptr::addr_of!(ace.SidStart).cast_mut().cast(),
+                            user.User.Sid
+                        ),
+                        0
+                    );
+                    assert_ne!(
+                        GetSecurityDescriptorControl(descriptor, &mut control, &mut revision),
+                        0
+                    );
+                    assert_ne!(control & SE_DACL_PROTECTED, 0);
+                    LocalFree(descriptor);
+                }
+                assert_eq!(std::fs::read_to_string(&path).unwrap(), "synthetic secret");
+                std::fs::write(&path, "synthetic secret").unwrap();
+            }
+        }
+
+        #[test]
+        fn missing_file_returns_an_error_without_creating_it() {
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("missing");
+            assert!(harden(&path).is_err());
+            super::super::harden_file(&path); // best-effort public contract
+            assert!(!path.exists());
+        }
     }
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -4,7 +4,20 @@ use std::process::Command;
 
 use crate::config;
 use crate::paths;
-use crate::proc::{output_contained, NoConsole};
+use crate::proc::{output_contained, NoConsole, OutputBounds};
+
+/// A transfer over someone's own uplink can legitimately take many minutes, so
+/// judge it by silence rather than by elapsed time: a push that is slow but
+/// still moving must finish. `--progress` at every remote call site is what
+/// makes that measurable, because Git reports progress once stderr is a pipe
+/// only when it is asked to. The total is a backstop for a process that hangs
+/// while still dribbling output, not a policy on how long a push may take.
+const REMOTE_IDLE: std::time::Duration = std::time::Duration::from_secs(120);
+const REMOTE_TOTAL: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+fn remote_bounds() -> OutputBounds {
+    OutputBounds::stalled_after(REMOTE_IDLE, REMOTE_TOTAL)
+}
 
 fn project_root(project_id: &str) -> Result<PathBuf, String> {
     paths::project_dir(project_id)
@@ -35,6 +48,16 @@ fn run_configured_git(
     optional_locks: bool,
     configure: impl FnOnce(&mut Command),
 ) -> Result<std::process::Output, String> {
+    run_configured_git_bounded(root, args, optional_locks, None, configure)
+}
+
+fn run_configured_git_bounded(
+    root: &PathBuf,
+    args: &[&str],
+    optional_locks: bool,
+    bounds: Option<OutputBounds>,
+    configure: impl FnOnce(&mut Command),
+) -> Result<std::process::Output, String> {
     let mut command = Command::new("git");
     command
         .no_console()
@@ -51,7 +74,17 @@ fn run_configured_git(
         .env_remove("GIT_INDEX_FILE")
         .env("GIT_OPTIONAL_LOCKS", if optional_locks { "1" } else { "0" });
     configure(&mut command);
-    output_contained(command).map_err(|e| format!("failed to run git: {e}"))
+    match bounds {
+        Some(bounds) => crate::proc::output_contained_with_bounds(command, bounds),
+        None => output_contained(command),
+    }
+    .map_err(|e| format!("failed to run git: {e}"))
+}
+
+/// Reach a remote without a token: public clones and pulls still transfer over
+/// the same uplink, so they get the same silence-based bound.
+fn run_git_remote(root: &PathBuf, args: &[&str]) -> Result<std::process::Output, String> {
+    run_configured_git_bounded(root, args, true, Some(remote_bounds()), |_| {})
 }
 
 pub(crate) fn ensure_repository(project_dir: &Path) -> Result<bool, String> {
@@ -323,6 +356,17 @@ fn restore_worktree(root: &PathBuf, oid: &str) -> Result<(), String> {
     ok_or_err(run_git(root, &["read-tree", "--reset", "-u", oid])?)
 }
 
+/// Collapse a progress line to the last frame it drew. `--progress` redraws in
+/// place with carriage returns, so a failed transfer would otherwise report
+/// every percentage it passed through instead of where it stopped.
+fn last_progress_frame(line: &str) -> &str {
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    match line.rfind('\r') {
+        Some(index) => &line[index + 1..],
+        None => line,
+    }
+}
+
 fn out_to_string(out: &std::process::Output) -> String {
     let mut s = String::new();
     s.push_str(&String::from_utf8_lossy(&out.stdout));
@@ -332,7 +376,12 @@ fn out_to_string(out: &std::process::Output) -> String {
         }
         s.push_str(&String::from_utf8_lossy(&out.stderr));
     }
-    s.trim().to_string()
+    s.split('\n')
+        .map(last_progress_frame)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
 }
 
 /// Strip any embedded credentials from a remote URL for display.
@@ -476,7 +525,7 @@ fn run_git_authed(
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE");
-    crate::proc::output_contained_with_timeout(command, std::time::Duration::from_secs(300))
+    crate::proc::output_contained_with_bounds(command, remote_bounds())
         .map_err(|e| format!("failed to run git: {e}"))
 }
 
@@ -499,7 +548,7 @@ pub(crate) fn attach_imported_repository_history_lock_held(
         ok_or_err(run_git_authed(
             root,
             token,
-            &["fetch", "--no-tags", "origin", refspec],
+            &["fetch", "--no-tags", "--progress", "origin", refspec],
         )?)
     })
 }
@@ -730,7 +779,11 @@ fn git_push_sync(project_id: String) -> Result<String, String> {
     let branch = current_branch(&root)?;
     // Push to the named `origin` remote (credentials come from the env-backed
     // helper), so git updates the `origin/<branch>` tracking ref itself.
-    let out = run_git_authed(&root, &cfg.github_token, &["push", "-u", "origin", &branch])?;
+    let out = run_git_authed(
+        &root,
+        &cfg.github_token,
+        &["push", "--progress", "-u", "origin", &branch],
+    )?;
     if !out.status.success() {
         return Err(out_to_string(&out));
     }
@@ -782,9 +835,15 @@ fn pull_origin(root: &PathBuf, token: &str) -> Result<String, String> {
         return Err("No remote 'origin' set for this project.".into());
     }
     let branch = current_branch(root)?;
-    let pull_args = ["pull", "--no-rebase", "origin", branch.as_str()];
+    let pull_args = [
+        "pull",
+        "--no-rebase",
+        "--progress",
+        "origin",
+        branch.as_str(),
+    ];
     let output = if token.is_empty() {
-        run_git(root, &pull_args)?
+        run_git_remote(root, &pull_args)?
     } else {
         run_git_authed(root, token, &pull_args)?
     };
@@ -1127,9 +1186,10 @@ mod tests {
     use super::{
         attach_imported_repository_history_at, clean_remote_credentials, commit_index,
         current_branch, ensure_repository, ensure_repository_with, initialize_repo,
-        is_allowed_remote_url, ok_or_err, parse_status_porcelain, remote_credentials_need_cleanup,
-        restore_worktree, run_configured_git, run_git, run_git_read_only, sanitize_url, show,
-        stage, stage_all, unstage, unstage_all, validate_git_oid, Command,
+        is_allowed_remote_url, ok_or_err, out_to_string, parse_status_porcelain,
+        remote_credentials_need_cleanup, restore_worktree, run_configured_git, run_git,
+        run_git_read_only, sanitize_url, show, stage, stage_all, unstage, unstage_all,
+        validate_git_oid, Command,
     };
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -1137,6 +1197,21 @@ mod tests {
     use std::time::Duration;
 
     static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    #[test]
+    fn a_failed_transfer_reports_where_it_stopped_not_every_percentage() {
+        let out = std::process::Output {
+            status: std::process::Command::new("false").status().unwrap(),
+            stdout: Vec::new(),
+            stderr: b"Writing objects:  10% (1/10)\rWriting objects:  90% (9/10)\r\n\
+                      error: failed to push some refs\r\n"
+                .to_vec(),
+        };
+        assert_eq!(
+            out_to_string(&out),
+            "Writing objects:  90% (9/10)\nerror: failed to push some refs"
+        );
+    }
 
     /// Create a throwaway git repo in a temp dir with a fixed identity.
     fn temp_repo() -> PathBuf {

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -51,7 +51,7 @@ fn run_configured_git(
         .env_remove("GIT_INDEX_FILE")
         .env("GIT_OPTIONAL_LOCKS", if optional_locks { "1" } else { "0" });
     configure(&mut command);
-    output_contained(&mut command).map_err(|e| format!("failed to run git: {e}"))
+    output_contained(command).map_err(|e| format!("failed to run git: {e}"))
 }
 
 pub(crate) fn ensure_repository(project_dir: &Path) -> Result<bool, String> {
@@ -476,7 +476,8 @@ fn run_git_authed(
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE");
-    output_contained(&mut command).map_err(|e| format!("failed to run git: {e}"))
+    crate::proc::output_contained_with_timeout(command, std::time::Duration::from_secs(300))
+        .map_err(|e| format!("failed to run git: {e}"))
 }
 
 /// Attach the authenticated repository history to content imported through the

--- a/src-tauri/src/mcp/client.rs
+++ b/src-tauri/src/mcp/client.rs
@@ -159,8 +159,19 @@ struct StdioTransport {
     stdout: BufReader<tokio::process::ChildStdout>,
     stderr: Option<tokio::task::JoinHandle<()>>,
     stderr_output: std::sync::Arc<tokio::sync::Mutex<Vec<u8>>>,
-    pid: u32,
     containment: Option<crate::proc::ProcessTreeGuard>,
+}
+
+impl Drop for StdioTransport {
+    fn drop(&mut self) {
+        // Dropping a JoinHandle detaches it. Cancellation must also stop the
+        // pipe reader, including when discovery or a tool request is aborted.
+        if let Some(stderr) = self.stderr.take() {
+            stderr.abort();
+        }
+        self.containment.take();
+        let _ = self.child.start_kill();
+    }
 }
 
 impl StdioTransport {
@@ -252,7 +263,6 @@ impl StdioTransport {
             stdout: BufReader::new(stdout),
             stderr: Some(stderr),
             stderr_output,
-            pid,
             containment: Some(containment),
         })
     }
@@ -260,14 +270,21 @@ impl StdioTransport {
     async fn shutdown(mut self) {
         self.stdin.take();
         let exited = tokio::time::timeout(Duration::from_millis(500), self.child.wait()).await;
-        if !matches!(exited, Ok(Ok(_))) {
-            crate::proc::terminate_process_tree(self.pid).await;
-            let _ = self.child.kill().await;
-            let _ = self.child.wait().await;
-        }
+        // Close the Job Object before waiting on cleanup: this also closes
+        // inherited pipes owned by grandchildren after the server exits.
         self.containment.take();
-        if let Some(stderr) = self.stderr.take() {
-            let _ = tokio::time::timeout(Duration::from_millis(500), stderr).await;
+        if !matches!(exited, Ok(Ok(_))) {
+            let _ = self.child.start_kill();
+            let _ = tokio::time::timeout(Duration::from_secs(2), self.child.wait()).await;
+        }
+        if let Some(mut stderr) = self.stderr.take() {
+            if tokio::time::timeout(Duration::from_millis(500), &mut stderr)
+                .await
+                .is_err()
+            {
+                stderr.abort();
+                let _ = stderr.await;
+            }
         }
     }
 
@@ -4970,6 +4987,45 @@ mod tests {
 
         assert_eq!(tools[0].name, "graceful");
         assert_eq!(std::fs::read_to_string(marker).unwrap(), "closed");
+    }
+
+    #[tokio::test]
+    async fn dropping_stdio_transport_aborts_its_diagnostics_reader() {
+        let transport = StdioTransport::spawn(
+            "node",
+            &["-e".into(), "setInterval(()=>{},1000)".into()],
+            &BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+        let diagnostics = transport.stderr.as_ref().unwrap().abort_handle();
+        drop(transport);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !diagnostics.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("diagnostics task survived transport cancellation");
+    }
+
+    #[tokio::test]
+    async fn uncooperative_stdio_shutdown_is_bounded() {
+        let transport = StdioTransport::spawn(
+            "node",
+            &[
+                "-e".into(),
+                "process.stdin.resume();setInterval(()=>{},1000)".into(),
+            ],
+            &BTreeMap::new(),
+        )
+        .await
+        .unwrap();
+        let diagnostics = transport.stderr.as_ref().unwrap().abort_handle();
+        tokio::time::timeout(Duration::from_secs(4), transport.shutdown())
+            .await
+            .expect("uncooperative MCP server blocked shutdown");
+        assert!(diagnostics.is_finished());
     }
 
     #[tokio::test]

--- a/src-tauri/src/mcp/server_discovery.rs
+++ b/src-tauri/src/mcp/server_discovery.rs
@@ -93,7 +93,7 @@ fn publish_discovery_contents(
     file.sync_all()
         .map_err(|e| format!("failed to sync MCP discovery file: {e}"))?;
     drop(file);
-    atomicwrites::replace_atomic(temp_path, path)
+    crate::sandbox::replace_file(temp_path, path)
         .map_err(|e| format!("failed to publish MCP discovery file: {e}"))?;
     if let Ok(directory) = std::fs::File::open(parent) {
         let _ = directory.sync_all();
@@ -122,46 +122,8 @@ fn harden_empty_discovery_file(path: &std::path::Path) -> Result<(), String> {
 
 #[cfg(windows)]
 fn harden_empty_discovery_file(path: &std::path::Path) -> Result<(), String> {
-    use crate::proc::NoConsole as _;
-    use std::process::Stdio;
-
-    let name = std::env::var("USERNAME")
-        .ok()
-        .filter(|name| !name.is_empty())
-        .ok_or_else(|| "cannot determine the current Windows user for MCP ACLs".to_string())?;
-    let principal = std::env::var("USERDOMAIN")
-        .ok()
-        .filter(|domain| !domain.is_empty())
-        .map_or_else(|| name.clone(), |domain| format!("{domain}\\{name}"));
-    let system_root = std::env::var_os("SystemRoot")
-        .filter(|root| !root.is_empty())
-        .ok_or_else(|| "cannot locate the Windows system directory for MCP ACLs".to_string())?;
-    let icacls = std::path::PathBuf::from(system_root)
-        .join("System32")
-        .join("icacls.exe");
-    if !icacls.is_file() {
-        return Err(format!(
-            "cannot locate the Windows ACL utility at {}",
-            icacls.display()
-        ));
-    }
-    let status = std::process::Command::new(&icacls)
-        .no_console()
-        .arg(path)
-        .arg("/inheritance:r")
-        .arg("/grant:r")
-        .arg(format!("{principal}:(F)"))
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|e| format!("failed to harden MCP discovery file ACL: {e}"))?;
-    if !status.success() {
-        return Err(format!(
-            "failed to harden MCP discovery file ACL (icacls exited with {status})"
-        ));
-    }
-    Ok(())
+    crate::fsperm::harden_file_checked(path)
+        .map_err(|error| format!("failed to harden MCP discovery file ACL: {error}"))
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -11,7 +11,10 @@
 //! `no_console()` is a no-op on macOS and Linux, where a spawned child has no
 //! console window to hide; those platforms compile the trivial branch.
 
-use std::process::{Command, Stdio};
+use std::process::Command;
+
+mod output;
+pub use output::{output_contained, output_contained_with_timeout};
 
 /// `CREATE_NO_WINDOW` (winbase.h): the child runs without allocating a console.
 #[cfg(windows)]
@@ -51,39 +54,6 @@ impl NoConsole for tokio::process::Command {
     #[cfg(not(windows))]
     fn no_console(&mut self) -> &mut Self {
         self
-    }
-}
-
-/// Run a synchronous command while applying the same Windows Job Object
-/// containment used by async compiler and language-server children.
-pub fn output_contained(command: &mut Command) -> std::io::Result<std::process::Output> {
-    // `Command::output` configures these streams for the caller, but the
-    // Windows path has to use `spawn` so the suspended child can be assigned
-    // to its Job Object before it starts. Reproduce `output` semantics before
-    // spawning or `wait_with_output` has no pipes to collect.
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        command.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP | CREATE_SUSPENDED);
-        let mut child = command.spawn()?;
-        let pid = child.id();
-        let _containment = match contain_process_tree(pid) {
-            Ok(containment) => containment,
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(error);
-            }
-        };
-        child.wait_with_output()
-    }
-    #[cfg(not(windows))]
-    {
-        command.output()
     }
 }
 
@@ -361,17 +331,22 @@ pub async fn terminate_process_tree(pid: u32) {
     }
     #[cfg(windows)]
     {
-        let _ = tokio::process::Command::new("taskkill")
+        let mut command = tokio::process::Command::new("taskkill");
+        command
             .no_console()
             .args(["/PID", &pid.to_string(), "/T", "/F"])
-            .status()
-            .await;
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), command.status()).await;
     }
 }
 
 #[cfg(all(test, windows))]
 mod windows_tests {
     use super::*;
+    use std::process::Stdio;
     use std::time::Duration;
 
     #[tokio::test]
@@ -421,13 +396,14 @@ mod windows_tests {
 
     #[test]
     fn synchronous_commands_run_inside_a_job_object() {
-        let output = output_contained(Command::new("cmd.exe").args([
+        let mut command = Command::new("cmd.exe");
+        command.args([
             "/D",
             "/S",
             "/C",
             "echo contained-out & echo contained-err 1>&2",
-        ]))
-        .expect("run contained synchronous child");
+        ]);
+        let output = output_contained(command).expect("run contained synchronous child");
 
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("contained-out"));

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -14,7 +14,9 @@
 use std::process::Command;
 
 mod output;
-pub use output::{output_contained, output_contained_with_timeout};
+pub use output::{
+    output_contained, output_contained_with_bounds, output_contained_with_timeout, OutputBounds,
+};
 
 /// `CREATE_NO_WINDOW` (winbase.h): the child runs without allocating a console.
 #[cfg(windows)]

--- a/src-tauri/src/proc/output.rs
+++ b/src-tauri/src/proc/output.rs
@@ -1,0 +1,182 @@
+use std::io;
+use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+const OUTPUT_LIMIT: usize = 64 * 1024 * 1024;
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Synchronous callers must run on blocking workers. A single shared reactor
+/// drains both pipes without creating reader threads for every Git refresh.
+pub fn output_contained(command: Command) -> io::Result<Output> {
+    output_contained_with_timeout(command, Duration::from_secs(120))
+}
+
+pub fn output_contained_with_timeout(command: Command, timeout: Duration) -> io::Result<Output> {
+    static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+    let runtime = RUNTIME
+        .get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .thread_name("oleafly-process-output")
+                .enable_all()
+                .build()
+                .map_err(|error| error.to_string())
+        })
+        .as_ref()
+        .map_err(|error| io::Error::other(error.clone()))?;
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    runtime.spawn(async move {
+        let _ = sender.send(collect_output(command, timeout, OUTPUT_LIMIT).await);
+    });
+    receiver
+        .recv()
+        .map_err(|_| io::Error::other("process output worker stopped"))?
+}
+
+async fn read_output(mut pipe: impl AsyncRead + Unpin, limit: usize) -> io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut bytes = [0; 8192];
+    loop {
+        let count = pipe.read(&mut bytes).await?;
+        if count == 0 {
+            return Ok(output);
+        }
+        if output.len().saturating_add(count) > limit {
+            return Err(io::Error::other(format!(
+                "command output exceeded the {limit}-byte limit"
+            )));
+        }
+        output.extend_from_slice(&bytes[..count]);
+    }
+}
+
+fn spawn_output(command: Command) -> io::Result<(tokio::process::Child, super::ProcessTreeGuard)> {
+    let mut command = tokio::process::Command::from(command);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    super::isolate_process_tree(&mut command);
+    let child = command.spawn()?;
+    let containment = super::contain_process_tree(
+        child
+            .id()
+            .ok_or_else(|| io::Error::other("child has no process id"))?,
+    )?;
+    Ok((child, containment))
+}
+
+async fn collect_output(command: Command, timeout: Duration, limit: usize) -> io::Result<Output> {
+    let started = Instant::now();
+    // CreateProcess and Job Object setup must not park the shared I/O reactor.
+    // If admission times out, the blocking task still owns the child/guard;
+    // dropping its eventual result closes that tree without publishing it.
+    let launched = tokio::time::timeout(
+        timeout,
+        tokio::task::spawn_blocking(move || spawn_output(command)),
+    )
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "command startup timed out"))?;
+    let (mut child, containment) = launched.map_err(io::Error::other)??;
+    let mut containment = Some(containment);
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("missing stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("missing stderr"))?;
+    // Keep reads in this future: cancellation closes the pipes immediately,
+    // rather than detaching tasks that can outlive the command indefinitely.
+    let result = tokio::time::timeout(timeout.saturating_sub(started.elapsed()), async {
+        let wait = async {
+            let status = child.wait().await?;
+            // A hook/helper may leave a descendant holding either pipe open.
+            // Stop the owned tree as soon as its leader finishes.
+            drop(containment.take());
+            Ok::<_, io::Error>(status)
+        };
+        let (status, stdout, stderr) =
+            tokio::try_join!(wait, read_output(stdout, limit), read_output(stderr, limit))?;
+        Ok(Output {
+            status,
+            stdout,
+            stderr,
+        })
+    })
+    .await
+    .unwrap_or_else(|_| {
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "command timed out and was stopped",
+        ))
+    });
+    drop(containment);
+    if result.is_err() {
+        let _ = child.start_kill();
+        let _ = tokio::time::timeout(CLEANUP_TIMEOUT, child.wait()).await;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn node(script: &str) -> Command {
+        let mut command = Command::new("node");
+        command.args(["-e", script]);
+        command
+    }
+
+    #[test]
+    fn captures_both_pipes_and_exit_status() {
+        let output = output_contained(node(
+            "process.stdout.write('out');process.stderr.write('err');process.exitCode=7",
+        ))
+        .unwrap();
+        assert_eq!(output.stdout, b"out");
+        assert_eq!(output.stderr, b"err");
+        assert_eq!(output.status.code(), Some(7));
+    }
+
+    #[test]
+    fn stalled_command_has_a_deadline() {
+        let start = Instant::now();
+        let error = output_contained_with_timeout(
+            node("setInterval(()=>{},1000)"),
+            Duration::from_millis(250),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn leader_exit_closes_inherited_descendant_pipes() {
+        let start = Instant::now();
+        let output = output_contained_with_timeout(node(
+            "require('child_process').spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{stdio:['ignore',1,2]});process.stdout.write('leader');process.exit(0)",
+        ), Duration::from_secs(5)).unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"leader");
+        assert!(start.elapsed() < Duration::from_secs(4));
+    }
+
+    #[tokio::test]
+    async fn excessive_output_fails_instead_of_silently_truncating() {
+        let error = collect_output(
+            node("process.stdout.write('x'.repeat(16384));setInterval(()=>{},1000)"),
+            Duration::from_secs(5),
+            1024,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("output exceeded"));
+    }
+}

--- a/src-tauri/src/proc/output.rs
+++ b/src-tauri/src/proc/output.rs
@@ -1,11 +1,38 @@
 use std::io;
 use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 const OUTPUT_LIMIT: usize = 64 * 1024 * 1024;
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How long a command may run, and how it is judged.
+#[derive(Clone, Copy, Debug)]
+pub struct OutputBounds {
+    idle: Option<Duration>,
+    total: Duration,
+}
+
+impl OutputBounds {
+    /// One wall-clock deadline that progress does not extend. Correct only
+    /// where the worst case is known and short, or where the command reports
+    /// nothing while it works.
+    pub fn total(total: Duration) -> Self {
+        Self { idle: None, total }
+    }
+
+    /// Stop after `idle` with no bytes on either pipe, keeping `total` as a
+    /// backstop. Work that is slow but still moving must survive, so this only
+    /// bounds a command that reports progress while it runs.
+    pub fn stalled_after(idle: Duration, total: Duration) -> Self {
+        Self {
+            idle: Some(idle),
+            total,
+        }
+    }
+}
 
 /// Synchronous callers must run on blocking workers. A single shared reactor
 /// drains both pipes without creating reader threads for every Git refresh.
@@ -14,6 +41,10 @@ pub fn output_contained(command: Command) -> io::Result<Output> {
 }
 
 pub fn output_contained_with_timeout(command: Command, timeout: Duration) -> io::Result<Output> {
+    output_contained_with_bounds(command, OutputBounds::total(timeout))
+}
+
+pub fn output_contained_with_bounds(command: Command, bounds: OutputBounds) -> io::Result<Output> {
     static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
     let runtime = RUNTIME
         .get_or_init(|| {
@@ -28,18 +59,26 @@ pub fn output_contained_with_timeout(command: Command, timeout: Duration) -> io:
         .map_err(|error| io::Error::other(error.clone()))?;
     let (sender, receiver) = std::sync::mpsc::sync_channel(1);
     runtime.spawn(async move {
-        let _ = sender.send(collect_output(command, timeout, OUTPUT_LIMIT).await);
+        let _ = sender.send(collect_output(command, bounds, OUTPUT_LIMIT).await);
     });
     receiver
         .recv()
         .map_err(|_| io::Error::other("process output worker stopped"))?
 }
 
-async fn read_output(mut pipe: impl AsyncRead + Unpin, limit: usize) -> io::Result<Vec<u8>> {
+async fn read_output(
+    mut pipe: impl AsyncRead + Unpin,
+    limit: usize,
+    started: Instant,
+    activity: &AtomicU64,
+) -> io::Result<Vec<u8>> {
     let mut output = Vec::new();
     let mut bytes = [0; 8192];
     loop {
         let count = pipe.read(&mut bytes).await?;
+        // Both pipes share one clock, so a command that reports only on stderr
+        // still counts as making progress.
+        activity.store(started.elapsed().as_millis() as u64, Ordering::Relaxed);
         if count == 0 {
             return Ok(output);
         }
@@ -49,6 +88,18 @@ async fn read_output(mut pipe: impl AsyncRead + Unpin, limit: usize) -> io::Resu
             )));
         }
         output.extend_from_slice(&bytes[..count]);
+    }
+}
+
+/// Resolves once neither pipe has delivered anything for `idle`.
+async fn stalled(started: Instant, activity: &AtomicU64, idle: Duration) {
+    loop {
+        let last = Duration::from_millis(activity.load(Ordering::Relaxed));
+        let quiet = started.elapsed().saturating_sub(last);
+        if quiet >= idle {
+            return;
+        }
+        tokio::time::sleep(idle - quiet).await;
     }
 }
 
@@ -69,13 +120,17 @@ fn spawn_output(command: Command) -> io::Result<(tokio::process::Child, super::P
     Ok((child, containment))
 }
 
-async fn collect_output(command: Command, timeout: Duration, limit: usize) -> io::Result<Output> {
+async fn collect_output(
+    command: Command,
+    bounds: OutputBounds,
+    limit: usize,
+) -> io::Result<Output> {
     let started = Instant::now();
     // CreateProcess and Job Object setup must not park the shared I/O reactor.
     // If admission times out, the blocking task still owns the child/guard;
     // dropping its eventual result closes that tree without publishing it.
     let launched = tokio::time::timeout(
-        timeout,
+        bounds.total,
         tokio::task::spawn_blocking(move || spawn_output(command)),
     )
     .await
@@ -90,23 +145,39 @@ async fn collect_output(command: Command, timeout: Duration, limit: usize) -> io
         .stderr
         .take()
         .ok_or_else(|| io::Error::other("missing stderr"))?;
+    let activity = AtomicU64::new(started.elapsed().as_millis() as u64);
     // Keep reads in this future: cancellation closes the pipes immediately,
     // rather than detaching tasks that can outlive the command indefinitely.
-    let result = tokio::time::timeout(timeout.saturating_sub(started.elapsed()), async {
-        let wait = async {
-            let status = child.wait().await?;
-            // A hook/helper may leave a descendant holding either pipe open.
-            // Stop the owned tree as soon as its leader finishes.
-            drop(containment.take());
-            Ok::<_, io::Error>(status)
+    let result = tokio::time::timeout(bounds.total.saturating_sub(started.elapsed()), async {
+        let collect = async {
+            let wait = async {
+                let status = child.wait().await?;
+                // A hook/helper may leave a descendant holding either pipe open.
+                // Stop the owned tree as soon as its leader finishes.
+                drop(containment.take());
+                Ok::<_, io::Error>(status)
+            };
+            let (status, stdout, stderr) = tokio::try_join!(
+                wait,
+                read_output(stdout, limit, started, &activity),
+                read_output(stderr, limit, started, &activity)
+            )?;
+            Ok(Output {
+                status,
+                stdout,
+                stderr,
+            })
         };
-        let (status, stdout, stderr) =
-            tokio::try_join!(wait, read_output(stdout, limit), read_output(stderr, limit))?;
-        Ok(Output {
-            status,
-            stdout,
-            stderr,
-        })
+        match bounds.idle {
+            None => collect.await,
+            Some(idle) => tokio::select! {
+                collected = collect => collected,
+                () = stalled(started, &activity, idle) => Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "command stopped reporting progress and was stopped",
+                )),
+            },
+        }
     })
     .await
     .unwrap_or_else(|_| {
@@ -168,11 +239,41 @@ mod tests {
         assert!(start.elapsed() < Duration::from_secs(4));
     }
 
+    #[test]
+    fn steady_progress_outlives_a_deadline_that_would_have_killed_it() {
+        // Five reports at 100ms cross an idle budget of 250ms many times over.
+        // A total cap of the same size would stop this transfer mid-flight.
+        let output = output_contained_with_bounds(
+            node(
+                "let n=0;const t=setInterval(()=>{process.stderr.write('sending ');\
+                 if(++n===5){clearInterval(t);process.stdout.write('done');process.exit(0)}},100)",
+            ),
+            OutputBounds::stalled_after(Duration::from_millis(250), Duration::from_secs(30)),
+        )
+        .unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"done");
+        assert_eq!(output.stderr, b"sending sending sending sending sending ");
+    }
+
+    #[test]
+    fn a_command_that_goes_quiet_stops_without_waiting_for_the_backstop() {
+        let start = Instant::now();
+        let error = output_contained_with_bounds(
+            node("process.stderr.write('sending ');setInterval(()=>{},1000)"),
+            OutputBounds::stalled_after(Duration::from_millis(250), Duration::from_secs(300)),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(error.to_string().contains("stopped reporting progress"));
+        assert!(start.elapsed() < Duration::from_secs(30));
+    }
+
     #[tokio::test]
     async fn excessive_output_fails_instead_of_silently_truncating() {
         let error = collect_output(
             node("process.stdout.write('x'.repeat(16384));setInterval(()=>{},1000)"),
-            Duration::from_secs(5),
+            OutputBounds::total(Duration::from_secs(5)),
             1024,
         )
         .await

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::paths;
-use crate::proc::NoConsole;
 use crate::sandbox::{atomic_write, guard_export_dest, resolve, AtomicFile};
 
 /// Public path resolver (sandbox). Re-exported so call sites keep importing
@@ -4342,11 +4341,11 @@ fn canonical_supported_pandoc(candidate: &Path) -> Option<PathBuf> {
     if !candidate.is_file() {
         return None;
     }
-    let output = Command::new(&candidate)
-        .no_console()
-        .arg("--version")
-        .output()
-        .ok()?;
+    let mut command = Command::new(&candidate);
+    command.arg("--version");
+    let output =
+        crate::proc::output_contained_with_timeout(command, std::time::Duration::from_secs(5))
+            .ok()?;
     (output.status.success() && pandoc_version_supported(&output.stdout)).then_some(candidate)
 }
 
@@ -4905,11 +4904,11 @@ async fn download_pandoc_impl(
         .map_err(|e| e.to_string())?;
     staging_file.sync_all().map_err(|e| e.to_string())?;
     drop(staging_file);
-    let version = std::process::Command::new(&staging)
-        .no_console()
-        .arg("--version")
-        .output()
-        .map_err(|e| format!("Downloaded Pandoc failed to run: {e}"))?;
+    let mut command = std::process::Command::new(&staging);
+    command.arg("--version");
+    let version =
+        crate::proc::output_contained_with_timeout(command, std::time::Duration::from_secs(5))
+            .map_err(|e| format!("Downloaded Pandoc failed to run: {e}"))?;
     if !version.status.success()
         || !String::from_utf8_lossy(&version.stdout).starts_with("pandoc 3.9.0.2")
     {

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -2970,7 +2970,13 @@ fn create_markdown_project_in(
 }
 
 #[tauri::command]
-pub fn rename_project(project_id: String, name: String) -> Result<ProjectMeta, String> {
+pub async fn rename_project(project_id: String, name: String) -> Result<ProjectMeta, String> {
+    tauri::async_runtime::spawn_blocking(move || rename_project_blocking(project_id, name))
+        .await
+        .map_err(|error| format!("project rename task failed: {error}"))?
+}
+
+fn rename_project_blocking(project_id: String, name: String) -> Result<ProjectMeta, String> {
     with_project_metadata(&project_id, || {
         let trimmed = name.trim();
         if trimmed.is_empty() {
@@ -8444,7 +8450,12 @@ mod tests {
         assert!(trusted.allow_shell_escape);
         assert!(read_meta(&project_id).unwrap().allow_shell_escape);
 
-        let renamed = super::rename_project(project_id.clone(), "Trusted Paper".into()).unwrap();
+        let renamed = tauri::async_runtime::block_on(super::rename_project(
+            project_id.clone(),
+            "Trusted Paper".into(),
+        ))
+        .unwrap();
+        assert_eq!(renamed.name, "Trusted Paper");
         assert!(renamed.allow_shell_escape);
         assert!(!std::fs::read_to_string(project.join("project.json"))
             .unwrap()

--- a/src-tauri/src/research_tasks/isolation.rs
+++ b/src-tauri/src/research_tasks/isolation.rs
@@ -888,6 +888,9 @@ mod tests {
 
     #[test]
     fn source_symlinks_are_rejected() {
+        if !crate::paths::symlink_creation_is_permitted() {
+            return;
+        }
         let temp = tempfile::tempdir().unwrap();
         let project = temp.path().join("project");
         fs::create_dir(&project).unwrap();

--- a/src-tauri/src/research_tasks/mod.rs
+++ b/src-tauri/src/research_tasks/mod.rs
@@ -734,37 +734,58 @@ fn validated_artifacts(
     Ok(artifacts)
 }
 
+// Store initialization, SQLite queries, and preview file reads can block on
+// disk or another connection. Keep them off the main WebView event loop.
+async fn blocking_task_command<T: Send + 'static>(
+    state: &ResearchTaskState,
+    operation: impl FnOnce(&ResearchTaskState) -> Result<T, String> + Send + 'static,
+) -> Result<T, String> {
+    let state = state.clone();
+    tauri::async_runtime::spawn_blocking(move || operation(&state))
+        .await
+        .map_err(|error| format!("task storage worker failed: {error}"))?
+}
+
 #[tauri::command]
-pub fn research_task_list(
+pub async fn research_task_list(
     state: tauri::State<'_, ResearchTaskState>,
     project_id: String,
 ) -> Result<Vec<ResearchTask>, String> {
-    crate::paths::validate_project_id(&project_id)?;
-    state.store()?.list(&project_id)
+    blocking_task_command(&state, move |state| {
+        crate::paths::validate_project_id(&project_id)?;
+        state.store()?.list(&project_id)
+    })
+    .await
 }
 
 #[tauri::command]
-pub fn research_task_create(
+pub async fn research_task_create(
     state: tauri::State<'_, ResearchTaskState>,
     draft: ResearchTaskDraft,
 ) -> Result<ResearchTask, String> {
-    crate::paths::validate_project_id(&draft.project_id)?;
-    crate::paths::project_dir(&draft.project_id)?;
-    ensure_skills_available(&draft.project_id, &draft.skill_ids)?;
-    let task = state.store()?.create(draft)?;
-    state.emit_task(&task);
-    Ok(task)
+    blocking_task_command(&state, move |state| {
+        crate::paths::validate_project_id(&draft.project_id)?;
+        crate::paths::project_dir(&draft.project_id)?;
+        ensure_skills_available(&draft.project_id, &draft.skill_ids)?;
+        let task = state.store()?.create(draft)?;
+        state.emit_task(&task);
+        Ok(task)
+    })
+    .await
 }
 
 #[tauri::command]
-pub fn research_task_edit(
+pub async fn research_task_edit(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
     edit: ResearchTaskEdit,
 ) -> Result<ResearchTask, String> {
-    let task = state.store()?.edit(&task_id, edit)?;
-    state.emit_task(&task);
-    Ok(task)
+    blocking_task_command(&state, move |state| {
+        let task = state.store()?.edit(&task_id, edit)?;
+        state.emit_task(&task);
+        Ok(task)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -839,47 +860,59 @@ async fn cancel_task(state: &ResearchTaskState, task_id: String) -> Result<Resea
 }
 
 #[tauri::command]
-pub fn research_task_retry(
+pub async fn research_task_retry(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
 ) -> Result<ResearchTask, String> {
-    let task = state.store()?.retry(&task_id)?;
-    state.emit_task(&task);
-    Ok(task)
+    blocking_task_command(&state, move |state| {
+        let task = state.store()?.retry(&task_id)?;
+        state.emit_task(&task);
+        Ok(task)
+    })
+    .await
 }
 
 #[tauri::command]
-pub fn research_task_events(
+pub async fn research_task_events(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
     execution_generation: u64,
     after_sequence: Option<u64>,
     limit: Option<usize>,
 ) -> Result<TaskTranscriptPage, String> {
-    state.store()?.events(
-        &task_id,
-        execution_generation,
-        after_sequence,
-        limit.unwrap_or(100),
-    )
+    blocking_task_command(&state, move |state| {
+        state.store()?.events(
+            &task_id,
+            execution_generation,
+            after_sequence,
+            limit.unwrap_or(100),
+        )
+    })
+    .await
 }
 
 #[tauri::command]
-pub fn research_task_file_preview(
+pub async fn research_task_file_preview(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
     path: String,
 ) -> Result<TaskFilePreview, String> {
-    preview::file_preview(&state.store()?, &task_id, &path)
+    blocking_task_command(&state, move |state| {
+        preview::file_preview(&state.store()?, &task_id, &path)
+    })
+    .await
 }
 
 #[tauri::command]
-pub fn research_task_artifact_preview(
+pub async fn research_task_artifact_preview(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
     path: String,
 ) -> Result<TaskArtifactPreview, String> {
-    preview::artifact_preview(&state.store()?, &task_id, &path)
+    blocking_task_command(&state, move |state| {
+        preview::artifact_preview(&state.store()?, &task_id, &path)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -989,6 +1022,24 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn task_storage_queries_leave_the_calling_thread_and_preserve_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = ResearchTaskState::for_test(temp.path().join("tasks"), 1);
+        let caller = std::thread::current().id();
+        let (worker, tasks) = blocking_task_command(&state, |state| {
+            Ok((std::thread::current().id(), state.store()?.list("paper")?))
+        })
+        .await
+        .unwrap();
+        assert_ne!(worker, caller);
+        assert!(tasks.is_empty());
+        let error = blocking_task_command::<()>(&state, |_| Err("storage failed".into()))
+            .await
+            .unwrap_err();
+        assert_eq!(error, "storage failed");
+    }
 
     struct FixtureRuntime {
         runs: AtomicUsize,

--- a/src-tauri/src/research_tasks/mod.rs
+++ b/src-tauri/src/research_tasks/mod.rs
@@ -1041,6 +1041,98 @@ mod tests {
         assert_eq!(error, "storage failed");
     }
 
+    #[test]
+    fn async_storage_commands_preserve_task_lifecycle_and_preview_errors() {
+        use tauri::Manager as _;
+
+        let _env = crate::paths::data_dir_env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("OLEAFLY_DATA_DIR", temp.path());
+        let project = crate::paths::create_project_dir("command-paper").unwrap();
+        std::fs::write(project.join("main.tex"), "original source").unwrap();
+        let app = tauri::test::mock_builder()
+            .manage(ResearchTaskState::for_test(temp.path().join("tasks"), 1))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        tauri::async_runtime::block_on(async {
+            let state = || app.state::<ResearchTaskState>();
+            assert!(research_task_list(state(), "../outside".into())
+                .await
+                .is_err());
+            let draft = ResearchTaskDraft {
+                project_id: "command-paper".into(),
+                title: "Review source".into(),
+                prompt: "Check the manuscript".into(),
+                runtime_id: "fixture".into(),
+                agent_id: "fixture-agent".into(),
+                model_id: "fixture-model".into(),
+                skill_ids: Vec::new(),
+                dependency_ids: Vec::new(),
+            };
+            let task = research_task_create(state(), draft.clone()).await.unwrap();
+            assert_eq!(task.status, ResearchTaskStatus::Queued);
+            assert_eq!(
+                research_task_list(state(), draft.project_id.clone())
+                    .await
+                    .unwrap(),
+                vec![task.clone()]
+            );
+            let edited = research_task_edit(
+                state(),
+                task.id.clone(),
+                ResearchTaskEdit {
+                    title: "Revised review".into(),
+                    prompt: draft.prompt,
+                    runtime_id: draft.runtime_id,
+                    agent_id: draft.agent_id,
+                    model_id: draft.model_id,
+                    skill_ids: Vec::new(),
+                    dependency_ids: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+            assert_eq!(edited.title, "Revised review");
+            assert!(research_task_retry(state(), task.id.clone())
+                .await
+                .unwrap_err()
+                .contains("failed or cancelled"));
+            state().store().unwrap().request_cancel(&task.id).unwrap();
+            let retried = research_task_retry(state(), task.id.clone()).await.unwrap();
+            assert_eq!(retried.status, ResearchTaskStatus::Queued);
+            assert_eq!(retried.title, edited.title);
+            let transcript = research_task_events(state(), task.id.clone(), 0, None, None)
+                .await
+                .unwrap();
+            assert!(transcript.events.is_empty());
+            assert_eq!(transcript.next_sequence, None);
+            for path in ["main.tex", "../outside"] {
+                let expected_file =
+                    preview::file_preview(&state().store().unwrap(), &task.id, path).unwrap_err();
+                assert_eq!(
+                    research_task_file_preview(state(), task.id.clone(), path.into())
+                        .await
+                        .unwrap_err(),
+                    expected_file
+                );
+                let expected_artifact =
+                    preview::artifact_preview(&state().store().unwrap(), &task.id, path)
+                        .unwrap_err();
+                assert_eq!(
+                    research_task_artifact_preview(state(), task.id.clone(), path.into())
+                        .await
+                        .unwrap_err(),
+                    expected_artifact
+                );
+            }
+            assert_eq!(
+                std::fs::read_to_string(project.join("main.tex")).unwrap(),
+                "original source"
+            );
+        });
+        std::env::remove_var("OLEAFLY_DATA_DIR");
+    }
+
     struct FixtureRuntime {
         runs: AtomicUsize,
     }

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -269,18 +269,31 @@ pub fn atomic_write(destination: &Path, bytes: &[u8]) -> Result<(), String> {
 pub(crate) fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
     #[cfg(windows)]
     {
-        const RETRY_DELAYS_MS: [u64; 9] = [10, 20, 40, 80, 160, 320, 500, 500, 500];
-        for delay in RETRY_DELAYS_MS {
+        // Indexers and compiler processes can hold a non-delete-sharing read
+        // handle for several seconds. Preserve atomic replacement while giving
+        // those transient locks a bounded chance to clear.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
+        let mut delay = std::time::Duration::from_millis(10);
+        loop {
             match atomicwrites::replace_atomic(source, destination) {
                 Ok(()) => return Ok(()),
-                Err(error) if is_retryable_replace_error_code(error.raw_os_error()) => {
-                    std::thread::sleep(std::time::Duration::from_millis(delay));
+                Err(error)
+                    if is_retryable_replace_error_code(error.raw_os_error())
+                        && std::time::Instant::now() < deadline =>
+                {
+                    std::thread::sleep(
+                        delay.min(deadline.saturating_duration_since(std::time::Instant::now())),
+                    );
+                    delay = (delay * 2).min(std::time::Duration::from_millis(250));
                 }
                 Err(error) => return Err(error),
             }
         }
     }
-    atomicwrites::replace_atomic(source, destination)
+    #[cfg(not(windows))]
+    {
+        atomicwrites::replace_atomic(source, destination)
+    }
 }
 
 #[cfg(any(windows, test))]
@@ -453,6 +466,33 @@ mod tests {
             assert!(!is_retryable_replace_error_code(Some(code)));
         }
         assert!(!is_retryable_replace_error_code(None));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_save_waits_for_a_longer_lived_windows_reader_without_truncating() {
+        use std::fs::OpenOptions;
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("main.tex");
+        std::fs::write(&destination, b"previous complete draft").unwrap();
+        let reader = OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .open(&destination)
+            .unwrap();
+        let observed = destination.clone();
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(3));
+            assert_eq!(std::fs::read(observed).unwrap(), b"previous complete draft");
+            drop(reader);
+        });
+        atomic_write(&destination, b"next complete draft").unwrap();
+        release.join().unwrap();
+        assert_eq!(std::fs::read(destination).unwrap(), b"next complete draft");
+        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -20,14 +20,16 @@ struct SecretLock {
 }
 
 fn lock_file(file: &std::fs::File) -> Result<(), String> {
-    fs4::FileExt::lock(file).map_err(|error| format!("failed to lock secret store: {error}"))
+    oleafly_core::locking::lock_file(file, true, oleafly_core::locking::STORAGE_LOCK_TIMEOUT)
+        .map_err(|error| format!("failed to lock secret store: {error}"))
 }
 
 fn lock_secrets(parent: &Path) -> Result<SecretLock, String> {
-    let guard = SECRET_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let guard = oleafly_core::locking::lock_mutex(
+        SECRET_LOCK.get_or_init(|| Mutex::new(())),
+        oleafly_core::locking::STORAGE_LOCK_TIMEOUT,
+    )
+    .map_err(|error| format!("failed to lock secret store: {error}"))?;
     std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     let path = parent.join(".secret-store.lock");
     let mut options = std::fs::OpenOptions::new();

--- a/src-tauri/src/templates.rs
+++ b/src-tauri/src/templates.rs
@@ -297,21 +297,27 @@ fn list_templates_in_roots(
 }
 
 #[tauri::command]
-pub fn list_templates(app: AppHandle) -> Result<Vec<TemplateInfo>, String> {
-    let roots = template_roots(&app);
+pub async fn list_templates(app: AppHandle) -> Result<Vec<TemplateInfo>, String> {
+    tauri::async_runtime::spawn_blocking(move || list_templates_blocking(&app))
+        .await
+        .map_err(|error| format!("failed to list templates: {error}"))
+}
+
+fn list_templates_blocking(app: &AppHandle) -> Vec<TemplateInfo> {
+    let roots = template_roots(app);
     let mut items = list_templates_in_roots(&roots);
     items.sort_by(|a, b| {
         a.0.order
             .cmp(&b.0.order)
             .then_with(|| a.0.name.cmp(&b.0.name))
     });
-    Ok(items
+    items
         .into_iter()
         .map(|(m, dir, source)| {
             let has_preview = dir.join("preview.png").is_file();
-            to_info(&app, m, has_preview, source)
+            to_info(app, m, has_preview, source)
         })
-        .collect())
+        .collect()
 }
 
 #[derive(serde::Deserialize)]
@@ -422,9 +428,18 @@ pub fn save_custom_template(
 /// The pre-rendered page-1 preview as a `data:` URI, or `None` if absent. Called
 /// lazily per card so the gallery list stays light.
 #[tauri::command]
-pub fn template_preview(app: AppHandle, template_id: String) -> Result<Option<String>, String> {
+pub async fn template_preview(
+    app: AppHandle,
+    template_id: String,
+) -> Result<Option<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || template_preview_blocking(&app, &template_id))
+        .await
+        .map_err(|error| format!("failed to load template preview: {error}"))?
+}
+
+fn template_preview_blocking(app: &AppHandle, template_id: &str) -> Result<Option<String>, String> {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    let dir = template_dir(&app, &template_id)?;
+    let dir = template_dir(app, template_id)?;
     let png = dir.join("preview.png");
     if !png.is_file() {
         return Ok(None);

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -22,7 +22,7 @@ pub(crate) enum TerminalEvent {
 }
 
 struct TermSession {
-    master: Box<dyn MasterPty + Send>,
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     writer: TerminalWriter,
     child: Arc<Mutex<Box<dyn portable_pty::Child + Send + Sync>>>,
     _containment: crate::proc::ProcessTreeGuard,
@@ -194,17 +194,26 @@ struct OwnedSession<T> {
 
 struct SessionRegistry<T> {
     sessions: HashMap<String, OwnedSession<T>>,
+    window_generations: HashMap<String, u64>,
 }
 
 impl<T> Default for SessionRegistry<T> {
     fn default() -> Self {
         Self {
             sessions: HashMap::new(),
+            window_generations: HashMap::new(),
         }
     }
 }
 
 impl<T> SessionRegistry<T> {
+    fn generation(&mut self, window_label: &str) -> u64 {
+        *self
+            .window_generations
+            .entry(window_label.to_string())
+            .or_default()
+    }
+
     fn insert(&mut self, owner: SessionOwner, session: T) -> String {
         let mut id = random_session_id();
         while self.sessions.contains_key(&id) {
@@ -241,6 +250,11 @@ impl<T> SessionRegistry<T> {
     }
 
     fn drain_window(&mut self, window_label: &str) -> Vec<T> {
+        let generation = self
+            .window_generations
+            .entry(window_label.to_string())
+            .or_default();
+        *generation = generation.wrapping_add(1);
         let ids: Vec<String> = self
             .sessions
             .iter()
@@ -253,6 +267,9 @@ impl<T> SessionRegistry<T> {
     }
 
     fn drain_all(&mut self) -> Vec<T> {
+        for generation in self.window_generations.values_mut() {
+            *generation = generation.wrapping_add(1);
+        }
         self.sessions
             .drain()
             .map(|(_, record)| record.session)
@@ -424,16 +441,43 @@ pub async fn term_open<R: Runtime>(
 ) -> Result<String, String> {
     let owner = webview_command_owner(&webview, &project_id)?;
     let cwd = crate::paths::project_dir(&project_id)?;
+    let ticket = terminal_open_ticket(owner);
     tauri::async_runtime::spawn_blocking(move || {
-        open_terminal(&cwd, owner, cols, rows, channel, default_shell())
+        open_terminal_with_ticket(&cwd, ticket, cols, rows, channel, default_shell())
     })
     .await
     .map_err(|e| format!("failed to start shell: {e}"))?
 }
 
+struct TerminalOpenTicket {
+    owner: SessionOwner,
+    generation: u64,
+}
+
+fn terminal_open_ticket(owner: SessionOwner) -> TerminalOpenTicket {
+    let generation = SESSIONS
+        .lock()
+        .expect("terminal registry poisoned")
+        .get_or_insert_with(SessionRegistry::default)
+        .generation(&owner.window_label);
+    TerminalOpenTicket { owner, generation }
+}
+
+#[cfg(test)]
 fn open_terminal(
     cwd: &Path,
     owner: SessionOwner,
+    cols: u16,
+    rows: u16,
+    channel: Channel<TerminalEvent>,
+    cmd: CommandBuilder,
+) -> Result<String, String> {
+    open_terminal_with_ticket(cwd, terminal_open_ticket(owner), cols, rows, channel, cmd)
+}
+
+fn open_terminal_with_ticket(
+    cwd: &Path,
+    ticket: TerminalOpenTicket,
     cols: u16,
     rows: u16,
     channel: Channel<TerminalEvent>,
@@ -511,19 +555,22 @@ fn open_terminal(
     let writer = TerminalWriter::start(writer, Some(channel.clone()))?;
 
     let child = Arc::new(Mutex::new(child));
+    let session = TermSession {
+        master: Arc::new(Mutex::new(pty.master)),
+        writer,
+        child: Arc::clone(&child),
+        _containment: containment,
+    };
     let id = {
         let mut sessions = SESSIONS.lock().expect("terminal registry poisoned");
-        sessions
-            .get_or_insert_with(SessionRegistry::default)
-            .insert(
-                owner,
-                TermSession {
-                    master: pty.master,
-                    writer,
-                    child: Arc::clone(&child),
-                    _containment: containment,
-                },
-            )
+        let registry = sessions.get_or_insert_with(SessionRegistry::default);
+        if registry.generation(&ticket.owner.window_label) != ticket.generation {
+            drop(sessions);
+            drop(reader);
+            stop_session(session);
+            return Err("terminal window was reloaded while the shell was starting".into());
+        }
+        registry.insert(ticket.owner, session)
     };
     println!(
         "term: session {id} opened pty={:.1}ms spawn={:.1}ms contain={:.1}ms",
@@ -658,7 +705,7 @@ fn write_terminal(owner: &SessionOwner, id: &str, data: &str) -> Result<WriteRec
 }
 
 #[tauri::command]
-pub fn term_resize<R: Runtime>(
+pub async fn term_resize<R: Runtime>(
     webview: Webview<R>,
     project_id: String,
     id: String,
@@ -666,17 +713,28 @@ pub fn term_resize<R: Runtime>(
     rows: u16,
 ) -> Result<(), String> {
     let owner = webview_command_owner(&webview, &project_id)?;
-    resize_terminal(&owner, &id, cols, rows)
+    tauri::async_runtime::spawn_blocking(move || resize_terminal(&owner, &id, cols, rows))
+        .await
+        .map_err(|error| format!("failed to resize terminal: {error}"))?
 }
 
 fn resize_terminal(owner: &SessionOwner, id: &str, cols: u16, rows: u16) -> Result<(), String> {
-    let sessions = SESSIONS.lock().expect("terminal registry poisoned");
-    let session = sessions
-        .as_ref()
-        .ok_or_else(|| "terminal session is not open".to_string())?
-        .get(id, owner)?;
-    session
-        .master
+    // ResizePseudoConsole can wait on ConPTY. Never keep the global registry
+    // locked while resizing, or even input/close for other terminals stalls.
+    let master = {
+        let sessions = SESSIONS.lock().expect("terminal registry poisoned");
+        Arc::clone(
+            &sessions
+                .as_ref()
+                .ok_or_else(|| "terminal session is not open".to_string())?
+                .get(id, owner)?
+                .master,
+        )
+    };
+    let master = master
+        .lock()
+        .map_err(|_| "terminal resize is unavailable")?;
+    master
         .resize(PtySize {
             rows,
             cols,
@@ -711,6 +769,69 @@ fn kill_terminal(owner: &SessionOwner, id: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn reload_rejects_an_in_flight_terminal_open() {
+        let directory = tempfile::tempdir().unwrap();
+        let owner = SessionOwner::new("audit-stale-open", "proj");
+        let ticket = terminal_open_ticket(owner.clone());
+        kill_window_sessions(&owner.window_label);
+        let result = open_terminal_with_ticket(
+            directory.path(),
+            ticket,
+            80,
+            24,
+            Channel::new(|_| Ok(())),
+            nonreading_terminal_fixture(),
+        );
+        assert!(result.unwrap_err().contains("reloaded"));
+        let sessions = SESSIONS.lock().unwrap();
+        assert!(!sessions
+            .as_ref()
+            .unwrap()
+            .sessions
+            .values()
+            .any(|record| record.owner == owner));
+    }
+
+    #[test]
+    fn slow_resize_does_not_hold_the_global_session_registry() {
+        let directory = tempfile::tempdir().unwrap();
+        let owner = SessionOwner::new("audit-resize-lock", "proj");
+        let id = open_terminal(
+            directory.path(),
+            owner.clone(),
+            80,
+            24,
+            Channel::new(|_| Ok(())),
+            nonreading_terminal_fixture(),
+        )
+        .unwrap();
+        let master = {
+            let sessions = SESSIONS.lock().unwrap();
+            Arc::clone(&sessions.as_ref().unwrap().get(&id, &owner).unwrap().master)
+        };
+        let locked = master.lock().unwrap();
+        let resize_owner = owner.clone();
+        let resize_id = id.clone();
+        let (started, ready) = std::sync::mpsc::channel();
+        let resize = std::thread::spawn(move || {
+            started.send(()).unwrap();
+            resize_terminal(&resize_owner, &resize_id, 100, 30)
+        });
+        ready
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let registry_available = SESSIONS.try_lock().is_ok();
+        drop(locked);
+        resize.join().unwrap().unwrap();
+        kill_terminal(&owner, &id).unwrap();
+        assert!(
+            registry_available,
+            "resize blocked input/close for every terminal"
+        );
+    }
+
     #[tokio::test]
     async fn oversized_pastes_are_rejected_whole_and_leave_the_terminal_usable() {
         let writer = TerminalWriter::start(Box::new(std::io::sink()), None).unwrap();

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -731,9 +731,11 @@ fn resize_terminal(owner: &SessionOwner, id: &str, cols: u16, rows: u16) -> Resu
                 .master,
         )
     };
+    // Recover a poisoned master the way storage locks do. A panic in one
+    // resize must not make every later resize of that terminal fail.
     let master = master
         .lock()
-        .map_err(|_| "terminal resize is unavailable")?;
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     master
         .resize(PtySize {
             rows,

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -33,6 +33,9 @@ const MAX_PENDING_INPUT_WRITES: usize = 256;
 
 type WriteReceipt = tokio::sync::oneshot::Receiver<Result<(), String>>;
 
+/// The pair of handles a session reads from and writes to.
+type TerminalStreams = (Box<dyn Read + Send>, Box<dyn Write + Send>);
+
 struct PendingWrite {
     bytes: Vec<u8>,
     completion: tokio::sync::oneshot::Sender<Result<(), String>>,
@@ -515,43 +518,7 @@ fn open_terminal_with_ticket(
     let contained = started.elapsed();
     drop(pty.slave);
 
-    #[cfg(unix)]
-    let (mut reader, writer): (Box<dyn Read + Send>, Box<dyn Write + Send>) = {
-        use std::os::fd::{AsRawFd, BorrowedFd};
-        let fd = pty
-            .master
-            .as_raw_fd()
-            .ok_or("terminal input is unavailable")?;
-        let fd = unsafe { BorrowedFd::borrow_raw(fd) }
-            .try_clone_to_owned()
-            .map_err(|error| format!("failed to open terminal input: {error}"))?;
-        let flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFL) };
-        if flags < 0
-            || unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
-        {
-            return Err(format!(
-                "failed to configure terminal input: {}",
-                std::io::Error::last_os_error()
-            ));
-        }
-        let reader = fd
-            .try_clone()
-            .map_err(|error| format!("failed to open terminal output: {error}"))?;
-        (
-            Box::new(TerminalReader(std::fs::File::from(reader))),
-            Box::new(std::fs::File::from(fd)),
-        )
-    };
-    #[cfg(not(unix))]
-    let mut reader = pty
-        .master
-        .try_clone_reader()
-        .map_err(|e| format!("failed to read pty: {e}"))?;
-    #[cfg(not(unix))]
-    let writer = pty
-        .master
-        .take_writer()
-        .map_err(|error| format!("failed to write pty: {error}"))?;
+    let (reader, writer) = terminal_streams(&*pty.master)?;
     let writer = TerminalWriter::start(writer, Some(channel.clone()))?;
 
     let child = Arc::new(Mutex::new(child));
@@ -579,12 +546,61 @@ fn open_terminal_with_ticket(
         (contained - spawned).as_secs_f64() * 1000.0
     );
 
-    // ConPTY keeps the reader blocked until the pseudo console closes, so a
-    // shell that exits on its own never EOFs the reader on Windows. Poll for
-    // the exit and drop the session; closing the master unblocks the reader,
-    // which then delivers the exit event. The poller ends when the session is
-    // torn down elsewhere and its registry clone of the child goes away.
-    let poll_id = id.clone();
+    spawn_exit_poller(id.clone(), child);
+    spawn_output_reader(id.clone(), reader, channel);
+
+    Ok(id)
+}
+
+/// Open the pair of handles the session reads from and writes to. Unix needs a
+/// non-blocking duplicate of the master descriptor; Windows takes the reader
+/// and writer the pty exposes.
+fn terminal_streams(master: &(dyn MasterPty + Send)) -> Result<TerminalStreams, String> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::{AsRawFd, BorrowedFd};
+        let fd = master.as_raw_fd().ok_or("terminal input is unavailable")?;
+        let fd = unsafe { BorrowedFd::borrow_raw(fd) }
+            .try_clone_to_owned()
+            .map_err(|error| format!("failed to open terminal input: {error}"))?;
+        let flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFL) };
+        if flags < 0
+            || unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+        {
+            return Err(format!(
+                "failed to configure terminal input: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let reader = fd
+            .try_clone()
+            .map_err(|error| format!("failed to open terminal output: {error}"))?;
+        Ok((
+            Box::new(TerminalReader(std::fs::File::from(reader))),
+            Box::new(std::fs::File::from(fd)),
+        ))
+    }
+    #[cfg(not(unix))]
+    {
+        let reader = master
+            .try_clone_reader()
+            .map_err(|e| format!("failed to read pty: {e}"))?;
+        let writer = master
+            .take_writer()
+            .map_err(|error| format!("failed to write pty: {error}"))?;
+        Ok((reader, writer))
+    }
+}
+
+/// ConPTY keeps the reader blocked until the pseudo console closes, so a shell
+/// that exits on its own never EOFs the reader on Windows. Poll for the exit
+/// and drop the session; closing the master unblocks the reader, which then
+/// delivers the exit event. The poller ends when the session is torn down
+/// elsewhere and its registry clone of the child goes away.
+fn spawn_exit_poller(
+    poll_id: String,
+    child: Arc<Mutex<Box<dyn portable_pty::Child + Send + Sync>>>,
+) {
     std::thread::spawn(move || loop {
         std::thread::sleep(std::time::Duration::from_millis(250));
         if Arc::strong_count(&child) == 1 {
@@ -610,8 +626,13 @@ fn open_terminal_with_ticket(
         }
         break;
     });
+}
 
-    let session_id = id.clone();
+fn spawn_output_reader(
+    session_id: String,
+    mut reader: Box<dyn Read + Send>,
+    channel: Channel<TerminalEvent>,
+) {
     std::thread::spawn(move || {
         let mut buffer = [0u8; 8192];
         let mut pending: Vec<u8> = Vec::new();
@@ -663,8 +684,6 @@ fn open_terminal_with_ticket(
             println!("term: session {session_id} exit event delivered={delivered}");
         }
     });
-
-    Ok(id)
 }
 
 fn stop_session(session: TermSession) {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -615,17 +615,52 @@ fn spawn_exit_poller(
             continue;
         }
         println!("term: session {poll_id} shell exited");
-        let session = {
-            let mut sessions = SESSIONS.lock().expect("terminal registry poisoned");
-            sessions
-                .as_mut()
-                .and_then(|registry| registry.remove_unchecked(&poll_id))
-        };
-        if let Some(session) = session {
+        if let Some(session) = take_session(&poll_id) {
             stop_session(session);
         }
         break;
     });
+}
+
+/// Remove a session from the registry by id. The reader and the exit poller
+/// race to tear the same session down, so whichever arrives second gets None.
+fn take_session(session_id: &str) -> Option<TermSession> {
+    let mut sessions = SESSIONS.lock().expect("terminal registry poisoned");
+    sessions
+        .as_mut()
+        .and_then(|registry| registry.remove_unchecked(session_id))
+}
+
+/// Forward shell output until the pty closes. Returns whether the channel still
+/// accepts events, and any bytes left after the last complete character.
+fn stream_terminal_output(
+    session_id: &str,
+    reader: &mut dyn Read,
+    channel: &Channel<TerminalEvent>,
+) -> (bool, Vec<u8>) {
+    let mut buffer = [0u8; 8192];
+    let mut pending: Vec<u8> = Vec::new();
+    let mut channel_open = true;
+    while let Ok(count) = reader.read(&mut buffer) {
+        if count == 0 {
+            break;
+        }
+        if !channel_open {
+            continue;
+        }
+        pending.extend_from_slice(&buffer[..count]);
+        let data = drain_utf8_lossy(&mut pending);
+        if data.is_empty() {
+            continue;
+        }
+        if channel.send(TerminalEvent::Output { data }).is_ok() {
+            continue;
+        }
+        channel_open = false;
+        pending.clear();
+        stop_sessions_in_background(take_session(session_id).into_iter().collect());
+    }
+    (channel_open, pending)
 }
 
 fn spawn_output_reader(
@@ -634,49 +669,14 @@ fn spawn_output_reader(
     channel: Channel<TerminalEvent>,
 ) {
     std::thread::spawn(move || {
-        let mut buffer = [0u8; 8192];
-        let mut pending: Vec<u8> = Vec::new();
-        let mut channel_open = true;
-        loop {
-            match reader.read(&mut buffer) {
-                Ok(0) | Err(_) => break,
-                Ok(n) => {
-                    if !channel_open {
-                        continue;
-                    }
-                    pending.extend_from_slice(&buffer[..n]);
-                    let data = drain_utf8_lossy(&mut pending);
-                    if data.is_empty() {
-                        continue;
-                    }
-                    if channel.send(TerminalEvent::Output { data }).is_err() {
-                        channel_open = false;
-                        pending.clear();
-                        let session = {
-                            let mut sessions = SESSIONS.lock().expect("terminal registry poisoned");
-                            sessions
-                                .as_mut()
-                                .and_then(|registry| registry.remove_unchecked(&session_id))
-                        };
-                        stop_sessions_in_background(session.into_iter().collect());
-                    }
-                }
-            }
-        }
+        let (mut channel_open, pending) =
+            stream_terminal_output(&session_id, reader.as_mut(), &channel);
         println!("term: session {session_id} reader eof (channel_open={channel_open})");
         if channel_open && !pending.is_empty() {
             let data = String::from_utf8_lossy(&pending).to_string();
-            if channel.send(TerminalEvent::Output { data }).is_err() {
-                channel_open = false;
-            }
+            channel_open = channel.send(TerminalEvent::Output { data }).is_ok();
         }
-        let session = {
-            let mut sessions = SESSIONS.lock().expect("terminal registry poisoned");
-            sessions
-                .as_mut()
-                .and_then(|registry| registry.remove_unchecked(&session_id))
-        };
-        if let Some(session) = session {
+        if let Some(session) = take_session(&session_id) {
             stop_session(session);
         }
         if channel_open {

--- a/src-tauri/src/worktree_lock.rs
+++ b/src-tauri/src/worktree_lock.rs
@@ -73,9 +73,9 @@ impl ProjectWorktreeLock {
         Ok(lock)
     }
 
-    /// Acquire the read lock, but give up instead of waiting forever. Project
-    /// enumeration runs on every visit to the library and must never be able
-    /// to park its caller: one holder of the write lock would otherwise stall
+    /// Acquire the read lock under the caller's own budget, which is far
+    /// shorter than the storage default. Project enumeration runs on every
+    /// visit to the library, so one holder of the write lock must not stall
     /// the whole listing, and every action that triggers one after it.
     pub(crate) fn shared_bounded(project_id: &str, budget: Duration) -> Result<Self, String> {
         let file = open_lock_file(project_id)?;
@@ -104,8 +104,9 @@ impl ProjectWorktreeLock {
     }
 
     /// Take the write lock only when it is free. Background maintenance that
-    /// can safely run later must never queue readers behind itself: the file
-    /// lock has no timeout, so one slow holder stalls every project listing.
+    /// can safely run later must never queue readers behind itself: waiting
+    /// callers spend the full storage budget before failing, so one slow
+    /// holder stalls every project listing for that long.
     pub(crate) fn try_exclusive(project_id: &str) -> Result<Option<Self>, String> {
         let file = open_lock_file(project_id)?;
         match fs4::FileExt::try_lock(&file) {

--- a/src-tauri/src/worktree_lock.rs
+++ b/src-tauri/src/worktree_lock.rs
@@ -4,6 +4,7 @@
 //! tree. Restores can therefore replace portable project files while readers
 //! and writers continue to coordinate on one stable inode.
 
+use oleafly_core::locking::{lock_file, STORAGE_LOCK_TIMEOUT};
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -34,7 +35,7 @@ impl ProjectWorktreeLock {
         {
             let _waiting =
                 crate::stall_trace::watch(|| format!("worktree shared wait on {project_id}"));
-            fs4::FileExt::lock_shared(&file)
+            lock_file(&file, false, STORAGE_LOCK_TIMEOUT)
                 .map_err(|error| format!("could not acquire project read lock: {error}"))?;
         }
         let _held = held(project_id, "shared");
@@ -63,7 +64,7 @@ impl ProjectWorktreeLock {
         {
             let _waiting =
                 crate::stall_trace::watch(|| format!("worktree exclusive wait on {project_id}"));
-            fs4::FileExt::lock(&file)
+            lock_file(&file, true, STORAGE_LOCK_TIMEOUT)
                 .map_err(|error| format!("could not acquire project write lock: {error}"))?;
         }
         let _held = held(project_id, "exclusive");
@@ -128,7 +129,7 @@ impl ProjectWorktreeLock {
         {
             let _waiting =
                 crate::stall_trace::watch(|| format!("worktree identity wait on {project_id}"));
-            fs4::FileExt::lock(&file)
+            lock_file(&file, true, STORAGE_LOCK_TIMEOUT)
                 .map_err(|error| format!("could not acquire project identity lock: {error}"))?;
         }
         let _held = held(project_id, "identity");
@@ -143,7 +144,7 @@ impl ProjectWorktreeLock {
         {
             let _waiting =
                 crate::stall_trace::watch(|| format!("worktree recovery wait on {project_id}"));
-            fs4::FileExt::lock(&file)
+            lock_file(&file, true, STORAGE_LOCK_TIMEOUT)
                 .map_err(|error| format!("could not acquire project recovery lock: {error}"))?;
         }
         let _held = held(project_id, "recovery");

--- a/src/App.docks.test.tsx
+++ b/src/App.docks.test.tsx
@@ -239,7 +239,7 @@ describe("project dock layout", () => {
   let dom: JSDOM;
   let root: import("react-dom/client").Root | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
       url: "https://oleafly.test",
     });
@@ -263,6 +263,8 @@ describe("project dock layout", () => {
       return 1;
     };
     window.cancelAnimationFrame = vi.fn();
+    // Account for cold module loading in setup, outside the interaction budget.
+    await import("./App");
   });
 
   beforeEach(async () => {

--- a/src/components/ai/ChatCore.agent-loop.test.tsx
+++ b/src/components/ai/ChatCore.agent-loop.test.tsx
@@ -496,6 +496,8 @@ beforeAll(async () => {
   ({ useAiToolSettingsStore } = await import("@/store/ai-tool-settings"));
   ({ useAssistantRuntimeStore } = await import("@/store/assistant-runtime"));
   ({ activeChatRun, endChatRun } = await import("./chat-run-registry"));
+  // Load the lazy dialog before timing interactions with its trigger.
+  await import("@/components/usage/UsageReport");
 });
 
 afterEach(() => cleanup());

--- a/src/components/ai/chat-parts.test.tsx
+++ b/src/components/ai/chat-parts.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, fireEvent, getByRole, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearExpansionState } from "./activity/expansion-state";
 import { ResearchToolCard } from "./activity/ResearchToolCard";
 import { useFilesStore } from "@/store/files";
@@ -30,6 +30,11 @@ import {
   ToolPicture,
   freeFigurePath,
 } from "./chat-parts";
+
+beforeAll(async () => {
+  // Keep cold loading of the lazy renderer outside interaction deadlines.
+  await import("@/components/ui/markdown-renderer");
+});
 
 describe("ToolPicture", () => {
   const png = "data:image/png;base64,iVBORw0KGgo=";
@@ -1309,7 +1314,11 @@ describe("MessageItem footer", () => {
       const copyButton = getByRole("button", { name: "Copy message" });
       const footer = time?.parentElement;
 
-      expect(time).toHaveTextContent("5:41 PM");
+      expect(time).toHaveTextContent(new Date(createdAt).toLocaleTimeString([], {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      }));
       expect(copyButton.parentElement).toBe(footer);
       expect(footer?.previousElementSibling).toHaveTextContent("Timestamped message");
     },

--- a/src/components/ai/chat-theme-switch.test.tsx
+++ b/src/components/ai/chat-theme-switch.test.tsx
@@ -2,7 +2,7 @@
 
 import { Profiler, type ProfilerOnRenderCallback } from "react";
 import { act, render, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyTheme, ThemeProvider } from "@/lib/theme";
 import { clearDiagramCache } from "@/components/ui/mermaid-diagram";
 import {
@@ -50,6 +50,10 @@ async function settle(ms = 80) {
 
 describe("theme switch with a rendered chat", () => {
   let intersection: IntersectionObserverStub;
+
+  beforeAll(async () => {
+    await import("@/components/ui/markdown-renderer");
+  });
 
   beforeEach(() => {
     window.localStorage.setItem("oleafly.theme", "dark");

--- a/src/components/dock/TerminalPane.tsx
+++ b/src/components/dock/TerminalPane.tsx
@@ -8,6 +8,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { Loader2 } from "lucide-react";
 import { E2E_HOOKS } from "@/lib/e2e-flags";
 import { useAppTheme } from "@/lib/theme";
+import { createTerminalResizer } from "@/lib/terminal-resize";
 import {
   resolveTerminalTheme,
   useSettingsStore,
@@ -113,6 +114,7 @@ export function TerminalPane({
   const hiddenOutputLengthRef = useRef(0);
   const sessionIdRef = useRef<string | null>(null);
   const sessionLiveRef = useRef(false);
+  const resizerRef = useRef<ReturnType<typeof createTerminalResizer> | null>(null);
   const surfacedErrorsRef = useRef(new Set<string>());
   const outputWrittenRef = useRef<(() => void) | undefined>(undefined);
   const visibleRef = useRef(visible);
@@ -216,6 +218,7 @@ export function TerminalPane({
     let sessionLive = false;
     let sessionExited = false;
     let disposed = false;
+    let resizer: ReturnType<typeof createTerminalResizer> | null = null;
     const pendingInput: string[] = [];
     const writeInput = (id: string, data: string) => {
       void invoke("term_write", { id, projectId, data }).catch((error) => {
@@ -267,6 +270,8 @@ export function TerminalPane({
         return;
       }
       sessionExited = true;
+      resizer?.dispose();
+      resizerRef.current = null;
       sessionLive = false;
       sessionLiveRef.current = false;
       sessionId = null;
@@ -294,25 +299,20 @@ export function TerminalPane({
         sessionIdRef.current = id;
         sessionLive = true;
         sessionLiveRef.current = true;
+        resizer = createTerminalResizer(
+          (cols, rows) => invoke("term_resize", { id, projectId, cols, rows }),
+          (error) => {
+            if (!disposed && sessionLive) {
+              writeTerminalErrorOnce(terminal, surfacedErrorsRef.current,
+                "The terminal could not resize", error, outputWritten);
+            }
+          },
+        );
+        resizerRef.current = resizer;
         for (const data of pendingInput.splice(0)) writeInput(id, data);
         setBooted(true);
         if (visibleRef.current || terminal.cols !== openedCols || terminal.rows !== openedRows) {
-          void invoke("term_resize", {
-            id,
-            projectId,
-            cols: terminal.cols,
-            rows: terminal.rows,
-          }).catch((error) => {
-            if (!disposed && sessionLive) {
-              writeTerminalErrorOnce(
-                terminal,
-                surfacedErrorsRef.current,
-                "The terminal could not resize",
-                error,
-                outputWritten,
-              );
-            }
-          });
+          resizer.request(terminal.cols, terminal.rows);
         }
         if (visibleRef.current) terminal.focus();
       })
@@ -336,28 +336,15 @@ export function TerminalPane({
       if (!visibleRef.current || !openedRef.current) return;
       fit.fit();
       if (sessionLive && sessionId) {
-        void invoke("term_resize", {
-          id: sessionId,
-          projectId,
-          cols: terminal.cols,
-          rows: terminal.rows,
-        }).catch((error) => {
-          if (!disposed && sessionLive) {
-            writeTerminalErrorOnce(
-              terminal,
-              surfacedErrorsRef.current,
-              "The terminal could not resize",
-              error,
-              outputWritten,
-            );
-          }
-        });
+        resizer?.request(terminal.cols, terminal.rows);
       }
     });
     observer.observe(host);
 
     return () => {
       disposed = true;
+      resizer?.dispose();
+      if (resizerRef.current === resizer) resizerRef.current = null;
       if (openTimer !== null) {
         window.clearTimeout(openTimer);
         openTimer = null;
@@ -397,30 +384,10 @@ export function TerminalPane({
     fitRef.current?.fit();
     const id = sessionIdRef.current;
     if (id && sessionLiveRef.current) {
-      void invoke("term_resize", {
-        id,
-        projectId,
-        cols: terminal.cols,
-        rows: terminal.rows,
-      }).catch((error) => {
-        if (
-          sessionLiveRef.current &&
-          sessionIdRef.current === id &&
-          terminalRef.current === terminal
-        ) {
-          writeTerminalErrorOnce(
-            terminal,
-            surfacedErrorsRef.current,
-            "The terminal could not resize",
-            error,
-            outputWrittenRef.current,
-          );
-        }
-      });
+      resizerRef.current?.request(terminal.cols, terminal.rows);
     }
   }, [
     appTheme,
-    projectId,
     terminalBackground,
     terminalColorTheme,
     terminalCursorBlink,
@@ -463,30 +430,11 @@ export function TerminalPane({
       terminal?.focus();
       const id = sessionIdRef.current;
       if (terminal && id && sessionLiveRef.current) {
-        void invoke("term_resize", {
-          id,
-          projectId,
-          cols: terminal.cols,
-          rows: terminal.rows,
-        }).catch((error) => {
-          if (
-            sessionLiveRef.current &&
-            sessionIdRef.current === id &&
-            terminalRef.current === terminal
-          ) {
-            writeTerminalErrorOnce(
-              terminal,
-              surfacedErrorsRef.current,
-              "The terminal could not resize",
-              error,
-              outputWrittenRef.current,
-            );
-          }
-        });
+        resizerRef.current?.request(terminal.cols, terminal.rows);
       }
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [projectId, visible]);
+  }, [visible]);
 
   const paneBackground = resolveTerminalTheme(
     { terminalColorTheme, terminalBackground, terminalForeground, terminalCursorColor },

--- a/src/components/editor/diff/DiffView.test.tsx
+++ b/src/components/editor/diff/DiffView.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useDiffStore } from "@/store/diff";
+import { DiffView } from "./DiffView";
+
+const mocks = vi.hoisted(() => ({ gitShow: vi.fn() }));
+const source = "Original line\nAdded line\n";
+const files = {
+  projectId: "diff-project",
+  files: { "main.tex": { content: source } },
+  setContent: vi.fn(),
+};
+
+vi.mock("@/store/files", () => ({
+  useFilesStore: Object.assign(
+    (selector: (state: typeof files) => unknown) => selector(files),
+    { getState: () => files },
+  ),
+}));
+vi.mock("@/lib/tauri", () => ({ gitShow: mocks.gitShow, readFileContent: vi.fn() }));
+vi.mock("../cm/theme", () => ({ editorTheme: () => [] }));
+vi.mock("../cm/languages", () => ({ languageForPath: () => null }));
+
+beforeEach(() => {
+  mocks.gitShow.mockReset();
+  useDiffStore.setState({ diffs: [], activeKey: null, mode: "split" });
+});
+afterEach(cleanup);
+
+function sideText(side: "a" | "b") {
+  const content = document.querySelector(`.cm-merge-${side} .cm-content`);
+  return content ? EditorView.findFromDOM(content as HTMLElement)?.state.doc.toString() : undefined;
+}
+
+it("reloads a working diff after staging and unstaging with a fast Git backend", async () => {
+  let index = "Original line\n";
+  mocks.gitShow.mockImplementation(async () => index);
+  useDiffStore.getState().openDiff("main.tex", "working");
+  render(<DiffView />);
+  await waitFor(() => expect(sideText("a")).toBe(index));
+  expect(sideText("b")).toBe(source);
+
+  index = source;
+  act(() => window.dispatchEvent(new CustomEvent("oleafly:git-changed")));
+  await waitFor(() => expect(sideText("a")).toBe(source));
+  expect(sideText("b")).toBe(source);
+  expect(document.querySelector(".cm-changedLine, .cm-changedText")).toBeNull();
+
+  index = "Original line\n";
+  act(() => window.dispatchEvent(new CustomEvent("oleafly:git-changed")));
+  await waitFor(() => expect(sideText("a")).toBe(index));
+  expect(sideText("b")).toBe(source);
+});

--- a/src/components/editor/diff/DiffView.test.tsx
+++ b/src/components/editor/diff/DiffView.test.tsx
@@ -30,6 +30,13 @@ beforeEach(() => {
 });
 afterEach(cleanup);
 
+function editableView(): EditorView {
+  const content = document.querySelector(".cm-merge-b .cm-content");
+  const view = content ? EditorView.findFromDOM(content as HTMLElement) : null;
+  if (!view) throw new Error("the editable side of the diff is not mounted");
+  return view;
+}
+
 function sideText(side: "a" | "b") {
   const content = document.querySelector(`.cm-merge-${side} .cm-content`);
   return content ? EditorView.findFromDOM(content as HTMLElement)?.state.doc.toString() : undefined;
@@ -53,4 +60,22 @@ it("reloads a working diff after staging and unstaging with a fast Git backend",
   act(() => window.dispatchEvent(new CustomEvent("oleafly:git-changed")));
   await waitFor(() => expect(sideText("a")).toBe(index));
   expect(sideText("b")).toBe(source);
+});
+
+it("keeps the editable working view when a git change leaves the baseline alone", async () => {
+  mocks.gitShow.mockImplementation(async () => "Original line\n");
+  useDiffStore.getState().openDiff("main.tex", "working");
+  render(<DiffView />);
+  await waitFor(() => expect(sideText("a")).toBe("Original line\n"));
+
+  const editable = editableView();
+  editable.dispatch({ selection: { anchor: 5 } });
+  const calls = mocks.gitShow.mock.calls.length;
+
+  act(() => window.dispatchEvent(new CustomEvent("oleafly:git-changed")));
+  await waitFor(() => expect(mocks.gitShow.mock.calls.length).toBeGreaterThan(calls));
+  await act(() => Promise.resolve());
+
+  expect(editableView()).toBe(editable);
+  expect(editable.state.selection.main.anchor).toBe(5);
 });

--- a/src/components/editor/diff/DiffView.tsx
+++ b/src/components/editor/diff/DiffView.tsx
@@ -45,12 +45,32 @@ export function DiffView() {
   const [notice, setNotice] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [reloadKey, setReloadKey] = useState(0);
+  const baselineRef = useRef<string | null>(null);
 
   // Both views depend on INDEX. Working edits update live, but staging,
-  // unstaging, and committing also change the comparison baseline.
+  // unstaging, and committing also change the comparison baseline. A working
+  // diff is editable, so rebuild it only when that baseline really moved: an
+  // unrelated git change must not discard the caret, scroll, and undo history
+  // of someone typing in it.
   useEffect(() => {
     const onChanged = () => {
-      if (activeDiff(useDiffStore.getState())) setReloadKey((k) => k + 1);
+      const current = activeDiff(useDiffStore.getState());
+      if (!current) return;
+      if (current.side === "staged") {
+        setReloadKey((k) => k + 1);
+        return;
+      }
+      const activeProject = useFilesStore.getState().projectId;
+      if (!activeProject) return;
+      const baseline = baselineRef.current;
+      void gitShow(activeProject, diffSides(current.side).oldRev, current.path)
+        .then((next) => {
+          const still = activeDiff(useDiffStore.getState());
+          if (still?.path !== current.path || still.side !== current.side) return;
+          if (baselineRef.current !== baseline || next === baseline) return;
+          setReloadKey((k) => k + 1);
+        })
+        .catch(() => setReloadKey((k) => k + 1));
     };
     window.addEventListener("oleafly:git-changed", onChanged);
     return () => window.removeEventListener("oleafly:git-changed", onChanged);
@@ -66,6 +86,7 @@ export function DiffView() {
     setLoading(true);
     setError(null);
     setNotice(null);
+    baselineRef.current = null;
     const { oldRev, newRev, editable } = diffSides(side);
 
     let synchronizing = false;
@@ -114,6 +135,7 @@ export function DiffView() {
     const build = async () => {
       try {
         const oldText = await gitShow(projectId, oldRev, path);
+        baselineRef.current = oldText;
         const newText =
           newRev === "WORKTREE"
             ? useFilesStore.getState().files[path]?.content ?? await readFileContent(projectId, path).catch(() => "")

--- a/src/components/editor/diff/DiffView.tsx
+++ b/src/components/editor/diff/DiffView.tsx
@@ -46,10 +46,11 @@ export function DiffView() {
   const [loading, setLoading] = useState(true);
   const [reloadKey, setReloadKey] = useState(0);
 
-  // Rebuild only the staged diff on git changes; working diffs already update live.
+  // Both views depend on INDEX. Working edits update live, but staging,
+  // unstaging, and committing also change the comparison baseline.
   useEffect(() => {
     const onChanged = () => {
-      if (activeDiff(useDiffStore.getState())?.side === "staged") setReloadKey((k) => k + 1);
+      if (activeDiff(useDiffStore.getState())) setReloadKey((k) => k + 1);
     };
     window.addEventListener("oleafly:git-changed", onChanged);
     return () => window.removeEventListener("oleafly:git-changed", onChanged);

--- a/src/components/layout/SourceControl.test.tsx
+++ b/src/components/layout/SourceControl.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "@/store/settings";
@@ -148,6 +148,39 @@ function withRepository(changes = MIXED_CHANGES) {
 }
 
 describe("SourceControl", () => {
+  it("coalesces repeated refreshes while Git is slow and fetches one final snapshot", async () => {
+    withRepository();
+    render(<SourceControl />);
+    await screen.findByTestId("git-change-src/main.tex");
+    const slowStatus = deferred<typeof MIXED_CHANGES>();
+    mocks.gitStatus.mockImplementationOnce(() => slowStatus.promise);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(mocks.gitStatus).toHaveBeenCalledTimes(2));
+    for (let index = 0; index < 20; index++) {
+      fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    }
+    expect(mocks.gitStatus).toHaveBeenCalledTimes(2);
+    await act(async () => slowStatus.resolve(MIXED_CHANGES));
+    await waitFor(() => expect(mocks.gitStatus).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(mocks.refreshGitCount).toHaveBeenCalledTimes(2));
+  });
+
+  it("admits one staging action until its refreshed status is visible", async () => {
+    withRepository([{ path: "main.tex", status: "M", staged: false }]);
+    const staged = deferred<void>();
+    mocks.gitStageAll.mockImplementationOnce(() => staged.promise);
+    render(<SourceControl />);
+    const stageAll = await screen.findByRole("button", { name: "Stage all" });
+    fireEvent.click(stageAll);
+    for (let index = 0; index < 20; index++) fireEvent.click(stageAll);
+    expect(mocks.gitStageAll).toHaveBeenCalledTimes(1);
+    expect(stageAll).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Stage" })).toBeDisabled();
+    mocks.gitStatus.mockResolvedValue([{ path: "main.tex", status: "M", staged: true }]);
+    await act(async () => staged.resolve());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Unstage all" })).toBeEnabled());
+  });
+
   it("keeps the current project's status when an older project refresh finishes last", async () => {
     const user = userEvent.setup();
     const slowOlderProjectStatus = deferred<
@@ -526,7 +559,7 @@ describe("SourceControl", () => {
     expect(screen.queryByText(/Older Oleafly versions/)).toBeNull();
   });
 
-  it("drops a refresh that a newer one has already superseded", async () => {
+  it("queues a fresh snapshot and drops the superseded response", async () => {
     const user = userEvent.setup();
     const firstInitializedRead = deferred<boolean>();
     let reads = 0;
@@ -539,14 +572,15 @@ describe("SourceControl", () => {
     render(<SourceControl />);
 
     await user.click(screen.getByRole("button", { name: "Refresh" }));
-    expect(await screen.findByText("second.tex")).toBeInTheDocument();
+    expect(reads).toBe(1);
 
     await act(async () => {
       firstInitializedRead.resolve(false);
       await firstInitializedRead.promise;
     });
 
-    expect(screen.getByText("second.tex")).toBeInTheDocument();
+    expect(await screen.findByText("second.tex")).toBeInTheDocument();
+    expect(reads).toBe(2);
     expect(screen.queryByRole("button", { name: "Initialize Repository" })).toBeNull();
   });
 

--- a/src/components/layout/SourceControl.tsx
+++ b/src/components/layout/SourceControl.tsx
@@ -84,6 +84,11 @@ type ProjectActionToken = {
   session: number;
 };
 
+type PendingRefresh = ProjectActionToken & {
+  queued: boolean;
+  promise: Promise<void>;
+};
+
 export function SourceControl() {
   const projectId = useFilesStore((s) => s.projectId);
   const projectName = useFilesStore((s) => s.projectName);
@@ -122,6 +127,8 @@ export function SourceControl() {
   const previousProjectId = useRef(projectId);
   const refreshRequestId = useRef(0);
   const projectSession = useRef(0);
+  const pendingRefresh = useRef<PendingRefresh | null>(null);
+  const pendingMutation = useRef<ProjectActionToken | null>(null);
   const openDiff = useDiffStore((s) => s.openDiff);
   const clearActiveDiff = useDiffStore((s) => s.clearActiveDiff);
   const openFile = useFilesStore((s) => s.openFile);
@@ -131,6 +138,8 @@ export function SourceControl() {
     previousProjectId.current = projectId;
     projectSession.current += 1;
     refreshRequestId.current += 1;
+    pendingRefresh.current = null;
+    pendingMutation.current = null;
     setChanges([]);
     setInitialized(null);
     setBranch("");
@@ -159,7 +168,7 @@ export function SourceControl() {
     clearActiveDiff();
   };
 
-  const refresh = useCallback(async () => {
+  const refreshOnce = useCallback(async () => {
     if (!projectId || useFilesStore.getState().projectId !== projectId) return;
     const targetProjectId = projectId;
     const requestId = ++refreshRequestId.current;
@@ -207,6 +216,34 @@ export function SourceControl() {
       /* ignore */
     }
   }, [projectId]);
+
+  // A slow Git process must not turn repeated refreshes into an unbounded
+  // queue of readers ahead of a stage/commit waiting for the worktree lock.
+  const refresh = useCallback(async () => {
+    if (!projectId || useFilesStore.getState().projectId !== projectId) return;
+    const current = pendingRefresh.current;
+    if (current?.projectId === projectId && current.session === projectSession.current) {
+      current.queued = true;
+      refreshRequestId.current += 1;
+      return current.promise;
+    }
+    const operation: PendingRefresh = {
+      projectId,
+      session: projectSession.current,
+      queued: false,
+      promise: Promise.resolve(),
+    };
+    pendingRefresh.current = operation;
+    operation.promise = (async () => {
+      do {
+        operation.queued = false;
+        await refreshOnce();
+      } while (operation.queued && pendingRefresh.current === operation);
+    })().finally(() => {
+      if (pendingRefresh.current === operation) pendingRefresh.current = null;
+    });
+    return operation.promise;
+  }, [projectId, refreshOnce]);
 
   const initialize = async () => {
     const action = beginProjectAction();
@@ -314,13 +351,22 @@ export function SourceControl() {
     window.dispatchEvent(new CustomEvent("oleafly:git-changed"));
 
   const runGit = async (action: ProjectActionToken, op: () => Promise<unknown>) => {
+    if (busy || pendingMutation.current) return;
+    pendingMutation.current = action;
+    setBusy(true);
     try {
       await op();
       if (!isCurrentProjectAction(action)) return;
       notifyGitChanged(); // the listener refreshes this panel; an open diff reloads too
+      await pendingRefresh.current?.promise;
     } catch (e) {
       if (!isCurrentProjectAction(action)) return;
       setStatus({ ok: false, text: String(e) });
+    } finally {
+      if (pendingMutation.current === action) {
+        pendingMutation.current = null;
+        if (isCurrentProjectAction(action)) setBusy(false);
+      }
     }
   };
   const stageFile = (path: string) => {
@@ -474,6 +520,7 @@ export function SourceControl() {
           ))}
         <button type="button"
           onClick={() => void (c.staged ? unstageFile(c.path) : stageFile(c.path))}
+          disabled={busy}
           aria-label={c.staged ? "Unstage" : "Stage"}
           title={c.staged ? "Unstage" : "Stage"}
           className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100"
@@ -778,6 +825,7 @@ export function SourceControl() {
                   </span>
                   <button type="button"
                     onClick={() => void unstageAll()}
+                    disabled={busy}
                     title="Unstage all"
                     aria-label="Unstage all"
                     className="ml-auto flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground group-hover/hdr:opacity-100"
@@ -799,6 +847,7 @@ export function SourceControl() {
                   </span>
                   <button type="button"
                     onClick={() => void stageAll()}
+                    disabled={busy}
                     title="Stage all"
                     aria-label="Stage all"
                     className="ml-auto flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground group-hover/hdr:opacity-100"

--- a/src/components/layout/UpdateWindow.test.tsx
+++ b/src/components/layout/UpdateWindow.test.tsx
@@ -51,7 +51,8 @@ it("reports an up-to-date manual check without closing the window", async () => 
   render(<UpdateWindow />);
   expect(await screen.findByText("Oleafly v0.4.0 is the latest version")).toBeInTheDocument();
   expect(mocks.close).not.toHaveBeenCalled();
-  expect(mocks.celebrate).toHaveBeenCalledOnce();
+  // The status text commits before the passive celebration effect runs.
+  await waitFor(() => expect(mocks.celebrate).toHaveBeenCalledOnce());
 });
 
 it("closes an automatic check when no update is available", async () => {

--- a/src/components/ui/mermaid-diagram.failure.test.tsx
+++ b/src/components/ui/mermaid-diagram.failure.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, render, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "@/lib/theme";
 import { Markdown } from "./markdown";
 import { clearDiagramCache } from "./mermaid-diagram";
@@ -21,6 +21,10 @@ vi.mock("mermaid", () => ({
 
 describe("Mermaid render failures", () => {
   let intersection: IntersectionObserverStub | null = null;
+
+  beforeAll(async () => {
+    await import("./markdown-renderer");
+  });
 
   beforeEach(() => {
     clearDiagramCache();

--- a/src/components/usage/UsageReport.test.tsx
+++ b/src/components/usage/UsageReport.test.tsx
@@ -191,7 +191,13 @@ describe("UsageReport", () => {
     expect(screen.getByText("Sessions", { selector: "dt" }).parentElement).toHaveTextContent(
       "0 child runs, 1 usage record",
     );
-    expect(screen.getByText("Aug 1 to Aug 31, 2026 (UTC)")).toBeVisible();
+    const start = new Date(Date.UTC(2026, 7, 1)).toLocaleDateString(undefined, {
+      timeZone: "UTC", month: "short", day: "numeric",
+    });
+    const end = new Date(Date.UTC(2026, 7, 31)).toLocaleDateString(undefined, {
+      timeZone: "UTC", month: "short", day: "numeric", year: "numeric",
+    });
+    expect(screen.getByText(`${start} to ${end} (UTC)`)).toBeVisible();
     expect(screen.getByRole("img", { name: /daily input and output token trend/iu })).toBeVisible();
     expect(screen.getByRole("img", { name: /token activity by UTC weekday and hour/iu })).toBeVisible();
   });
@@ -203,8 +209,12 @@ describe("UsageReport", () => {
     expect(rows).toHaveLength(31);
     expect(rows[14]).toHaveTextContent("2026-08-15");
     expect(rows[14]).toHaveTextContent("0");
-    expect(within(trend).getByText("Aug 8")).toBeInTheDocument();
-    expect(within(trend).getByText("Aug 29")).toBeInTheDocument();
+    for (const day of [8, 29]) {
+      const label = new Date(Date.UTC(2026, 7, day)).toLocaleDateString(undefined, {
+        timeZone: "UTC", month: "short", day: "numeric",
+      });
+      expect(within(trend).getByText(label)).toBeInTheDocument();
+    }
   });
 
   it("keeps missing chart and table counters visibly unknown", () => {

--- a/src/lib/analysis/coordinator.test.ts
+++ b/src/lib/analysis/coordinator.test.ts
@@ -160,7 +160,11 @@ describe("ProjectAnalysisCoordinator", () => {
     const pending = coordinator.requestWorkspaceSymbols({ query: "" });
     const request = await requestAt(transport, "workspace/symbol");
     const rejected = expect(pending).rejects.toBeInstanceOf(StaleProjectAnalysisResultError);
+    expect(store.getState().snapshot.features.workspaceSymbols.status).toBe("running");
     coordinator.dispose();
+    // Nothing can answer the in-flight request now, so its slot must not keep
+    // claiming that analysis is running.
+    expect(store.getState().snapshot.features.workspaceSymbols.status).toBe("not_run");
     const snapshot = store.getState().snapshot;
     transport.respond(request, []);
     await rejected;

--- a/src/lib/analysis/coordinator.test.ts
+++ b/src/lib/analysis/coordinator.test.ts
@@ -16,6 +16,7 @@ import {
 import { createProjectAnalysisStore } from "@/store/project-analysis";
 import {
   ProjectAnalysisCoordinator,
+  StaleProjectAnalysisResultError,
 } from "./coordinator";
 
 interface Sent {
@@ -150,6 +151,24 @@ async function openDocument(client: LanguageServiceClient) {
 }
 
 describe("ProjectAnalysisCoordinator", () => {
+  it("does not publish late results or start indexing after disposal", async () => {
+    const transport = new CoordinatorTransport();
+    const client = await readyClient(transport);
+    const store = createProjectAnalysisStore();
+    const coordinator = new ProjectAnalysisCoordinator(client, store);
+    coordinator.activateProject({ projectId: "project-a", projectRevision: 1 });
+    const pending = coordinator.requestWorkspaceSymbols({ query: "" });
+    const request = await requestAt(transport, "workspace/symbol");
+    const rejected = expect(pending).rejects.toBeInstanceOf(StaleProjectAnalysisResultError);
+    coordinator.dispose();
+    const snapshot = store.getState().snapshot;
+    transport.respond(request, []);
+    await rejected;
+    expect(store.getState().snapshot).toBe(snapshot);
+    expect(() => coordinator.beginIndex()).toThrow(StaleProjectAnalysisResultError);
+    expect(store.getState().snapshot).toBe(snapshot);
+  });
+
   it("normalizes diagnostics and exposes advertised/unsupported placeholders", async () => {
     const transport = new CoordinatorTransport();
     const client = await readyClient(transport);

--- a/src/lib/analysis/coordinator.ts
+++ b/src/lib/analysis/coordinator.ts
@@ -196,6 +196,7 @@ function workspaceDiagnosticsFromResult(
  * existing index store. Callers push ProjectIndex snapshots through syncIndex.
  */
 export class ProjectAnalysisCoordinator {
+  private disposed = false;
   private requestGeneration = 0;
   private readonly unsubscribe: () => void;
   private readonly pendingDiagnostics = new Map<
@@ -220,6 +221,9 @@ export class ProjectAnalysisCoordinator {
   }
 
   dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.pendingDiagnostics.clear();
     this.unsubscribe();
   }
 
@@ -251,7 +255,7 @@ export class ProjectAnalysisCoordinator {
 
   beginIndex(): ProjectAnalysisRequestIdentity {
     const request = this.createRequest();
-    if (!this.store.getState().beginProjectIndex(request)) {
+    if (this.disposed || !this.store.getState().beginProjectIndex(request)) {
       throw new StaleProjectAnalysisResultError(request);
     }
     return request;
@@ -475,11 +479,12 @@ export class ProjectAnalysisCoordinator {
   ): Promise<T> {
     this.syncDocumentFromClient(documentUri);
     const request = this.createRequest(documentUri);
-    if (!this.store.getState().beginFeature(feature, request)) {
+    if (this.disposed || !this.store.getState().beginFeature(feature, request)) {
       throw new StaleProjectAnalysisResultError(request);
     }
     try {
       const raw = await operation();
+      if (this.disposed) throw new StaleProjectAnalysisResultError(request);
       const data = transform(raw, request);
       if (
         !this.store
@@ -490,6 +495,7 @@ export class ProjectAnalysisCoordinator {
       }
       return data;
     } catch (error) {
+      if (this.disposed) throw error;
       if (
         error instanceof UnsupportedLanguageServiceCapabilityError
       ) {

--- a/src/lib/analysis/coordinator.ts
+++ b/src/lib/analysis/coordinator.ts
@@ -224,6 +224,20 @@ export class ProjectAnalysisCoordinator {
     if (this.disposed) return;
     this.disposed = true;
     this.pendingDiagnostics.clear();
+    // Requests in flight now reject without reaching resolveFeature or
+    // failFeature, so release their slots here. Detaching a runtime without a
+    // project or revision change (an engine unloading, a forced restart) would
+    // otherwise leave those features reporting "running" with nothing left to
+    // answer them.
+    const actions = this.store.getState();
+    for (const feature of PROJECT_ANALYSIS_FEATURES) {
+      if (actions.snapshot.features[feature].status === "running") {
+        actions.markFeatureNotRun(
+          feature,
+          "The language service was detached. Analysis did not finish.",
+        );
+      }
+    }
     this.unsubscribe();
   }
 

--- a/src/lib/editor-support-contract.test.ts
+++ b/src/lib/editor-support-contract.test.ts
@@ -497,7 +497,8 @@ describe("editor support acceptance contract", () => {
         `${fixture.path} must use a ${fixture.engine} extension`,
       ).toContain(extname(fixturePath).toLowerCase());
 
-      const source = readFileSync(fixturePath, "utf8");
+      // Match the editor's source normalization on Windows checkouts too.
+      const source = readFileSync(fixturePath, "utf8").replace(/\r\n?/gu, "\n");
       fixtureSources.set(fixture.path, source);
       for (const marker of fixture.markers) {
         declaredMarkers.add(marker);

--- a/src/lib/native-dock-shortcuts.test.ts
+++ b/src/lib/native-dock-shortcuts.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "@/store/settings";
 import { useShortcutStore } from "@/store/shortcuts";
+
+const originalNavigator = globalThis.navigator;
 
 const toggleBrowser = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/browser-window", () => ({ toggleBrowser }));
@@ -43,6 +45,7 @@ import {
 
 describe("native dock shortcuts", () => {
   beforeEach(() => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
     native.invoke.mockClear();
     native.listeners.clear();
     native.projectId = "project-1";
@@ -50,6 +53,8 @@ describe("native dock shortcuts", () => {
     useSettingsStore.setState({ terminalOpen: false, browserOpen: false, webBrowser: true });
     useShortcutStore.getState().resetAll();
   });
+
+  afterEach(() => vi.stubGlobal("navigator", originalNavigator));
 
   it("serializes fixed Ctrl dock bindings for Tauri menu accelerators", () => {
     expect(nativeAccelerator({ key: "`", ctrl: true }, true)).toBe("Ctrl+`");
@@ -95,6 +100,14 @@ describe("native dock shortcuts", () => {
     expect(usesNativeDockMenu(true, "Linux x86_64")).toBe(true);
     expect(usesNativeDockMenu(true, "Win32")).toBe(false);
     expect(usesNativeDockMenu(false, "MacIntel")).toBe(false);
+  });
+
+  it("does not install native menu listeners or accelerators on Windows", async () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    const stop = await startNativeDockShortcutBridge();
+    expect(native.invoke).not.toHaveBeenCalled();
+    expect(native.listeners.size).toBe(0);
+    stop();
   });
 
   it("syncs current and edited dock bindings to the native menu", async () => {

--- a/src/lib/project-intelligence/seed-fixture.ts
+++ b/src/lib/project-intelligence/seed-fixture.ts
@@ -31,7 +31,9 @@ export function loadSeedSources(slug: string): Record<string, string> {
   for (const full of paths.sort(byCodePoint)) {
     const relative = path.relative(root, full).split(path.sep).join("/");
     if (!isProjectIntelligencePath(relative)) continue;
-    sources[relative] = fs.readFileSync(full, "utf8");
+    // The editor and project-source bridge normalize line endings before
+    // indexing. Keep golden offsets independent of Git's checkout settings.
+    sources[relative] = fs.readFileSync(full, "utf8").replace(/\r\n?/gu, "\n");
   }
   return sources;
 }

--- a/src/lib/project-sources.test.ts
+++ b/src/lib/project-sources.test.ts
@@ -384,26 +384,33 @@ describe("readProjectSourcesBatch without the batch command", () => {
 });
 
 describe("parity with the per-file implementation", () => {
-  it("produces identical texts and unreadable sets on the seed thesis, cold and warm", async () => {
-    const seed = loadSeedThesis();
+  it.each(["LF", "CRLF"])("preserves cold and warm seed-thesis parity with %s input", async (lineEnding) => {
+    const seed = Object.fromEntries(
+      Object.entries(loadSeedThesis()).map(([name, bytes]) => {
+        const text = normalizeSourceText(decodeLossy(bytes));
+        const source = lineEnding === "CRLF" ? text.replace(/\n/gu, "\r\n") : text;
+        return [name, new TextEncoder().encode(source)];
+      }),
+    );
     const paths = Object.keys(seed).sort();
     expect(paths.length).toBeGreaterThanOrEqual(10);
-    for (const bytes of Object.values(seed)) {
-      expect(decodeLossy(bytes)).not.toContain("\r");
-    }
     const disk = fakeDisk({ ...seed, "phantom.tex": "" });
     disk.files.delete("phantom.tex");
     const requested = [...paths, "phantom.tex"];
     mountFallback(disk);
     const legacy = await legacyReadProjectSources("p", requested);
+    const expectedTexts = Object.fromEntries(
+      Object.entries(legacy.texts).map(([name, text]) => [name, normalizeSourceText(text)]),
+    );
 
     bridge.batch = simulateCommand(disk);
     const cold = await readProjectSourcesBatch("p", requested);
-    expect(cold.texts).toEqual(legacy.texts);
+    expect(cold.texts).toEqual(expectedTexts);
+    expect(Object.values(cold.texts).every((text) => !text.includes("\r"))).toBe(true);
     expect([...cold.unreadable]).toEqual([...legacy.unreadable]);
 
     const warm = await readProjectSourcesBatch("p", requested);
-    expect(warm.texts).toEqual(legacy.texts);
+    expect(warm.texts).toEqual(expectedTexts);
     expect([...warm.unreadable]).toEqual([...legacy.unreadable]);
     expect(disk.calls[1].known).toHaveLength(paths.length);
   });

--- a/src/lib/proofreading/harper-dialects.test.ts
+++ b/src/lib/proofreading/harper-dialects.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Dialect, LocalLinter } from "harper.js";
-import { binary } from "harper.js/binary";
+// Harper's Node file loader uses URL.pathname, which duplicates the drive
+// prefix on Windows. The inlined build exercises the same WASM and dialects
+// without depending on that loader's filesystem conversion.
+import { binaryInlined as binary } from "harper.js/binaryInlined";
 import type { ProofreadingDialect } from "@oleafly/editor";
 import { harperDialectFor } from "./dialects";
 

--- a/src/lib/terminal-resize.test.ts
+++ b/src/lib/terminal-resize.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalResizer } from "./terminal-resize";
+
+describe("terminal resize queue", () => {
+  it("bounds a stalled resize storm to the active and latest sizes", async () => {
+    let release!: () => void;
+    const send = vi.fn(() => new Promise<void>((resolve) => { release = resolve; }));
+    const queue = createTerminalResizer(send, vi.fn());
+    queue.request(80, 24);
+    for (let cols = 81; cols <= 300; cols++) queue.request(cols, 40);
+    expect(send).toHaveBeenCalledTimes(1);
+    release();
+    await Promise.resolve();
+    expect(send.mock.calls).toEqual([[80, 24], [300, 40]]);
+    release();
+    await Promise.resolve();
+    queue.request(300, 40);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("discards queued work and late errors after terminal disposal", async () => {
+    let reject!: (error: Error) => void;
+    const send = vi.fn(() => new Promise<void>((_resolve, fail) => { reject = fail; }));
+    const onError = vi.fn();
+    const queue = createTerminalResizer(send, onError);
+    queue.request(80, 24);
+    queue.request(100, 30);
+    queue.dispose();
+    reject(new Error("terminal closed"));
+    await Promise.resolve();
+    queue.request(120, 30);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reports failures and permits retrying the same size", async () => {
+    const send = vi.fn().mockRejectedValueOnce(new Error("resize failed")).mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const queue = createTerminalResizer(send, onError);
+    queue.request(80, 24);
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledOnce();
+    queue.request(80, 24);
+    await Promise.resolve();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/terminal-resize.ts
+++ b/src/lib/terminal-resize.ts
@@ -1,0 +1,35 @@
+export function createTerminalResizer(
+  send: (cols: number, rows: number) => Promise<unknown>,
+  onError: (error: unknown) => void,
+) {
+  let pending: { cols: number; rows: number } | null = null;
+  let running = false;
+  let disposed = false;
+  let applied: { cols: number; rows: number } | null = null;
+  const drain = async () => {
+    running = true;
+    while (!disposed && pending) {
+      const size = pending;
+      pending = null;
+      if (applied?.cols === size.cols && applied.rows === size.rows) continue;
+      try {
+        await send(size.cols, size.rows);
+        applied = size;
+      } catch (error) {
+        if (!disposed) onError(error);
+      }
+    }
+    running = false;
+  };
+  return {
+    request(cols: number, rows: number) {
+      if (disposed) return;
+      pending = { cols, rows };
+      if (!running) void drain();
+    },
+    dispose() {
+      disposed = true;
+      pending = null;
+    },
+  };
+}

--- a/src/store/compile.test.ts
+++ b/src/store/compile.test.ts
@@ -193,6 +193,9 @@ beforeEach(() => {
 
 describe("compile output lifecycle", () => {
   it("coalesces bursty compiler output so WebKit gets a paint frame", async () => {
+    // This case measures log buffering; syntax validation has separate cases
+    // below and lazily loads the language service on the first compile.
+    useCompileStore.setState({ checkSyntaxBeforeCompile: false });
     const compile = deferred<{
       ok: boolean;
       has_pdf: boolean;

--- a/vendor/tauri-plugin-playwright/src/server.rs
+++ b/vendor/tauri-plugin-playwright/src/server.rs
@@ -354,7 +354,7 @@ async fn execute_command<R: Runtime>(
         Command::WaitForFunction { expression, timeout_ms } => {
             let e = json_str(&expression);
             eval_js(app, pending, window_label, &format!(
-                r#"(async function(){{ var dl=Date.now()+{t}; while(Date.now()<dl){{ try{{ var r=({expr}); if(r) return r; }}catch(ex){{}} await new Promise(function(r){{setTimeout(r,100)}}); }} throw new Error('waitForFunction timeout: '+{e}); }})()"#,
+                r#"(async function(){{ var dl=Date.now()+{t}; while(Date.now()<dl){{ try{{ var r=await ({expr}); if(r) return r; }}catch(ex){{}} await new Promise(function(r){{setTimeout(r,100)}}); }} throw new Error('waitForFunction timeout: '+{e}); }})()"#,
                 expr=expression, e=e, t=timeout_ms
             )).await
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import { VITE_CLIENT_WITHOUT_TRANSPORT } from "./e2e/vite-client-without-transport";
 import {
   assertNoProductionDevHookTokens,
   assertNoTauriStyleNonceTriggers,
@@ -9,6 +10,21 @@ import {
 
 // Tauri expects a fixed port; if that's not available it will attempt the next one.
 const host = process.env.TAURI_DEV_HOST;
+
+const staticE2eClient = (): Plugin => ({
+  name: "static-e2e-vite-client",
+  apply: "serve",
+  configureServer(server) {
+    if (process.env.OLEAFLY_E2E_DISABLE_HMR !== "1") return;
+    // Vite 6 still connects its client socket with server.hmr=false. Serve
+    // the static client to module workers too, beyond Playwright page routes.
+    server.middlewares.use((request, response, next) => {
+      if (request.url?.split("?")[0] !== "/@vite/client") return next();
+      response.setHeader("Content-Type", "application/javascript");
+      response.end(VITE_CLIENT_WITHOUT_TRANSPORT);
+    });
+  },
+});
 
 // Keep only comments that carry distribution/licensing instructions. Terser
 // receives the comment body without `/*`/`//`, so a leading `!` covers `/*!`.
@@ -62,7 +78,7 @@ export const rejectProductionDevHooks = (): Plugin => ({
 });
 
 export default defineConfig(async () => ({
-  plugins: [react(), tailwindcss(), rejectProductionDevHooks()],
+  plugins: [react(), tailwindcss(), rejectProductionDevHooks(), staticE2eClient()],
   optimizeDeps: {
     exclude: ["harper.js"],
     include: [
@@ -144,7 +160,11 @@ export default defineConfig(async () => ({
     port: 1420,
     strictPort: true,
     host: host || false,
-    hmr: host
+    // Browser evidence also loads module workers, whose HMR sockets cannot be
+    // intercepted by page routes and can trip Playwright's Firefox adapter.
+    hmr: process.env.OLEAFLY_E2E_DISABLE_HMR === "1"
+      ? false
+      : host
       ? {
           protocol: "ws",
           host,


### PR DESCRIPTION
## Summary
Windows storage operations, process output collection, terminal resizing, and cleanup could block their callers or leave work running after its owner closed. This PR moves blocking work off the UI thread, bounds storage and process waits, closes owned process trees/readers, and coalesces terminal and Git work. It also fixes document, compiler, and browser issues found while validating v0.4.0.

## Changes
- Replace per-access icacls processes with native current-user ACL hardening; preserve failure reporting before publishing MCP credentials.
- Move settings, project rename, template, research-task storage, and ConPTY resizing to blocking workers. Keep slow terminal operations outside the global session registry.
- Give worktree, checkpoint, settings, and secrets lock admission a 30-second budget per lock without stealing locks or modifying another owner's data.
- Bound Git output collection to 64 MiB per pipe and close owned descendants and pipes after leader exit, timeout, or failure. Local commands keep a 120-second deadline because they report nothing while they work. Remote transfers are judged by silence instead: push, pull, and fetch stop after 120 seconds with no bytes on either pipe, under a one-hour backstop, and pass `--progress`, without which Git prints nothing over a pipe and an ordinary push would look idle. Bound Pandoc probes to five seconds.
- Close MCP diagnostics readers and owned process trees on disposal; bound agent/task reaping and keep CLI compiler readers inside the cancellable command future.
- Coalesce terminal resize storms, reject shells that finish starting after renderer reload, and prevent disposed editor analysis from publishing late results.
- Coalesce Source Control refreshes, guard staging, and refresh open INDEX-based diffs after Git changes.
- Retry transient Windows atomic-replacement locks without truncating documents, settings, or discovery records.
- Preserve valid Markdown PDFs after nonfatal default-Fontconfig warnings and parse Windows CRLF compiler diagnostics consistently.
- Restore source navigation after toolbar focus by synchronizing CodeMirror and browser selections; a failing-before regression and the unchanged native definition/reference/rename/PDF scenario verify the fix.
- Restore browser Ctrl+L/T/W/R while webpages have focus using native accelerators routed to the trusted toolbar.
- Expand checkpoint, project-kind, live-agent, and Windows regressions. Correct asynchronous waits in the native test bridge.

## Review follow-ups
- Rebuild an open working diff only when its INDEX baseline actually moved. That view is editable, so an unrelated Git change no longer discards the caret, scroll position, split divider, and undo history of whoever is typing in it.
- Release feature slots when the analysis coordinator is disposed. An engine unload or a forced restart detaches a runtime without changing the project or the revision, which left those features reporting that analysis was still running.
- Keep the per-family compile severity in the project-kind matrix. Only the Typst and Markdown templates report warnings, so the TeX templates still have to land on "ok".
- Recover a poisoned terminal master, so one panicking resize cannot make every later resize of that terminal fail.
- Split shell startup, the output loop, and the shared registry removal into separate functions.
- Take the patched Tiptap core for GHSA-j95f-988m-3j2f. The override that keeps one core instance for the editor extension types was holding 3.30.4, one release below the fix, so the production audit gate failed on every branch once the advisory published.
- Index the two Windows references from the developer documentation.

## Validation
- Original Windows flow inventory: 350 distinct native cases passed, plus nine browser checks across Chromium, Firefox, and WebKit.
- 13 actual compiler cases passed across Tectonic, Typst, pdfLaTeX, XeLaTeX, and LuaLaTeX, including installed/bundled fonts and invalid-source diagnostics. TexLab and Tinymist passed rapid-revision checks.
- Live Z.AI and local Ollama replies, usage, file tools, and Z.AI delegation were exercised. Checkpoints passed restore, deduplication, encrypted archives, and retention for Tectonic, Typst, and Markdown.
- Lifecycle audit: 1,330 native tests passed across the broad run and clean sequential reruns, with five existing ignored cases; all eight broad-run failures were covered by the 310-test clean rerun. Core/history/CLI passed 154 tests; frontend lifecycle and editor-controller checks passed 75 tests.
- Final packaged Windows follow-up: 50 distinct applicable native cases passed, with two expected skips. This covers terminal execution/multiple sessions/limits, Git diff and history, MCP, checkpoints in three formats, live Z.AI/Ollama and delegation, ACP cancellation/reconnect, compiler selection, and all six editor workflow cases. One Z.AI response returned an empty reasoning block; the isolated retry returned reasoning and passed.
- The navigation regression failed before the fix and passed afterward. Direct Chromium, Firefox, and WebKit checks confirmed the DOM/source selection agree and only the editor scrolls, preserving the surrounding page offset.
- Both the test app and normal Windows executable rebuilt successfully with the final production frontend.
- Formatting, workspace Clippy with warnings denied, typecheck, production build, and bundle limits passed. Lint passed with one pre-existing App.tsx dependency warning. Production assets contain zero development-hook tokens.
- All three editor performance gates passed: P95 analysis of a 6,200-line source was 85.44 ms; 200-file analysis was 56.84 ms; end-of-book completion was 5.11 ms (budgets 750/750/100 ms).
- macOS verification of the review follow-ups: 1,813 native tests, 4,034 frontend tests, formatting, workspace Clippy with warnings denied, production build, and bundle limits all passed. Real-app runs covered Git staging with the INDEX diff round trip, Git history restore, checkpoints in three formats, terminal open/echo/exit and the multi-terminal cases, SyncTeX inverse, toolbar focus, and an authenticated push to GitHub.
- Earlier frontend CI passed 4,028 tests. Final-revision CI has passed frontend, Windows and Linux Rust checks, Clippy, dependency audit, ARM Markdown, Sonar, and both Unix app builds. The complete native UI shards are still running.
- Manual Windows checks covered visual/source editing, PDF controls, project forks, local Git commits/history, terminal shortcuts, and browser navigation/tab shortcuts from webpage focus.

Detailed evidence: [flow validation](https://github.com/Oleafly/Oleafly/blob/main/docs/developer/windows-v0.4-validation.md) and [lifecycle audit](https://github.com/Oleafly/Oleafly/blob/main/docs/developer/windows-lifecycle-audit.md).

## Scope
Remote GitHub publishing was skipped without its dedicated test credentials. Fonts and live models are representative cases; other provider/account integrations use fixtures. Privileged Windows symlink cases require Developer Mode or the appropriate privilege. Explicit user-requested background services retain their established behavior. Additional manual checks on the final normal build were blocked when the Windows computer-use helper repeatedly timed out on list_windows, including after the documented reset/retry. Earlier manual Windows checks are recorded above; the new automated native/browser results are separate. Credentials, synthetic libraries, logs, and test binaries remain outside the PR; the final PR diff passed the temporary-key scan.

