### PR TITLE
fix: finish the process and storage lifecycle follow-ups

### DIFF
--- a/docs/CompilationEngines.md
+++ b/docs/CompilationEngines.md
@@ -140,8 +140,11 @@ records.
 - Tectonic, Typst, TexLab, and Tinymist versions are pinned by manifests or
   release metadata.
 - Fetch scripts and runtime installers verify SHA-256 before extraction and
-  reject unexpected archive members. TinyTeX pins a canonical manifest for
-  Windows x64, macOS universal, Linux x64, and Linux ARM64 release assets.
+  reject unexpected archive members. TinyTeX pins a canonical manifest naming
+  the upstream assets it accepts: Windows x64, a universal macOS archive,
+  Linux x64, and Linux ARM64. Those names describe TinyTeX's own downloads,
+  not Oleafly's build targets. Oleafly releases macOS on Apple Silicon only,
+  alongside Windows x64, Linux x64, and Linux ARM64.
 - Language servers are not silently packaged as Tauri external binaries.
   installation is consent-gated and license-aware.
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use crate::config;
 use crate::paths;
-use crate::proc::{output_contained, NoConsole, OutputBounds};
+use crate::proc::{NoConsole, OutputBounds};
 
 /// A transfer over someone's own uplink can legitimately take many minutes, so
 /// judge it by silence rather than by elapsed time: a push that is slow but
@@ -17,6 +17,39 @@ const REMOTE_TOTAL: std::time::Duration = std::time::Duration::from_secs(60 * 60
 
 fn remote_bounds() -> OutputBounds {
     OutputBounds::stalled_after(REMOTE_IDLE, REMOTE_TOTAL)
+}
+
+/// Local commands report nothing while they work, so silence cannot tell a slow
+/// one from a wedged one and only the deadline separates them. Most finish in
+/// milliseconds. The ones that walk the whole working tree do not: staging a
+/// large project while a virus scanner opens every file is slow but healthy, so
+/// give that group room rather than failing an ordinary commit.
+const LOCAL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(120);
+const WORKTREE_SCALE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(600);
+
+fn walks_the_working_tree(subcommand: Option<&str>) -> bool {
+    matches!(
+        subcommand,
+        Some(
+            "add"
+                | "checkout"
+                | "clean"
+                | "commit"
+                | "gc"
+                | "reset"
+                | "restore"
+                | "stash"
+                | "status"
+        )
+    )
+}
+
+fn local_bounds(args: &[&str]) -> OutputBounds {
+    OutputBounds::total(if walks_the_working_tree(args.first().copied()) {
+        WORKTREE_SCALE_DEADLINE
+    } else {
+        LOCAL_DEADLINE
+    })
 }
 
 fn project_root(project_id: &str) -> Result<PathBuf, String> {
@@ -48,14 +81,14 @@ fn run_configured_git(
     optional_locks: bool,
     configure: impl FnOnce(&mut Command),
 ) -> Result<std::process::Output, String> {
-    run_configured_git_bounded(root, args, optional_locks, None, configure)
+    run_configured_git_bounded(root, args, optional_locks, local_bounds(args), configure)
 }
 
 fn run_configured_git_bounded(
     root: &PathBuf,
     args: &[&str],
     optional_locks: bool,
-    bounds: Option<OutputBounds>,
+    bounds: OutputBounds,
     configure: impl FnOnce(&mut Command),
 ) -> Result<std::process::Output, String> {
     let mut command = Command::new("git");
@@ -74,17 +107,14 @@ fn run_configured_git_bounded(
         .env_remove("GIT_INDEX_FILE")
         .env("GIT_OPTIONAL_LOCKS", if optional_locks { "1" } else { "0" });
     configure(&mut command);
-    match bounds {
-        Some(bounds) => crate::proc::output_contained_with_bounds(command, bounds),
-        None => output_contained(command),
-    }
-    .map_err(|e| format!("failed to run git: {e}"))
+    crate::proc::output_contained_with_bounds(command, bounds)
+        .map_err(|e| format!("failed to run git: {e}"))
 }
 
 /// Reach a remote without a token: public clones and pulls still transfer over
 /// the same uplink, so they get the same silence-based bound.
 fn run_git_remote(root: &PathBuf, args: &[&str]) -> Result<std::process::Output, String> {
-    run_configured_git_bounded(root, args, true, Some(remote_bounds()), |_| {})
+    run_configured_git_bounded(root, args, true, remote_bounds(), |_| {})
 }
 
 pub(crate) fn ensure_repository(project_dir: &Path) -> Result<bool, String> {
@@ -1186,7 +1216,7 @@ mod tests {
     use super::{
         attach_imported_repository_history_at, clean_remote_credentials, commit_index,
         current_branch, ensure_repository, ensure_repository_with, initialize_repo,
-        is_allowed_remote_url, ok_or_err, out_to_string, parse_status_porcelain,
+        is_allowed_remote_url, local_bounds, ok_or_err, out_to_string, parse_status_porcelain,
         remote_credentials_need_cleanup, restore_worktree, run_configured_git, run_git,
         run_git_read_only, sanitize_url, show, stage, stage_all, unstage, unstage_all,
         validate_git_oid, Command,
@@ -1211,6 +1241,31 @@ mod tests {
             out_to_string(&out),
             "Writing objects:  90% (9/10)\nerror: failed to push some refs"
         );
+    }
+
+    #[test]
+    fn only_tree_walking_subcommands_get_the_longer_local_deadline() {
+        let long = super::WORKTREE_SCALE_DEADLINE;
+        let short = super::LOCAL_DEADLINE;
+        assert!(long > short);
+        for args in [
+            vec!["add", "-A"],
+            vec!["commit", "-m", "message"],
+            vec!["status", "--porcelain"],
+            vec!["checkout", "--", "main.tex"],
+            vec!["restore", "--staged", "main.tex"],
+        ] {
+            assert_eq!(local_bounds(&args).total_for_test(), long, "{args:?}");
+        }
+        for args in [
+            vec!["log", "-1"],
+            vec!["diff", "--cached"],
+            vec!["show", "HEAD:main.tex"],
+            vec!["rev-parse", "HEAD"],
+            vec!["remote", "get-url", "origin"],
+        ] {
+            assert_eq!(local_bounds(&args).total_for_test(), short, "{args:?}");
+        }
     }
 
     /// Create a throwaway git repo in a temp dir with a fixed identity.

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -14,9 +14,7 @@
 use std::process::Command;
 
 mod output;
-pub use output::{
-    output_contained, output_contained_with_bounds, output_contained_with_timeout, OutputBounds,
-};
+pub use output::{output_contained_with_bounds, output_contained_with_timeout, OutputBounds};
 
 /// `CREATE_NO_WINDOW` (winbase.h): the child runs without allocating a console.
 #[cfg(windows)]
@@ -405,7 +403,8 @@ mod windows_tests {
             "/C",
             "echo contained-out & echo contained-err 1>&2",
         ]);
-        let output = output_contained(command).expect("run contained synchronous child");
+        let output = output_contained_with_timeout(command, std::time::Duration::from_secs(30))
+            .expect("run contained synchronous child");
 
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("contained-out"));

--- a/src-tauri/src/proc/output.rs
+++ b/src-tauri/src/proc/output.rs
@@ -32,14 +32,17 @@ impl OutputBounds {
             total,
         }
     }
+
+    #[cfg(test)]
+    pub fn total_for_test(&self) -> Duration {
+        self.total
+    }
 }
 
 /// Synchronous callers must run on blocking workers. A single shared reactor
 /// drains both pipes without creating reader threads for every Git refresh.
-pub fn output_contained(command: Command) -> io::Result<Output> {
-    output_contained_with_timeout(command, Duration::from_secs(120))
-}
-
+/// Every caller states its own bound: there is no default deadline, because
+/// what counts as too long depends entirely on the work.
 pub fn output_contained_with_timeout(command: Command, timeout: Duration) -> io::Result<Output> {
     output_contained_with_bounds(command, OutputBounds::total(timeout))
 }
@@ -66,6 +69,11 @@ pub fn output_contained_with_bounds(command: Command, bounds: OutputBounds) -> i
         .map_err(|_| io::Error::other("process output worker stopped"))?
 }
 
+pub(crate) const TRUNCATION_MARKER: &[u8] = b"\n... output truncated";
+
+/// Collect one pipe, keeping the first `limit` bytes. Reading continues past
+/// the cap and discards the rest, because a command blocked writing into a full
+/// pipe never exits and its status is what the caller actually needs.
 async fn read_output(
     mut pipe: impl AsyncRead + Unpin,
     limit: usize,
@@ -73,6 +81,7 @@ async fn read_output(
     activity: &AtomicU64,
 ) -> io::Result<Vec<u8>> {
     let mut output = Vec::new();
+    let mut truncated = false;
     let mut bytes = [0; 8192];
     loop {
         let count = pipe.read(&mut bytes).await?;
@@ -80,14 +89,19 @@ async fn read_output(
         // still counts as making progress.
         activity.store(started.elapsed().as_millis() as u64, Ordering::Relaxed);
         if count == 0 {
+            if truncated {
+                output.extend_from_slice(TRUNCATION_MARKER);
+            }
             return Ok(output);
         }
-        if output.len().saturating_add(count) > limit {
-            return Err(io::Error::other(format!(
-                "command output exceeded the {limit}-byte limit"
-            )));
+        let room = limit.saturating_sub(output.len());
+        if room == 0 {
+            truncated = true;
+            continue;
         }
-        output.extend_from_slice(&bytes[..count]);
+        let kept = room.min(count);
+        truncated |= kept < count;
+        output.extend_from_slice(&bytes[..kept]);
     }
 }
 
@@ -207,9 +221,10 @@ mod tests {
 
     #[test]
     fn captures_both_pipes_and_exit_status() {
-        let output = output_contained(node(
-            "process.stdout.write('out');process.stderr.write('err');process.exitCode=7",
-        ))
+        let output = output_contained_with_timeout(
+            node("process.stdout.write('out');process.stderr.write('err');process.exitCode=7"),
+            Duration::from_secs(30),
+        )
         .unwrap();
         assert_eq!(output.stdout, b"out");
         assert_eq!(output.stderr, b"err");
@@ -270,14 +285,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn excessive_output_fails_instead_of_silently_truncating() {
-        let error = collect_output(
-            node("process.stdout.write('x'.repeat(16384));setInterval(()=>{},1000)"),
+    async fn excessive_output_is_capped_without_losing_the_exit_status() {
+        let output = collect_output(
+            node(
+                "process.stdout.write('x'.repeat(16384));\
+                 process.stderr.write('why it failed');process.exit(3)",
+            ),
             OutputBounds::total(Duration::from_secs(5)),
             1024,
         )
         .await
-        .unwrap_err();
-        assert!(error.to_string().contains("output exceeded"));
+        .unwrap();
+        // The command succeeded at running. Reporting only "output exceeded"
+        // would hide both the exit code and the short pipe that explains it.
+        assert_eq!(output.status.code(), Some(3));
+        assert_eq!(output.stderr, b"why it failed");
+        assert_eq!(output.stdout.len(), 1024 + TRUNCATION_MARKER.len());
+        assert!(output.stdout.starts_with(b"xxxx"));
+        assert!(output.stdout.ends_with(TRUNCATION_MARKER));
+    }
+
+    #[tokio::test]
+    async fn a_command_that_outruns_the_cap_still_exits_on_its_own() {
+        // Four megabytes past a 1 KiB cap, far beyond the pipe buffer. Stopping
+        // the reads at the cap would block the child mid-write, so it would
+        // never reach its own exit and the deadline would decide the outcome.
+        let start = Instant::now();
+        let output = collect_output(
+            node("process.stdout.write('x'.repeat(4000000), () => process.exit(0))"),
+            OutputBounds::total(Duration::from_secs(30)),
+            1024,
+        )
+        .await
+        .unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout.len(), 1024 + TRUNCATION_MARKER.len());
+        assert!(start.elapsed() < Duration::from_secs(20));
     }
 }

--- a/src-tauri/src/research_tasks/mod.rs
+++ b/src-tauri/src/research_tasks/mod.rs
@@ -795,13 +795,17 @@ pub async fn research_task_start(
     task_id: String,
 ) -> Result<ResearchTask, String> {
     state.attach_app(app);
-    let store = state.store()?;
-    let current = store.require(&task_id)?;
-    state.runtime_for(&current.runtime_id, &current.agent_id)?;
-    let requested = store.request_start(&task_id)?;
-    state.emit_task(&requested);
+    let requested_id = task_id.clone();
+    blocking_task_command(&state, move |state| {
+        let store = state.store()?;
+        let current = store.require(&requested_id)?;
+        state.runtime_for(&current.runtime_id, &current.agent_id)?;
+        state.emit_task(&store.request_start(&requested_id)?);
+        Ok(())
+    })
+    .await?;
     state.launch_ready().await?;
-    store.require(&task_id)
+    blocking_task_command(&state, move |state| state.store()?.require(&task_id)).await
 }
 
 #[tauri::command]
@@ -815,14 +819,18 @@ pub async fn research_task_cancel(
 }
 
 async fn cancel_task(state: &ResearchTaskState, task_id: String) -> Result<ResearchTask, String> {
-    let store = state.store()?;
-    let current = store.require(&task_id)?;
-    let mut active = if current.status == ResearchTaskStatus::Running {
-        lock(&state.inner.active).get(&task_id).cloned()
-    } else {
-        None
-    };
-    let cancellation = store.request_cancel(&task_id)?;
+    let requested_id = task_id.clone();
+    let (cancellation, mut active) = blocking_task_command(state, move |state| {
+        let store = state.store()?;
+        let current = store.require(&requested_id)?;
+        let active = if current.status == ResearchTaskStatus::Running {
+            lock(&state.inner.active).get(&requested_id).cloned()
+        } else {
+            None
+        };
+        Ok((store.request_cancel(&requested_id)?, active))
+    })
+    .await?;
     if cancellation.status == ResearchTaskStatus::Cancelled {
         state.emit_task(&cancellation);
         state.launch_ready().await?;
@@ -849,14 +857,19 @@ async fn cancel_task(state: &ResearchTaskState, task_id: String) -> Result<Resea
     };
     active.wait_until_settled().await;
     runtime_cancel?;
-    if !store.finalize_cancel(&task_id, active.execution_generation)? {
-        return Err("The task changed before cancellation finished.".into());
-    }
-    state.finish_active(&task_id, active.execution_generation);
-    let cancelled = store.require(&task_id)?;
-    state.emit_task(&cancelled);
+    let generation = active.execution_generation;
+    let settle_id = task_id.clone();
+    blocking_task_command(state, move |state| {
+        if !state.store()?.finalize_cancel(&settle_id, generation)? {
+            return Err("The task changed before cancellation finished.".into());
+        }
+        state.finish_active(&settle_id, generation);
+        state.emit_task(&state.store()?.require(&settle_id)?);
+        Ok(())
+    })
+    .await?;
     state.launch_ready().await?;
-    store.require(&task_id)
+    blocking_task_command(state, move |state| state.store()?.require(&task_id)).await
 }
 
 #[tauri::command]
@@ -923,17 +936,23 @@ pub async fn research_task_apply(
     request: TaskApplyRequest,
 ) -> Result<TaskApplyResult, String> {
     state.attach_app(app.clone());
+    let admitted = request.clone();
+    let task = blocking_task_command(&state, move |state| {
+        let store = state.store()?;
+        let task = store.require(&admitted.task_id)?;
+        if task.status != ResearchTaskStatus::AwaitingReview {
+            return Err("This task is not waiting for review.".into());
+        }
+        store.begin_apply(
+            &task.id,
+            task.execution_generation,
+            admitted.expected_project_generation,
+            &admitted.selected_paths,
+        )?;
+        Ok(task)
+    })
+    .await?;
     let store = state.store()?;
-    let task = store.require(&request.task_id)?;
-    if task.status != ResearchTaskStatus::AwaitingReview {
-        return Err("This task is not waiting for review.".into());
-    }
-    store.begin_apply(
-        &task.id,
-        task.execution_generation,
-        request.expected_project_generation,
-        &request.selected_paths,
-    )?;
     let apply_store = store.clone();
     let apply_task = task.clone();
     let selected_paths = request.selected_paths.clone();
@@ -947,27 +966,36 @@ pub async fn research_task_apply(
         },
     )
     .await;
-    let mutation = match mutation {
-        Ok(mutation) => mutation,
-        Err(error) => {
-            if !apply::has_recovery_journal(&store, &task)? {
-                store.clear_apply(&task.id, Some(&error))?;
-            }
-            return Err(error);
-        }
+    let failed = match &mutation {
+        Err(error) => Some(error.clone()),
+        Ok(mutation) => mutation.value.as_ref().err().cloned(),
     };
-    if let Err(error) = mutation.value {
-        if !apply::has_recovery_journal(&store, &task)? {
-            store.clear_apply(&task.id, Some(&error))?;
-        }
+    if let Some(error) = failed {
+        let failed_task = task.clone();
+        let reported = error.clone();
+        blocking_task_command(&state, move |state| {
+            let store = state.store()?;
+            if !apply::has_recovery_journal(&store, &failed_task)? {
+                store.clear_apply(&failed_task.id, Some(&reported))?;
+            }
+            Ok(())
+        })
+        .await?;
         return Err(error);
     }
+    let mutation = mutation?;
     let review = TaskReviewResult {
         selected_paths: request.selected_paths,
         applied_at: now_ms(),
         project_mutation_generation: mutation.generation,
     };
-    let task = store.complete_apply(&task.id, &review)?;
+    let completed_id = task.id.clone();
+    let task = blocking_task_command(&state, move |state| {
+        let task = state.store()?.complete_apply(&completed_id, &review)?;
+        state.emit_task(&task);
+        Ok(task)
+    })
+    .await?;
     let project_state = crate::project::publish_project_state_changed(
         &app,
         &app_state,
@@ -977,7 +1005,6 @@ pub async fn research_task_apply(
         true,
         Some(mutation.generation),
     )?;
-    state.emit_task(&task);
     state.launch_ready().await?;
     Ok(TaskApplyResult {
         task,
@@ -990,19 +1017,19 @@ pub async fn research_task_delete(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
 ) -> Result<(), String> {
-    let store = state.store()?;
-    let task = store.require(&task_id)?;
-    if task.status == ResearchTaskStatus::Running {
-        return Err("Stop this task before deleting it.".into());
-    }
-    store.delete(&task_id)?;
-    let workspace_root = isolation::task_workspace_root(store.root(), &task_id);
-    let project_root = crate::paths::project_dir(&task.project_id).ok();
-    tauri::async_runtime::spawn_blocking(move || {
+    blocking_task_command(&state, move |state| {
+        let store = state.store()?;
+        let task = store.require(&task_id)?;
+        if task.status == ResearchTaskStatus::Running {
+            return Err("Stop this task before deleting it.".into());
+        }
+        store.delete(&task_id)?;
+        let workspace_root = isolation::task_workspace_root(store.root(), &task_id);
+        let project_root = crate::paths::project_dir(&task.project_id).ok();
         isolation::purge_task_workspaces(project_root.as_deref(), &workspace_root);
+        Ok(())
     })
     .await
-    .map_err(|error| format!("The task workspace cleanup stopped: {error}"))
 }
 
 #[tauri::command]
@@ -1010,8 +1037,12 @@ pub async fn research_task_accept_result(
     state: tauri::State<'_, ResearchTaskState>,
     task_id: String,
 ) -> Result<ResearchTask, String> {
-    let task = state.store()?.complete_without_apply(&task_id)?;
-    state.emit_task(&task);
+    let task = blocking_task_command(&state, move |state| {
+        let task = state.store()?.complete_without_apply(&task_id)?;
+        state.emit_task(&task);
+        Ok(task)
+    })
+    .await?;
     state.launch_ready().await?;
     Ok(task)
 }


### PR DESCRIPTION
## Summary
Four items left open by #144. Three are behaviour, one is a documentation
correction. None of them change what the app does when everything is working;
they change what happens at the edges, where the previous bounds either
reported the wrong thing or blocked the wrong caller.

## Changes
- Keep the first 64 MiB of each pipe instead of discarding the whole result. Crossing the cap used to return an error, which threw away the other pipe and the exit status too, so a `git diff` over a large tracked artifact reported a hard failure for a command that had succeeded. Reading now continues past the cap and discards the excess, because a child blocked writing into a full pipe never reaches its own exit. The kept bytes end with a truncation marker, matching what `agent_exec` already did.
- Route `research_task_start`, `cancel`, `delete`, `apply`, and `accept_result` through `blocking_task_command`. They ran synchronous SQLite directly on the async executor while their siblings did not, which parks a worker and stalls unrelated tasks behind it. Each one is split around the asynchronous work it interleaves with rather than wrapped whole, so `apply` still hands the worktree mutation back to the async path between its two storage steps.
- Match the local Git deadline to the job. Silence cannot bound these commands, because they print nothing while they work, so a watchdog cannot tell a slow `git add` from a wedged one. Commands that walk the whole working tree now get ten minutes, since staging a large project while a virus scanner opens every file is slow rather than stuck. Everything else keeps two minutes. With every caller stating its own bound, the default-deadline helper has no callers left and is removed.
- Correct the sidecar policy note. It listed "macOS universal" among the pinned targets, which reads as though a universal macOS build exists. Those names are TinyTeX's own release assets, so the note now says that, and says what Oleafly ships: macOS on Apple Silicon, Windows x64, Linux x64, and Linux ARM64.

## Validation
- 1,815 native tests pass, up from 1,813. Formatting, workspace Clippy with warnings denied, the frontend suite at 4,034 tests, lint, and the production build all pass. Lint keeps the one pre-existing App.tsx dependency warning.
- Three new cases cover the cap: the exit status and the short pipe survive a stdout flood, a command that writes four megabytes past a 1 KiB cap still reaches its own exit, and the deadline classification is asserted per subcommand.
- One test was written wrong on the first attempt and is worth recording. A command that never stops writing is never idle, so it correctly runs to the total backstop rather than tripping the silence bound. The case now asserts what actually matters, which is that draining past the cap lets the child exit at all.
- Real-app runs on macOS: 14 passed, 2 skipped, covering Git staging with the INDEX diff round trip, local history restore, Git history navigation, compile, and the terminal dock including open/echo/exit and the multi-terminal cases. The GitHub publish case was skipped in this run.

## Scope
The research-task commands are covered by their native tests and by the app's own lifecycle checks, not by a live agent run. The Windows paths in the output collector are unchanged in shape and were verified only on macOS here; CI covers the rest.
