### PR TITLE
Fix TeX package installation and CLI bridge dialogs

### DIFF
--- a/e2e/settings-install-harness.html
+++ b/e2e/settings-install-harness.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Settings installation tests</title></head><body><div id="root"></div><script type="module" src="/e2e/settings-install-harness.tsx"></script></body></html>

--- a/e2e/settings-install-harness.tsx
+++ b/e2e/settings-install-harness.tsx
@@ -1,0 +1,12 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createRoot } from "react-dom/client";
+import { SettingsModal } from "/src/components/layout/SettingsModal";
+import { useSettingsStore } from "/src/store/settings";
+import "/src/styles/globals.css";
+
+useSettingsStore.setState({ settingsOpen: true });
+createRoot(document.getElementById("root")!).render(
+  <QueryClientProvider client={new QueryClient()}>
+    <SettingsModal />
+  </QueryClientProvider>,
+);

--- a/e2e/tests/84-settings-install-browser.spec.ts
+++ b/e2e/tests/84-settings-install-browser.spec.ts
@@ -1,0 +1,173 @@
+import { existsSync } from "node:fs";
+import { chromium, webkit, expect, test, type Page } from "@playwright/test";
+
+async function setup(page: Page) {
+  page.setDefaultTimeout(15_000);
+  await page.addInitScript(() => {
+    const state = {
+      installs: 0,
+      fail: true,
+      packages: ["pgf", "graphics", "tools"],
+      calls: [] as { command: string; args: unknown }[],
+    };
+    const agent = {
+      definition: {
+        id: "fixture",
+        name: "Research CLI",
+        version: "1.2.3",
+        description: "Test bridge",
+        builtin: true,
+        distribution: { npx: { package: "research-fixture@1.2.3", args: [] } },
+      },
+      installed: false,
+      managed: false,
+      executable: null,
+      installedVersion: null,
+      platform: "windows-x86_64",
+      canInstall: true,
+      reason: null,
+      authentication: null,
+      taskSupported: true,
+      taskUnavailableReason: null,
+      cli: null,
+    };
+    Object.assign(window, {
+      __settingsInstallTest: state,
+      isTauri: true,
+      __TAURI_INTERNALS__: {
+        transformCallback: () => 1,
+        unregisterCallback: () => {},
+        invoke: async (command: string, args: Record<string, unknown> = {}) => {
+          state.calls.push({ command, args });
+          if (command === "acp_catalog") return [agent];
+          if (command === "acp_install") {
+            state.installs += 1;
+            await new Promise((resolve) => setTimeout(resolve, 400));
+            if (state.fail) throw "The bridge download was interrupted. Try again.";
+            agent.installed = true;
+            agent.managed = true;
+            return agent;
+          }
+          if (command === "latex_engine_info")
+            return {
+              kind: "system",
+              lualatex: "/test/lualatex",
+              tlmgr: "/test/tlmgr",
+              latexmk: "/test/latexmk",
+              version: "test",
+            };
+          if (command === "tlmgr_installed") return state.packages;
+          if (command === "tlmgr_search") return [{ name: "classicthesis", description: "A thesis package" }];
+          if (command === "tlmgr_install") {
+            if (state.fail) throw "TeX Live repository is unreachable. Check your connection.";
+            state.packages.push(...(args.packages as string[]));
+            return "installed";
+          }
+          if (command === "tinytex_install_state") return { partial_download_bytes: 0 };
+          if (command === "get_ai_config") return { providers: [] };
+          if (command === "tex_distributions") return [];
+          if (command.startsWith("plugin:")) return 1;
+          return [];
+        },
+      },
+    });
+  });
+  await page.goto(
+    `${process.env.OLEAFLY_BROWSER_TEST_URL ?? "http://localhost:1420"}/e2e/settings-install-harness.html`,
+  );
+  await expect(page.getByRole("dialog", { name: "Settings", exact: true })).toBeVisible();
+}
+
+for (const browserType of [chromium, webkit]) {
+  test(`${browserType.name()}: bridge confirmation is clickable above Settings and can retry`, async () => {
+    test.skip(!existsSync(browserType.executablePath()), "Browser executable is not installed");
+    const browser = await browserType.launch();
+    try {
+      const page = await browser.newPage({ viewport: { width: 1200, height: 950 } });
+      await setup(page);
+      await page.getByTestId("settings-section-ai").click();
+      await page.getByTestId("ai-settings-tab-agents").click();
+      await page.getByTestId("acp-agent-card-fixture").getByRole("button", { expanded: false }).click();
+      await page.getByTestId("acp-agent-install-fixture").click();
+      const review = page.getByRole("dialog", { name: "Install Research CLI bridge 1.2.3" });
+      await expect(review).toBeVisible();
+      const install = review.getByRole("button", { name: "Install", exact: true });
+      await expect(install).toBeEnabled();
+
+      await expect
+        .poll(() =>
+          install.evaluate((button) => {
+            const rect = button.getBoundingClientRect();
+            const settings = document.querySelector<HTMLElement>('[aria-label="Settings"][role="dialog"]')!
+              .parentElement!;
+            const previous = settings.style.pointerEvents;
+            settings.style.pointerEvents = "auto";
+            const visible = button.contains(
+              document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2),
+            );
+            settings.style.pointerEvents = previous;
+            return visible;
+          }),
+        )
+        .toBe(true);
+      for (let i = 0; i < 8; i += 1) {
+        await page.keyboard.press("Tab");
+        expect(await review.evaluate((dialog) => dialog.contains(document.activeElement))).toBe(true);
+      }
+      await page.keyboard.press("Escape");
+      await expect(review).toBeHidden();
+      await expect(page.getByRole("dialog", { name: "Settings", exact: true })).toBeVisible();
+      await expect(page.getByTestId("acp-agent-install-fixture")).toBeFocused();
+      await page.getByTestId("acp-agent-install-fixture").click();
+      await install.click();
+      await expect(review.getByRole("button", { name: "Installing", exact: true })).toBeDisabled();
+      await expect(review.getByRole("button", { name: "Close", exact: true })).toBeDisabled();
+      await page.keyboard.press("Escape");
+      await expect(review).toBeVisible();
+      await expect(review.getByRole("alert")).toContainText("download was interrupted");
+      await page.evaluate(() => {
+        (window as any).__settingsInstallTest.fail = false;
+      });
+      await install.click();
+      await expect(review).toBeHidden();
+      await expect(page.getByRole("status")).toContainText("Research CLI is installed");
+      expect(await page.evaluate(() => (window as any).__settingsInstallTest.installs)).toBe(2);
+    } finally {
+      await browser.close();
+    }
+  });
+  test(`${browserType.name()}: TeX Live search, installed aliases, failure details and retry`, async () => {
+    test.skip(!existsSync(browserType.executablePath()), "Browser executable is not installed");
+    const browser = await browserType.launch();
+    try {
+      const page = await browser.newPage({ viewport: { width: 1200, height: 950 } });
+      await setup(page);
+      await page.getByTestId("settings-section-engine").click();
+      const packages = page.getByRole("region", { name: "LaTeX packages" });
+      const query = packages.getByRole("textbox", { name: "Find LaTeX packages" });
+      await query.fill("tikz");
+      await expect(packages.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
+      await expect(packages).toContainText("Included in pgf");
+      await query.fill("classicthesis");
+      await packages.getByRole("button", { name: "Search TeX Live" }).click();
+      await expect(packages.getByText("classicthesis", { exact: true })).toBeVisible();
+      await packages.getByRole("button", { name: "Add", exact: true }).click();
+      await expect(packages.getByRole("alert")).toContainText("repository is unreachable");
+      await page.evaluate(() => {
+        (window as any).__settingsInstallTest.fail = false;
+      });
+      await packages.getByRole("button", { name: "Add", exact: true }).click();
+      await expect(packages.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
+      await expect(packages.getByRole("alert")).toBeHidden();
+      expect(
+        await page.evaluate(() =>
+          (window as any).__settingsInstallTest.calls
+            .filter((call: any) => call.command === "tlmgr_install")
+            .map((call: any) => call.args.packages),
+        ),
+      ).toEqual([["classicthesis"], ["classicthesis"]]);
+    } finally {
+      await browser.close();
+    }
+  });
+}

--- a/packages/latex/src/import-compat.test.ts
+++ b/packages/latex/src/import-compat.test.ts
@@ -4,7 +4,7 @@ import {
   importCompatFinding,
   latexmkFixesFinding,
   loadsPackage,
-  missingLatexPackages,
+  missingLatexFiles,
   scanImportCompatibility,
   stripLineComments,
 } from "./import-compat";
@@ -176,17 +176,17 @@ describe("taxonomy catalog", () => {
   });
 });
 
-describe("missingLatexPackages", () => {
-  it("extracts package stems from missing .sty and .cls errors", () => {
+describe("missingLatexFiles", () => {
+  it("extracts filenames from missing .sty and .cls errors", () => {
     const log = [
       "! LaTeX Error: File `siunitx.sty' not found.",
       "! LaTeX Error: File `sn-jnl.cls' not found.",
       "! I can't find file `algorithmic.sty'.",
     ].join("\n");
-    expect(missingLatexPackages(log).sort()).toEqual([
-      "algorithmic",
-      "siunitx",
-      "sn-jnl",
+    expect(missingLatexFiles(log).sort()).toEqual([
+      "algorithmic.sty",
+      "siunitx.sty",
+      "sn-jnl.cls",
     ]);
   });
 
@@ -195,7 +195,7 @@ describe("missingLatexPackages", () => {
       "! LaTeX Error: File `figure1.pdf' not found.",
       "! I can't find file `chapters/intro.tex'.",
     ].join("\n");
-    expect(missingLatexPackages(log)).toEqual([]);
+    expect(missingLatexFiles(log)).toEqual([]);
   });
 
   it("deduplicates repeated misses and rejects unsafe names", () => {
@@ -204,6 +204,15 @@ describe("missingLatexPackages", () => {
       "! LaTeX Error: File `siunitx.sty' not found.",
       "! LaTeX Error: File `bad name$.sty' not found.",
     ].join("\n");
-    expect(missingLatexPackages(log)).toEqual(["siunitx"]);
+    expect(missingLatexFiles(log)).toEqual(["siunitx.sty"]);
   });
+  it("preserves filenames and recognizes quote variants without treating project paths as packages", () => {
+    const log = [
+      "! LaTeX Error: File 'tikz.sty' not found.",
+      '! LaTeX Error: File "university_thesis.cls" not found.',
+      "! LaTeX Error: File `styles/custom.sty' not found.",
+    ].join("\n");
+    expect(missingLatexFiles(log)).toEqual(["tikz.sty", "university_thesis.cls"]);
+  });
+
 });

--- a/packages/latex/src/import-compat.ts
+++ b/packages/latex/src/import-compat.ts
@@ -324,28 +324,18 @@ export function classifyCompileFailure(logRaw: string): ImportCompatFinding[] {
   return findings;
 }
 
-/**
- * Package/class files a failed compile could not find, as installable tlmgr
- * package names (best effort: the file stem is the package name for the vast
- * majority of CTAN packages). Matches the pdfLaTeX/XeLaTeX error shapes:
- *
- *   ! LaTeX Error: File `foo.sty' not found.
- *   ! I can't find file `bar.cls'.
- *
- * Linear indexOf scans only. Capped and deduplicated.
- */
-export function missingLatexPackages(logRaw: string): string[] {
+export function missingLatexFiles(logRaw: string): string[] {
   const log =
     logRaw.length > MAX_CLASSIFY_CHARS ? logRaw.slice(0, MAX_CLASSIFY_CHARS) : logRaw;
   const found = new Set<string>();
-  const markers = ["LaTeX Error: File `", "I can't find file `"];
+  const markers = ["LaTeX Error: File `", "I can't find file `", "LaTeX Error: File '", 'LaTeX Error: File "'];
   for (const marker of markers) {
     let from = 0;
     while (from < log.length && found.size < 8) {
       const idx = log.indexOf(marker, from);
       if (idx === -1) break;
       const start = idx + marker.length;
-      const quote = log.indexOf("'", start);
+      const quote = log.indexOf(marker.endsWith('"') ? '"' : "'", start);
       if (quote === -1 || quote - start > 128) {
         from = start;
         continue;
@@ -354,10 +344,7 @@ export function missingLatexPackages(logRaw: string): string[] {
       const dot = file.lastIndexOf(".");
       const ext = dot === -1 ? "" : file.slice(dot + 1).toLowerCase();
       if (ext === "sty" || ext === "cls") {
-        const stem = file.slice(0, dot).split("/").pop() ?? "";
-        // tlmgr package names are a safe charset; anything else is not
-        // installable by name and would just fail the install call.
-        if (stem && /^[a-zA-Z0-9.-]+$/.test(stem)) found.add(stem);
+        if (/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(file)) found.add(file);
       }
       from = quote + 1;
     }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -394,6 +394,7 @@ else
     "e2e/tests/24-pdf-selection-browser.spec.ts"
     "e2e/tests/27-markdown-rendering-browser.spec.ts"
     "e2e/tests/56-preview-window-browser.spec.ts"
+    "e2e/tests/84-settings-install-browser.spec.ts"
   )
   if [ -n "$APP_BINARY" ]; then
     filtered=()

--- a/src-tauri/src/latex_engine.rs
+++ b/src-tauri/src/latex_engine.rs
@@ -8,6 +8,8 @@
 //! admin rights and manages packages with `tlmgr`). Everything here is opt-in
 //! and deletable from Settings.
 
+pub(crate) mod packages;
+
 use crate::paths;
 use crate::proc::NoConsole;
 use crate::state::AppState;
@@ -365,7 +367,10 @@ async fn find_engine() -> EngineInfo {
 
 #[tauri::command]
 pub async fn latex_engine_info() -> EngineInfo {
-    find_engine().await
+    let mut info = find_engine().await;
+    info.tlmgr = crate::tex_distro::active_latexmk_distribution()
+        .and_then(|distribution| distribution.tlmgr);
+    info
 }
 
 #[tauri::command]
@@ -1520,7 +1525,10 @@ async fn tlmgr_run_at(tlmgr: &str, action: &str, packages: Vec<String>) -> Resul
     let output = run_tex_utility(Path::new(tlmgr), &args, TLMGR_MUTATION_TIMEOUT).await?;
     let log = format!("{}{}", output.stdout, output.stderr);
     if !output.success {
-        return Err(log.trim().to_string());
+        return Err(packages::package_command_error(
+            &output,
+            "TeX Live could not complete the package operation.",
+        ));
     }
     Ok(log)
 }

--- a/src-tauri/src/latex_engine/packages.rs
+++ b/src-tauri/src/latex_engine/packages.rs
@@ -1,0 +1,288 @@
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, serde::Serialize)]
+pub struct TexPackage {
+    name: String,
+    description: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SearchResult {
+    packages: BTreeMap<String, String>,
+    files: BTreeMap<String, Vec<String>>,
+}
+
+fn literal_pattern(value: &str) -> String {
+    let mut pattern = String::new();
+    for ch in value.chars() {
+        if "\\.^$|?*+()[]{}".contains(ch) {
+            pattern.push('\\');
+        }
+        pattern.push(ch);
+    }
+    pattern
+}
+
+fn validate_files(files: &[String]) -> Result<(), String> {
+    if files.is_empty() || files.len() > 8 {
+        return Err("Choose between one and eight missing LaTeX files.".into());
+    }
+    for file in files {
+        if file.len() > 128
+            || !file
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_alphanumeric)
+            || !file
+                .bytes()
+                .all(|ch| ch.is_ascii_alphanumeric() || b"._-".contains(&ch))
+            || !file.rsplit_once('.').is_some_and(|(_, extension)| {
+                extension.eq_ignore_ascii_case("sty") || extension.eq_ignore_ascii_case("cls")
+            })
+        {
+            return Err(format!("Invalid LaTeX package filename: {file}"));
+        }
+    }
+    Ok(())
+}
+
+async fn search_at(tlmgr: &str, pattern: String, files: bool) -> Result<SearchResult, String> {
+    let mut args = vec!["search".into(), "--global".into(), "--json".into()];
+    if files {
+        args.push("--file".into());
+    }
+    args.extend(["--".into(), pattern]);
+    let output = run_tex_utility(Path::new(tlmgr), &args, TLMGR_INFO_TIMEOUT).await?;
+    if !output.success {
+        return Err(package_command_error(&output, "Could not search TeX Live."));
+    }
+    parse_search_result(&output.stdout)
+}
+
+fn parse_search_result(stdout: &str) -> Result<SearchResult, String> {
+    let json = stdout
+        .find('{')
+        .map(|start| &stdout[start..])
+        .unwrap_or(stdout);
+    serde_json::from_str(json)
+        .map_err(|error| format!("Could not read the TeX Live search results: {error}"))
+}
+
+pub(super) fn package_command_error(output: &TexUtilityOutput, fallback: &str) -> String {
+    let detail = format!("{}\n{}", output.stdout.trim(), output.stderr.trim());
+    if detail.trim().is_empty() {
+        fallback.into()
+    } else {
+        detail.trim().into()
+    }
+}
+
+#[tauri::command]
+pub async fn tlmgr_search(query: String) -> Result<Vec<TexPackage>, String> {
+    let query = query.trim();
+    if query.len() < 2 || query.len() > 128 || query.chars().any(char::is_control) {
+        return Err("Enter between 2 and 128 characters to search TeX Live.".into());
+    }
+    let _runtime = acquire_tex_runtime_read()?;
+    let tlmgr = tlmgr_path()?;
+    let result = search_at(&tlmgr, literal_pattern(query), false).await?;
+    Ok(search_packages(result, query))
+}
+
+fn search_packages(result: SearchResult, query: &str) -> Vec<TexPackage> {
+    let mut packages: Vec<_> = result
+        .packages
+        .into_iter()
+        .filter(|(name, _)| validate_package_names(std::slice::from_ref(name)).is_ok())
+        .map(|(name, description)| TexPackage { name, description })
+        .collect();
+    packages.sort_by(|a, b| {
+        (!a.name.eq_ignore_ascii_case(query))
+            .cmp(&(!b.name.eq_ignore_ascii_case(query)))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    packages.truncate(200);
+    packages
+}
+
+fn resolve_providers(result: SearchResult, files: &[String]) -> Result<Vec<String>, String> {
+    let mut packages = BTreeSet::new();
+    for file in files {
+        let providers: Vec<_> = result
+            .files
+            .iter()
+            .filter(|(name, paths)| {
+                validate_package_names(std::slice::from_ref(name)).is_ok()
+                    && paths.iter().any(|path| {
+                        path.starts_with("texmf-dist/tex/")
+                            && !path.starts_with("texmf-dist/tex/latex-dev/")
+                            && path.rsplit('/').next() == Some(file.as_str())
+                    })
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
+        match providers.as_slice() {
+            [name] => { packages.insert(name.clone()); }
+            [] => return Err(format!("TeX Live has no package that provides {file}. If this file belongs to your university or publisher template, add it to the project from the original template.")),
+            _ => return Err(format!("Several TeX Live packages provide {file}: {}. Search for these packages in Settings and choose the one required by your template.", providers.join(", "))),
+        }
+    }
+    Ok(packages.into_iter().collect())
+}
+
+async fn install_missing_at(tlmgr: &str, files: Vec<String>) -> Result<String, String> {
+    validate_files(&files)?;
+    let pattern = format!(
+        "(^|/)({})$",
+        files
+            .iter()
+            .map(|file| literal_pattern(file))
+            .collect::<Vec<_>>()
+            .join("|")
+    );
+    let result = search_at(tlmgr, pattern, true).await?;
+    let packages = resolve_providers(result, &files)?;
+    tlmgr_run_at(tlmgr, "install", packages).await
+}
+
+#[tauri::command]
+pub async fn tlmgr_install_missing(
+    state: tauri::State<'_, AppState>,
+    files: Vec<String>,
+) -> Result<String, String> {
+    validate_files(&files)?;
+    let _mutation = TinytexMutationGuard::acquire_maintenance()?;
+    let _compile = state.compile_lock.lock().await;
+    let _figure_compile = state.figure_compile_lock.lock().await;
+    let _runtime = acquire_tex_runtime_write()?;
+    install_missing_at(&tlmgr_path()?, files).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn results(files: serde_json::Value) -> SearchResult {
+        parse_search_result(&serde_json::json!({"packages": {}, "files": files}).to_string())
+            .unwrap()
+    }
+
+    #[test]
+    fn resolves_file_owners_and_deduplicates_shared_packages() {
+        let result = results(serde_json::json!({
+            "pgf": ["texmf-dist/tex/latex/pgf/frontendlayer/tikz.sty"],
+            "caption": ["texmf-dist/tex/latex/caption/caption.sty", "texmf-dist/tex/latex/caption/subcaption.sty"],
+            "latex-graphics-dev": ["texmf-dist/tex/latex-dev/graphics/graphicx.sty"],
+            "graphics": ["texmf-dist/tex/latex/graphics/graphicx.sty"]
+        }));
+        let files = ["tikz.sty", "caption.sty", "subcaption.sty", "graphicx.sty"].map(String::from);
+        assert_eq!(
+            resolve_providers(result, &files).unwrap(),
+            ["caption", "graphics", "pgf"]
+        );
+    }
+
+    #[test]
+    fn does_not_install_an_arbitrary_provider_or_an_incomplete_set() {
+        let files = ["thesis.cls".into()];
+        assert!(resolve_providers(results(serde_json::json!({})), &files)
+            .unwrap_err()
+            .contains("original template"));
+        let result = results(
+            serde_json::json!({"a": ["texmf-dist/tex/latex/a/thesis.cls"], "b": ["texmf-dist/tex/latex/b/thesis.cls"]}),
+        );
+        assert!(resolve_providers(result, &files)
+            .unwrap_err()
+            .contains("Several"));
+        let result = results(serde_json::json!({"a": ["texmf-dist/doc/latex/a/thesis.cls"]}));
+        assert!(resolve_providers(result, &files).is_err());
+    }
+
+    #[test]
+    fn escapes_search_patterns_and_rejects_invalid_filenames() {
+        assert_eq!(literal_pattern("a.b+(c)[d]"), r"a\.b\+\(c\)\[d\]");
+        for file in [
+            "../thesis.cls",
+            "--foo.sty",
+            "foo.tex",
+            "foo.sty|bar",
+            "a b.sty",
+        ] {
+            assert!(validate_files(&[file.into()]).is_err());
+        }
+        assert!(validate_files(&["university_thesis.cls".into()]).is_ok());
+        assert!(validate_files(&[]).is_err());
+    }
+
+    #[test]
+    fn parses_json_after_repository_notice_and_prioritizes_exact_names() {
+        let result = parse_search_result("tlmgr: package repository https://example.test\n{\"files\":{},\"packages\":{\"arsclassica\":\"Thesis style\",\"classicthesis\":\"Thesis\",\"--bad\":\"invalid\"}}").unwrap();
+        let packages = search_packages(result, "classicthesis");
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0].name, "classicthesis");
+        assert!(parse_search_result("not json").is_err());
+    }
+
+    #[test]
+    fn errors_keep_both_output_streams_and_never_return_an_empty_reason() {
+        let output = TexUtilityOutput {
+            success: false,
+            stdout: "repository details".into(),
+            stderr: "permission denied".into(),
+        };
+        let error = package_command_error(&output, "Install failed.");
+        assert!(error.contains("repository details"));
+        assert!(error.contains("permission denied"));
+        let empty = TexUtilityOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: String::new(),
+        };
+        assert_eq!(
+            package_command_error(&empty, "Install failed."),
+            "Install failed."
+        );
+    }
+
+    #[cfg(unix)]
+    fn fake_manager(result: &str) -> (tempfile::TempDir, String) {
+        use std::os::unix::fs::PermissionsExt;
+        let root = tempfile::tempdir().unwrap();
+        let script = root.path().join("tlmgr");
+        let calls = root.path().join("calls");
+        std::fs::write(&script, format!("#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{}'\nif [ \"$1\" = search ]; then\ncat <<'RESULT'\n{}\nRESULT\nelse\nprintf 'Installed\\n'\nfi\n", calls.display(), result)).unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+        (root, script.to_string_lossy().into_owned())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn installation_uses_resolved_package_names_at_the_process_boundary() {
+        let (root, manager) = fake_manager(
+            r#"{"packages":{},"files":{"pgf":["texmf-dist/tex/latex/pgf/tikz.sty"],"caption":["texmf-dist/tex/latex/caption/subcaption.sty"]}}"#,
+        );
+        install_missing_at(&manager, vec!["tikz.sty".into(), "subcaption.sty".into()])
+            .await
+            .unwrap();
+        let calls = std::fs::read_to_string(root.path().join("calls")).unwrap();
+        assert!(calls.starts_with("search\n--global\n--json\n--file\n--\n"));
+        assert!(calls.contains(r"(^|/)(tikz\.sty|subcaption\.sty)$"));
+        assert!(calls.ends_with("install\n--\ncaption\npgf\n"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn missing_template_files_stop_before_any_installation() {
+        let (root, manager) = fake_manager(
+            r#"{"packages":{},"files":{"pgf":["texmf-dist/tex/latex/pgf/tikz.sty"]}}"#,
+        );
+        let error = install_missing_at(&manager, vec!["tikz.sty".into(), "university.cls".into()])
+            .await
+            .unwrap_err();
+        assert!(error.contains("university.cls"));
+        assert!(!std::fs::read_to_string(root.path().join("calls"))
+            .unwrap()
+            .contains("install\n"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -499,6 +499,8 @@ pub fn run() {
             latex_engine::install_tinytex,
             latex_engine::delete_tinytex,
             latex_engine::tlmgr_installed,
+            latex_engine::packages::tlmgr_search,
+            latex_engine::packages::tlmgr_install_missing,
             latex_engine::tlmgr_install,
             latex_engine::tlmgr_remove,
             latex_engine::compile_tagged,

--- a/src-tauri/src/proc/output.rs
+++ b/src-tauri/src/proc/output.rs
@@ -241,19 +241,19 @@ mod tests {
 
     #[test]
     fn steady_progress_outlives_a_deadline_that_would_have_killed_it() {
-        // Five reports at 100ms cross an idle budget of 250ms many times over.
-        // A total cap of the same size would stop this transfer mid-flight.
+        // The idle budget includes Node startup, which is slower under emulation.
+        // Twenty reports at 100ms must keep the command alive beyond that budget.
         let output = output_contained_with_bounds(
             node(
                 "let n=0;const t=setInterval(()=>{process.stderr.write('sending ');\
-                 if(++n===5){clearInterval(t);process.stdout.write('done');process.exit(0)}},100)",
+                 if(++n===20){clearInterval(t);process.stdout.write('done');process.exit(0)}},100)",
             ),
-            OutputBounds::stalled_after(Duration::from_millis(250), Duration::from_secs(30)),
+            OutputBounds::stalled_after(Duration::from_secs(1), Duration::from_secs(30)),
         )
         .unwrap();
         assert!(output.status.success());
         assert_eq!(output.stdout, b"done");
-        assert_eq!(output.stderr, b"sending sending sending sending sending ");
+        assert_eq!(output.stderr, b"sending ".repeat(20));
     }
 
     #[test]

--- a/src/components/settings/EngineSection.packages.test.tsx
+++ b/src/components/settings/EngineSection.packages.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn(), error: vi.fn(), info: vi.fn(), success: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ isTauri: () => true, invoke: mocks.invoke }));
+vi.mock("@/lib/toast", () => ({ toast: { error: mocks.error, info: mocks.info, success: mocks.success } }));
+import { useEngineStore } from "@/store/engine";
+import { EngineSection } from "@/components/settings/EngineSection";
+
+const detail = "tlmgr install: package tikz not present in repository.";
+const engine = {
+  kind: "system" as const,
+  lualatex: "/test/lualatex",
+  tlmgr: "/test/tlmgr",
+  latexmk: "/test/latexmk",
+  version: "test",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.invoke.mockImplementation(async (command: string) => {
+    if (command === "latex_engine_info") return engine;
+    if (command === "tlmgr_installed" || command === "tex_distributions") return [];
+    if (command === "tinytex_install_state") return { partial_download_bytes: 0 };
+    if (command === "tlmgr_install") throw detail;
+    return null;
+  });
+  useEngineStore.setState({
+    info: engine,
+    installed: [],
+    busyPkg: null,
+    loaded: true,
+    installing: false,
+    packageError: null,
+  });
+});
+
+it("preserves the installer failure reason in the visible error", async () => {
+  await useEngineStore.getState().addPackage("tikz");
+  const shown = mocks.error.mock.calls.map((call) => call[0]).join("\n");
+  expect(shown).toContain(detail);
+});
+
+it("uses the TeX Live package owning tikz.sty when the Settings Add button is clicked", async () => {
+  const owner = "pgf";
+  render(<EngineSection />);
+  fireEvent.change(screen.getByPlaceholderText("Filter packages…"), { target: { value: "tikz" } });
+  fireEvent.click(screen.getByRole("button", { name: "Add" }));
+  await waitFor(() => expect(mocks.invoke.mock.calls.some(([cmd]) => cmd === "tlmgr_install")).toBe(true));
+  const actual = mocks.invoke.mock.calls.find(([cmd]) => cmd === "tlmgr_install");
+  expect(actual).toEqual(["tlmgr_install", { packages: [owner] }]);
+});
+
+it("searches TeX Live for packages beyond the suggested list", async () => {
+  mocks.invoke.mockImplementation(async (command: string) => {
+    if (command === "tlmgr_search") return [{ name: "classicthesis", description: "A thesis package" }];
+    if (command === "latex_engine_info") return engine;
+    if (command === "tlmgr_installed" || command === "tex_distributions") return [];
+    return null;
+  });
+  render(<EngineSection />);
+  fireEvent.change(screen.getByPlaceholderText("Filter packages…"), { target: { value: "classicthesis" } });
+  fireEvent.click(screen.getByRole("button", { name: "Search TeX Live" }));
+  await screen.findByText("classicthesis");
+  fireEvent.click(screen.getByRole("button", { name: "Add" }));
+  await waitFor(() =>
+    expect(mocks.invoke).toHaveBeenCalledWith("tlmgr_install", { packages: ["classicthesis"] }),
+  );
+});
+
+it("recognizes installed packages under their TeX Live names and removes the shared package", async () => {
+  mocks.invoke.mockImplementation(async (command: string) => {
+    if (command === "latex_engine_info") return engine;
+    if (command === "tlmgr_installed") return ["pgf", "caption", "tools"];
+    if (command === "tex_distributions") return [];
+    return null;
+  });
+  render(<EngineSection />);
+  fireEvent.change(screen.getByPlaceholderText("Filter packages…"), { target: { value: "tikz" } });
+  await screen.findByRole("button", { name: "Remove" });
+  fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+  await waitFor(() => expect(mocks.invoke).toHaveBeenCalledWith("tlmgr_remove", { packages: ["pgf"] }));
+});
+
+it("disables package changes when the detected distribution has no tlmgr", async () => {
+  const noManager = { ...engine, tlmgr: null };
+  mocks.invoke.mockImplementation(async (command: string) =>
+    command === "latex_engine_info" ? noManager : [],
+  );
+  useEngineStore.setState({ info: noManager });
+  render(<EngineSection />);
+  fireEvent.change(screen.getByPlaceholderText("Filter packages…"), { target: { value: "tikz" } });
+  expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "Search TeX Live" })).toBeDisabled();
+});
+
+it("keeps installer details visible after the toast and supports retry", async () => {
+  render(<EngineSection />);
+  fireEvent.change(screen.getByPlaceholderText("Filter packages…"), { target: { value: "tikz" } });
+  fireEvent.click(screen.getByRole("button", { name: "Add" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent(detail);
+  mocks.invoke.mockImplementation(async (command: string) =>
+    command === "tlmgr_installed" ? ["pgf", "dependency"] : null,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Add" }));
+  await screen.findByRole("button", { name: "Remove" });
+  expect(useEngineStore.getState().installed).toEqual(["pgf", "dependency"]);
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("does not replace a newer search with a stale response", async () => {
+  let resolve!: (value: unknown) => void;
+  const first = new Promise((done) => {
+    resolve = done;
+  });
+  mocks.invoke.mockImplementation(async (command: string, args: { query?: string }) => {
+    if (command === "tlmgr_search")
+      return args.query === "old" ? first : [{ name: "newthesis", description: "New thesis" }];
+    if (command === "latex_engine_info") return engine;
+    if (command === "tex_distributions" || command === "tlmgr_installed") return [];
+    return null;
+  });
+  render(<EngineSection />);
+  const input = screen.getByPlaceholderText("Filter packages…");
+  fireEvent.change(input, { target: { value: "old" } });
+  fireEvent.click(screen.getByRole("button", { name: "Search TeX Live" }));
+  fireEvent.change(input, { target: { value: "new" } });
+  fireEvent.click(screen.getByRole("button", { name: "Search TeX Live" }));
+  await screen.findByText("newthesis");
+  await act(async () => resolve([{ name: "oldthesis", description: "Old" }]));
+  expect(screen.queryByText("oldthesis")).toBeNull();
+  expect(screen.getByText("newthesis")).toBeVisible();
+});
+
+it("does not let an older package-list read hide a newer install error", async () => {
+  let resolve!: (value: string[]) => void;
+  const pending = new Promise<string[]>((done) => {
+    resolve = done;
+  });
+  mocks.invoke.mockImplementation(async (command: string) => {
+    if (command === "tlmgr_installed") return pending;
+    if (command === "tlmgr_install") throw detail;
+    return null;
+  });
+  const refreshing = useEngineStore.getState().refreshPackages();
+  await useEngineStore.getState().addPackage("pgf");
+  resolve(["pgf"]);
+  await refreshing;
+  expect(useEngineStore.getState().packageError).toContain(detail);
+});

--- a/src/components/settings/EngineSection.tsx
+++ b/src/components/settings/EngineSection.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
-import { AlertTriangle, Check, Cpu, Download, HardDrive, Info, Loader2, Trash2, X } from "lucide-react";
+import { AlertTriangle, Check, Cpu, Download, HardDrive, Info, Loader2, Trash2 } from "lucide-react";
 import { installPhaseLabel, useEngineStore } from "@/store/engine";
 import { useSettingsStore, type DefaultLatexEngine } from "@/store/settings";
-import { LATEX_PACKAGES, type TaggingStatus } from "@/lib/latex-packages";
+import { TexPackagesSection } from "./TexPackagesSection";
 import { hasPandoc, texDistributions, type TexDistribution } from "@/lib/tauri";
 import { ensurePandoc } from "@/features/pandoc";
 import { Button } from "@/components/ui/button";
 import { isTauri } from "@tauri-apps/api/core";
 import { Tooltip } from "@/components/ui/tooltip";
-import { Input } from "@/components/ui/input";
 import { ResetToDefaults } from "@/components/settings/ResetToDefaults";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
@@ -44,12 +43,6 @@ function distroTooltip(distro: TexDistribution): string {
       : "No latexmk or tlmgr was found in this install.";
   return `${bundled} Oleafly runs its TeX tools from ${distro.bin_dir}.`;
 }
-
-const TAG_BADGE: Record<TaggingStatus, { label: string; className: string } | null> = {
-  ok: null,
-  caution: { label: "tagging: caution", className: "bg-amber-500/10 text-amber-600 dark:text-amber-400" },
-  breaks: { label: "breaks tagging", className: "bg-red-500/10 text-red-600 dark:text-red-400" },
-};
 
 /**
  * Markdown projects compile through pandoc into LaTeX and then the bundled
@@ -130,14 +123,13 @@ function MarkdownEngineTab() {
 }
 
 export function EngineSection() {
-  const { info, installing, progress, installed, busyPkg, refresh, refreshPackages, install, remove, addPackage, removePackage } =
+  const { info, installing, progress, refresh, refreshPackages, install, remove } =
     useEngineStore();
   const defaultLatexEngine = useSettingsStore((s) => s.defaultLatexEngine);
   const setDefaultLatexEngine = useSettingsStore((s) => s.setDefaultLatexEngine);
   const resetEnginePreferences = useSettingsStore((s) => s.resetEnginePreferences);
   const installPhase = useEngineStore((s) => s.installPhase);
   const partialDownloadBytes = useEngineStore((s) => s.partialDownloadBytes);
-  const [query, setQuery] = useState("");
   const [distros, setDistros] = useState<TexDistribution[]>([]);
   const [tab, setTab] = useState<"latex" | "typst" | "markdown">("latex");
 
@@ -156,10 +148,7 @@ export function EngineSection() {
   }, [installing, info]);
 
   const kind = info?.kind ?? "none";
-  const hasEngine = kind !== "none";
-  const filtered = LATEX_PACKAGES.filter(
-    (p) => p.name.includes(query.toLowerCase()) || p.description.toLowerCase().includes(query.toLowerCase()),
-  );
+
 
   return (
     <Tabs
@@ -370,53 +359,7 @@ export function EngineSection() {
         </div>
       </div>
 
-      <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Packages</h3>
-        {!hasEngine && (
-          <p className="mb-2 text-xs text-muted-foreground">Install an engine above to add or remove LaTeX packages.</p>
-        )}
-        <Input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Filter packages…"
-          className="mb-2 w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-ring"
-        />
-        <div className="max-h-72 overflow-auto rounded-md border">
-          {filtered.map((p) => {
-            const on = installed.includes(p.name);
-            const badge = TAG_BADGE[p.tagging];
-            const busy = busyPkg === p.name;
-            return (
-              <div key={p.name} className="flex items-center gap-2 border-b px-2.5 py-2 last:border-b-0">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-xs">{p.name}</span>
-                    {on && <Check className="size-3 text-emerald-500" />}
-                    {badge && (
-                      <span className={cn("inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px]", badge.className)}>
-                        {p.tagging === "breaks" && <AlertTriangle className="size-2.5" />}
-                        {badge.label}
-                      </span>
-                    )}
-                  </div>
-                  <p className="truncate text-[11px] text-muted-foreground">{p.description}</p>
-                </div>
-                <button type="button"
-                  onClick={() => void (on ? removePackage(p.name) : addPackage(p.name))}
-                  disabled={!hasEngine || !!busyPkg}
-                  className={cn(
-                    "inline-flex w-16 items-center justify-center gap-1 rounded border px-2 py-1 text-xs disabled:opacity-40",
-                    "border-input hover:bg-accent",
-                  )}
-                >
-                  {busy ? <Loader2 className="size-3 animate-spin" /> : on ? <X className="size-3" /> : null}
-                  {busy ? "" : on ? "Remove" : "Add"}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      <TexPackagesSection />
       </TabsContent>
       <ResetToDefaults
         sectionName="Engines"

--- a/src/components/settings/TexPackagesSection.tsx
+++ b/src/components/settings/TexPackagesSection.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from "react";
+import { AlertTriangle, Check, Loader2, X } from "lucide-react";
+import { LATEX_PACKAGES, type TaggingStatus } from "@/lib/latex-packages";
+import { tlmgrSearch, type TexPackage } from "@/lib/tauri";
+import { useEngineStore } from "@/store/engine";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+const TAG_BADGE: Record<TaggingStatus, { label: string; className: string } | null> = {
+  ok: null,
+  caution: { label: "tagging: caution", className: "bg-amber-500/10 text-amber-600 dark:text-amber-400" },
+  breaks: { label: "breaks tagging", className: "bg-red-500/10 text-red-600 dark:text-red-400" },
+};
+
+export function TexPackagesSection() {
+  const { info, installed, busyPkg, packageError, addPackage, removePackage, refreshPackages } =
+    useEngineStore();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<TexPackage[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const requestId = useRef(0);
+  const available = !!info?.tlmgr;
+
+  useEffect(() => {
+    if (!info?.tlmgr) setQuery("");
+    requestId.current += 1;
+    setResults(null);
+    setSearchError(null);
+    setSearching(false);
+    return () => {
+      requestId.current += 1;
+    };
+  }, [info?.tlmgr]);
+
+  const search = async () => {
+    if (!available || searching || query.trim().length < 2) return;
+    const request = ++requestId.current;
+    setSearching(true);
+    setSearchError(null);
+    try {
+      const packages = await tlmgrSearch(query.trim());
+      if (request === requestId.current) setResults(packages);
+    } catch (error) {
+      if (request === requestId.current) {
+        const detail = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+        setSearchError(detail || "Could not search TeX Live. Try again.");
+      }
+    } finally {
+      if (request === requestId.current) setSearching(false);
+    }
+  };
+
+  const normalized = query.toLowerCase().trim();
+  const rows =
+    results?.map((p) => ({ ...p, texLivePackage: p.name, tagging: undefined })) ??
+    LATEX_PACKAGES.filter(
+      (p) =>
+        p.name.includes(normalized) ||
+        p.description.toLowerCase().includes(normalized) ||
+        p.texLivePackage?.includes(normalized),
+    );
+
+  return (
+    <section aria-label="LaTeX packages">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Packages</h3>
+      <p className="mb-2 text-xs text-muted-foreground">
+        {available
+          ? "These packages are for projects using latexmk (system TeX). Tectonic uses its own package bundle."
+          : "Package management requires TeX Live or TinyTeX. For MiKTeX, use MiKTeX Console."}
+      </p>
+      <form
+        className="mb-2 flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void search();
+        }}
+      >
+        <Input
+          value={query}
+          onChange={(event) => {
+            requestId.current += 1;
+            setQuery(event.target.value);
+            setResults(null);
+            setSearchError(null);
+            setSearching(false);
+          }}
+          placeholder="Filter packages…"
+          aria-label="Find LaTeX packages"
+          maxLength={128}
+          className="min-w-0 flex-1"
+        />
+        <Button
+          type="submit"
+          variant="outline"
+          size="sm"
+          disabled={!available || searching || !!busyPkg || normalized.length < 2}
+        >
+          {searching ? "Searching…" : "Search TeX Live"}
+        </Button>
+      </form>
+      {(searchError || packageError) && (
+        <div role="alert" className="mb-2 rounded-md border border-destructive/30 p-2 text-xs">
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words font-sans">
+            {searchError || packageError}
+          </pre>
+          {packageError && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={!!busyPkg || searching}
+              onClick={() => void refreshPackages()}
+            >
+              Refresh installed packages
+            </Button>
+          )}
+        </div>
+      )}
+      <p className="mb-2 text-xs text-muted-foreground">
+        {results
+          ? `${results.length} TeX Live results${results.length === 200 ? ". Use a more specific search to narrow this list." : "."}`
+          : "Suggested packages. Search TeX Live for more."}
+      </p>
+      <div className="max-h-72 overflow-auto rounded-md border">
+        {rows.length === 0 && (
+          <p className="p-3 text-xs text-muted-foreground">
+            {results
+              ? "No packages found. Try another name or keyword."
+              : "No suggested packages match. Search TeX Live to check the full catalog."}
+          </p>
+        )}
+        {rows.map((p) => {
+          const packageName = p.texLivePackage ?? p.name;
+          const on = installed.includes(packageName);
+          const badge = p.tagging ? TAG_BADGE[p.tagging] : null;
+          const busy = busyPkg === packageName;
+          return (
+            <div key={p.name} className="flex items-center gap-2 border-b px-2.5 py-2 last:border-b-0">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-xs">{p.name}</span>
+                  {on && <Check className="size-3 text-emerald-500" />}
+                  {badge && (
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px]",
+                        badge.className,
+                      )}
+                    >
+                      {p.tagging === "breaks" && <AlertTriangle className="size-2.5" />}
+                      {badge.label}
+                    </span>
+                  )}
+                </div>
+                <p className="truncate text-[11px] text-muted-foreground">{p.description}</p>
+                {packageName !== p.name && (
+                  <p className="text-[11px] text-muted-foreground">
+                    Included in {packageName}. Removing it also removes the other files in that package.
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchError(null);
+                  void (on ? removePackage(packageName) : addPackage(packageName));
+                }}
+                disabled={!available || !!busyPkg || searching}
+                className="inline-flex w-16 items-center justify-center gap-1 rounded border border-input px-2 py-1 text-xs hover:bg-accent disabled:opacity-40"
+              >
+                {busy ? <Loader2 className="size-3 animate-spin" /> : on ? <X className="size-3" /> : null}
+                {busy ? "" : on ? "Remove" : "Add"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/ai/AcpAgentsTab.tsx
+++ b/src/components/settings/ai/AcpAgentsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -20,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { appModalCoordinator } from "@/components/ui/use-modal-accessibility";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -197,7 +198,7 @@ function AgentCard({
   agent: AcpAgentStatus;
   projectId?: string | null;
   busy: string | null;
-  onInstall: (definition: AcpDefinition) => void;
+  onInstall: (definition: AcpDefinition, opener: HTMLButtonElement) => void;
   onRemove: (agentId: string) => void;
   onOpenTerminal: () => void;
 }) {
@@ -288,7 +289,7 @@ function AgentCard({
                 size="sm"
                 data-testid={`acp-agent-install-${agent.definition.id}`}
                 disabled={!!busy || !agent.canInstall}
-                onClick={() => onInstall(agent.definition)}
+                onClick={(event) => onInstall(agent.definition, event.currentTarget)}
               >
                 {installing ? (
                   <Loader2 className="size-3.5 animate-spin" />
@@ -326,6 +327,13 @@ export function AcpAgentsTab({ projectId }: { projectId?: string | null }) {
   const [results, setResults] = useState<AcpRegistryEntry[]>([]);
   const [definition, setDefinition] = useState("");
   const [review, setReview] = useState<AcpDefinition | null>(null);
+  const reviewOpener = useRef<HTMLElement | null>(null);
+  const reviewing = review !== null;
+  useEffect(() => {
+    if (!reviewing) return;
+    const id = appModalCoordinator.add(reviewOpener.current);
+    return () => { appModalCoordinator.remove(id)?.focus({ preventScroll: true }); };
+  }, [reviewing]);
 
   useEffect(() => {
     void useAcpSessionsStore
@@ -425,7 +433,11 @@ export function AcpAgentsTab({ projectId }: { projectId?: string | null }) {
             agent={agent}
             projectId={projectId}
             busy={busy}
-            onInstall={setReview}
+            onInstall={(definition, opener) => {
+              reviewOpener.current = opener;
+              setError(null);
+              setReview(definition);
+            }}
             onOpenTerminal={openTerminal}
             onRemove={(agentId) =>
               void action(agentId, async () => {
@@ -533,8 +545,15 @@ export function AcpAgentsTab({ projectId }: { projectId?: string | null }) {
         </form>
       </Section>
 
-      <Dialog open={review !== null} onOpenChange={(open) => !open && setReview(null)}>
-        <DialogContent className="max-w-md">
+      <Dialog open={reviewing} onOpenChange={(open) => { if (!open && !busy) setReview(null); }}>
+        <DialogContent
+          className="z-[100] max-w-md"
+          overlayClassName="z-[100]"
+          closeDisabled={!!busy}
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          onEscapeKeyDown={(event) => { if (busy) event.preventDefault(); }}
+          onPointerDownOutside={(event) => { if (busy) event.preventDefault(); }}
+        >
           <DialogHeader>
             <DialogTitle>
               Install {review?.name} bridge {review?.version}

--- a/src/lib/latex-packages.ts
+++ b/src/lib/latex-packages.ts
@@ -13,6 +13,7 @@ export type TaggingStatus = "ok" | "caution" | "breaks";
 export interface LatexPackage {
   name: string;
   description: string;
+  texLivePackage?: string;
   scope: PkgScope;
   defaultOn: boolean;
   tagging: TaggingStatus;
@@ -20,18 +21,18 @@ export interface LatexPackage {
 
 export const LATEX_PACKAGES: LatexPackage[] = [
   { name: "amsmath", description: "Advanced math typesetting", scope: "all", defaultOn: true, tagging: "ok" },
-  { name: "amssymb", description: "Extended math symbols", scope: "all", defaultOn: true, tagging: "ok" },
+  { name: "amssymb", texLivePackage: "amsfonts", description: "Extended math symbols", scope: "all", defaultOn: true, tagging: "ok" },
   { name: "mathtools", description: "amsmath superset with fixes and tools", scope: "all", defaultOn: false, tagging: "ok" },
-  { name: "amsthm", description: "Theorem and proof environments", scope: "pdf", defaultOn: false, tagging: "ok" },
+  { name: "amsthm", texLivePackage: "amscls", description: "Theorem and proof environments", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "unicode-math", description: "Unicode math for Xe/LuaLaTeX (required for tagged math)", scope: "pdf", defaultOn: false, tagging: "ok" },
-  { name: "graphicx", description: "Include graphics and images", scope: "all", defaultOn: true, tagging: "ok" },
+  { name: "graphicx", texLivePackage: "graphics", description: "Include graphics and images", scope: "all", defaultOn: true, tagging: "ok" },
   { name: "hyperref", description: "Hyperlinks, bookmarks, and PDF metadata", scope: "pdf", defaultOn: true, tagging: "ok" },
   { name: "bookmark", description: "Improved PDF bookmarks", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "geometry", description: "Page layout customization", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "booktabs", description: "Professional table rules", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "xcolor", description: "Color support", scope: "all", defaultOn: true, tagging: "ok" },
   { name: "listings", description: "Code listings (not compatible with tagging)", scope: "pdf", defaultOn: false, tagging: "breaks" },
-  { name: "tikz", description: "Programmable vector graphics (needs manual alt text)", scope: "pdf", defaultOn: false, tagging: "caution" },
+  { name: "tikz", texLivePackage: "pgf", description: "Programmable vector graphics (needs manual alt text)", scope: "pdf", defaultOn: false, tagging: "caution" },
   { name: "algorithm2e", description: "Algorithm typesetting", scope: "pdf", defaultOn: false, tagging: "caution" },
   { name: "biblatex", description: "Advanced bibliography support", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "natbib", description: "Author-year and numeric citations", scope: "pdf", defaultOn: false, tagging: "ok" },
@@ -43,13 +44,13 @@ export const LATEX_PACKAGES: LatexPackage[] = [
   { name: "enumitem", description: "List customization", scope: "all", defaultOn: true, tagging: "ok" },
   { name: "fancyhdr", description: "Custom headers and footers", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "caption", description: "Caption customization (some versions break tagging)", scope: "pdf", defaultOn: false, tagging: "caution" },
-  { name: "subcaption", description: "Subfigures and subtables", scope: "pdf", defaultOn: false, tagging: "caution" },
+  { name: "subcaption", texLivePackage: "caption", description: "Subfigures and subtables", scope: "pdf", defaultOn: false, tagging: "caution" },
   { name: "float", description: "Improved float placement", scope: "pdf", defaultOn: false, tagging: "ok" },
-  { name: "array", description: "Extended array and tabular", scope: "all", defaultOn: true, tagging: "ok" },
-  { name: "tabularx", description: "Auto-width tables", scope: "pdf", defaultOn: false, tagging: "ok" },
+  { name: "array", texLivePackage: "tools", description: "Extended array and tabular", scope: "all", defaultOn: true, tagging: "ok" },
+  { name: "tabularx", texLivePackage: "tools", description: "Auto-width tables", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "multirow", description: "Multi-row table cells", scope: "pdf", defaultOn: false, tagging: "caution" },
   { name: "url", description: "URL typesetting", scope: "all", defaultOn: true, tagging: "ok" },
-  { name: "inputenc", description: "Input encoding (unnecessary on Xe/LuaLaTeX)", scope: "pdf", defaultOn: false, tagging: "ok" },
+  { name: "inputenc", texLivePackage: "latex", description: "Input encoding (unnecessary on Xe/LuaLaTeX)", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "babel", description: "Multilingual support and document language", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "setspace", description: "Line spacing control", scope: "pdf", defaultOn: false, tagging: "ok" },
   { name: "parskip", description: "Paragraph spacing", scope: "pdf", defaultOn: false, tagging: "ok" },

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -725,6 +725,13 @@ export const confirmQuitFlush = (restart: boolean) =>
 // The user chose to stay after a blocked quit; the next quit flushes again.
 export const cancelQuitFlush = () => invoke<void>("cancel_quit_flush");
 export const deleteTinytex = () => invoke<void>("delete_tinytex");
+export interface TexPackage {
+  name: string;
+  description: string;
+}
+
+export const tlmgrSearch = (query: string) => invoke<TexPackage[]>("tlmgr_search", { query });
+export const tlmgrInstallMissing = (files: string[]) => invoke<string>("tlmgr_install_missing", { files });
 export const tlmgrInstalled = () => invoke<string[]>("tlmgr_installed");
 export const tlmgrInstall = (packages: string[]) => invoke<string>("tlmgr_install", { packages });
 export const tlmgrRemove = (packages: string[]) => invoke<string>("tlmgr_remove", { packages });

--- a/src/store/compile.test.ts
+++ b/src/store/compile.test.ts
@@ -3,6 +3,10 @@ import { LATEX_ENGINE } from "@/lib/document-engine";
 import type { CompileResult, LogDiagnostic } from "@oleafly/backend-port";
 
 const mocks = vi.hoisted(() => ({
+  latexEngineInfo: vi.fn(),
+  tlmgrInstallMissing: vi.fn(),
+  toastInfo: vi.fn(),
+  refreshPackages: vi.fn(),
   events: new Map<string, (event: { payload: string }) => void>(),
   listen: vi.fn(
     async (name: string, handler: (event: { payload: string }) => void) => {
@@ -59,6 +63,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/tauri", () => ({
+  latexEngineInfo: mocks.latexEngineInfo,
+  tlmgrInstallMissing: mocks.tlmgrInstallMissing,
   compileProject: mocks.compileProject,
   readCompiledPdf: mocks.readCompiledPdf,
   validateCompileFingerprint: mocks.validateCompileFingerprint,
@@ -87,8 +93,9 @@ vi.mock("@/store/project-index", () => ({
 vi.mock("@/store/settings", () => ({ useSettingsStore: { getState: () => mocks.settings } }));
 vi.mock("@/lib/toast", () => ({
   notifyError: vi.fn(),
-  toast: { errorUnique: vi.fn() },
+  toast: { errorUnique: vi.fn(), info: mocks.toastInfo },
 }));
+vi.mock("@/store/engine", () => ({ useEngineStore: { getState: () => ({ refreshPackages: mocks.refreshPackages }) } }));
 vi.mock("@/lib/log", () => ({ logError: vi.fn() }));
 vi.mock("@/lib/preview-window", () => ({
   refreshPreviewWindow: mocks.refreshPreviewWindow,
@@ -921,5 +928,62 @@ describe("compile log diagnostics", () => {
     useCompileStore.setState({ diagnostics: [diagnostic] });
     useCompileStore.getState().reset();
     expect(useCompileStore.getState().diagnostics).toBeNull();
+  });
+});
+
+describe("missing TeX file installation", () => {
+  let project = 0;
+  beforeEach(() => {
+    mocks.files.projectId = `missing-packages-${++project}`;
+    mocks.files.engine = { ...LATEX_ENGINE, id: "latexmk" };
+    mocks.latexEngineInfo.mockReset().mockResolvedValue({ tlmgr: "/tex/tlmgr" });
+    mocks.tlmgrInstallMissing.mockReset().mockResolvedValue("installed");
+    mocks.refreshPackages.mockReset().mockResolvedValue(undefined);
+    mocks.toastInfo.mockReset();
+    mocks.compileProject.mockResolvedValue({ ok: false, has_pdf: false, output_id: null, output_revision: null, log: "! LaTeX Error: File `tikz.sty' not found.", errors: [], synctex_path: null, out_dir: null, compile_time_ms: 1 });
+  });
+
+  async function offer() {
+    await useCompileStore.getState().recompile();
+    await vi.waitFor(() => expect(mocks.toastInfo).toHaveBeenCalled());
+    return mocks.toastInfo.mock.calls.find((call) => call[1]?.onClick)?.[1] as { onClick: () => void };
+  }
+
+  it("sends filenames to the resolver and recompiles only after installation", async () => {
+    const action = await offer();
+    const install = deferred<string>();
+    mocks.tlmgrInstallMissing.mockReturnValue(install.promise);
+    action.onClick();
+    action.onClick();
+    expect(mocks.tlmgrInstallMissing).toHaveBeenCalledExactlyOnceWith(["tikz.sty"]);
+    expect(mocks.compileProject).toHaveBeenCalledTimes(1);
+    install.resolve("installed");
+    await vi.waitFor(() => expect(mocks.compileProject).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not compile a different project after an installation finishes", async () => {
+    const action = await offer();
+    const install = deferred<string>();
+    mocks.tlmgrInstallMissing.mockReturnValue(install.promise);
+    action.onClick();
+    mocks.files.projectId = "other-project";
+    install.resolve("installed");
+    await vi.waitFor(() => expect(mocks.refreshPackages).toHaveBeenCalled());
+    await vi.dynamicImportSettled();
+    expect(mocks.compileProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers a retry after failure and ignores an action from another project", async () => {
+    const action = await offer();
+    mocks.tlmgrInstallMissing.mockRejectedValueOnce("Repository unavailable");
+    action.onClick();
+    await vi.waitFor(() => expect(mocks.tlmgrInstallMissing).toHaveBeenCalled());
+    await vi.dynamicImportSettled();
+    mocks.toastInfo.mockClear();
+    const retry = await offer();
+    expect(retry).toBeDefined();
+    mocks.files.projectId = "another-project";
+    retry.onClick();
+    expect(mocks.tlmgrInstallMissing).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/store/compile.ts
+++ b/src/store/compile.ts
@@ -16,7 +16,7 @@ import { engineHintDismissed, useEnginePickerStore } from "@/store/engine-picker
 import {
   classifyCompileFailure,
   importCompatFinding,
-  missingLatexPackages,
+  missingLatexFiles,
 } from "@oleafly/latex";
 import { useProjectAnalysisStore } from "@/store/project-analysis";
 import { useSettingsStore } from "@/store/settings";
@@ -406,25 +406,29 @@ function maybeSuggestMissingPackages(log: string): void {
   const files = useFilesStore.getState();
   const projectId = files.projectId;
   if (files.engine.id !== "latexmk" || !projectId) return;
-  const packages = missingLatexPackages(log);
+  const packages = missingLatexFiles(log);
   if (packages.length === 0) return;
   const signature = packageSuggestionSignature(packages);
   if (suggestedPackagesByProject.get(projectId) === signature) return;
-  suggestedPackagesByProject.set(projectId, signature);
   void (async () => {
     const tauri = await import("@/lib/tauri");
     const info = await tauri.latexEngineInfo().catch(() => null);
-    if (!info?.tlmgr) return; // MiKTeX installs on the fly; nothing to offer
-    const label = packages.length === 1 ? `Install ${packages[0]}` : `Install all ${packages.length}`;
+    if (!info?.tlmgr || useFilesStore.getState().projectId !== projectId || useFilesStore.getState().engine.id !== "latexmk") return;
+    if (suggestedPackagesByProject.get(projectId) === signature) return;
+    suggestedPackagesByProject.set(projectId, signature);
+    const label = packages.length === 1 ? `Find and install ${packages[0]}` : `Find and install ${packages.length} files`;
     const summary =
       packages.length === 1
-        ? `The compile needs the LaTeX package "${packages[0]}", which is not installed.`
-        : `The compile needs ${packages.length} LaTeX packages that are not installed (${packages.join(", ")}).`;
+        ? `The compile could not find "${packages[0]}". Look for the package that provides it in TeX Live.`
+        : `The compile could not find ${packages.join(", ")}. Look for their packages in TeX Live.`;
+    let installing = false;
     toast.info(
       summary,
       {
         label,
         onClick: () => {
+          if (installing || useFilesStore.getState().projectId !== projectId || useFilesStore.getState().engine.id !== "latexmk") return;
+          installing = true;
           void (async () => {
             toast.info(
               packages.length === 1
@@ -432,15 +436,18 @@ function maybeSuggestMissingPackages(log: string): void {
                 : `Installing ${packages.length} packages. The compile restarts when they finish.`,
             );
             try {
-              await tauri.tlmgrInstall(packages);
+              await tauri.tlmgrInstallMissing(packages);
+              const engineStore = await import("@/store/engine");
+              await engineStore.useEngineStore.getState().refreshPackages();
               suggestedPackagesByProject.delete(projectId);
-              void useCompileStore.getState().recompile();
+              if (useFilesStore.getState().projectId === projectId && useFilesStore.getState().engine.id === "latexmk") {
+                void useCompileStore.getState().recompile();
+              }
             } catch (error) {
-              notifyError(
-                "install missing packages",
-                error,
-                "The packages could not be installed. See Settings, LaTeX Engine for details.",
-              );
+              suggestedPackagesByProject.delete(projectId);
+              notifyError("install missing packages", error);
+            } finally {
+              installing = false;
             }
           })();
         },

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -14,6 +14,13 @@ import {
 import { toast } from "@/lib/toast";
 import { logError } from "@/lib/log";
 
+function packageErrorMessage(error: unknown, fallback: string): string {
+  const detail = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return detail.trim() ? `${fallback} ${detail.trim()}` : fallback;
+}
+
+let packageReadRequest = 0;
+
 export type InstallPhase = "download" | "extract" | "packages";
 
 interface EngineStore {
@@ -31,6 +38,7 @@ interface EngineStore {
   installWaitNoticeOpen: boolean;
   installed: string[];
   busyPkg: string | null;
+  packageError: string | null;
   loaded: boolean;
   refresh: () => Promise<void>;
   ensureLoaded: () => Promise<void>;
@@ -53,6 +61,7 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
   installWaitNoticeOpen: false,
   installed: [],
   busyPkg: null,
+  packageError: null,
   loaded: false,
 
   refresh: async () => {
@@ -79,10 +88,21 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
 
   refreshPackages: async () => {
     if (!isTauri()) return;
+    const request = ++packageReadRequest;
+    const manager = get().info?.tlmgr;
+    if (!manager) {
+      set({ installed: [], packageError: null });
+      return;
+    }
     try {
-      set({ installed: await tlmgrInstalled() });
-    } catch {
-      // tlmgr may be unavailable (no engine); leave the list empty
+      const installed = await tlmgrInstalled();
+      if (request === packageReadRequest && get().info?.tlmgr === manager) {
+        set({ installed, packageError: null });
+      }
+    } catch (error) {
+      if (request === packageReadRequest && get().info?.tlmgr === manager) {
+        set({ installed: [], packageError: packageErrorMessage(error, "Could not read the installed packages.") });
+      }
     }
   },
 
@@ -161,13 +181,16 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
 
   addPackage: async (name) => {
     if (!isTauri() || get().busyPkg) return;
-    set({ busyPkg: name });
+    packageReadRequest += 1;
+    set({ busyPkg: name, packageError: null });
     try {
       await tlmgrInstall([name]);
-      set((s) => ({ installed: [...s.installed, name] }));
+      await get().refreshPackages();
     } catch (e) {
       void logError("tlmgr install", e);
-      toast.error(`Could not install ${name}`);
+      const message = packageErrorMessage(e, `Could not install ${name}.`);
+      set({ packageError: message });
+      toast.error(message);
     } finally {
       set({ busyPkg: null });
     }
@@ -175,13 +198,16 @@ export const useEngineStore = create<EngineStore>((set, get) => ({
 
   removePackage: async (name) => {
     if (!isTauri() || get().busyPkg) return;
-    set({ busyPkg: name });
+    packageReadRequest += 1;
+    set({ busyPkg: name, packageError: null });
     try {
       await tlmgrRemove([name]);
-      set((s) => ({ installed: s.installed.filter((p) => p !== name) }));
+      await get().refreshPackages();
     } catch (e) {
       void logError("tlmgr remove", e);
-      toast.error(`Could not remove ${name}`);
+      const message = packageErrorMessage(e, `Could not remove ${name}.`);
+      set({ packageError: message });
+      toast.error(message);
     } finally {
       set({ busyPkg: null });
     }


### PR DESCRIPTION
LaTeX package installation now finds the TeX Live package that provides a missing `.sty` or `.cls` file. For example, `tikz.sty` installs `pgf`. Settings searches the full TeX Live catalog, keeps installer errors visible for retry, and refreshes the installed list after changes. Files that TeX Live cannot supply get a clear error with guidance for template files.

The CLI bridge confirmation now appears above Settings. Keyboard focus stays in the confirmation and returns to the install button when cancelled. The dialog stays open during installation, and failures leave it ready for retry.

Validation:

- Regression tests cover package lookup, shared package names, stale responses, errors, retries, and recompilation after installation.
- Four browser tests pass across Chromium and WebKit using the real Settings UI with controlled native-command responses.
- macOS: 4,046 frontend tests pass across 448 files; typechecking, the production build, lint, bundle-size budgets, and all three editor-performance tests pass. Lint reports the existing PanelLayout dependency warning.
- Rust 1.98.1: the full workspace passes on macOS (1,810 tests) and Ubuntu 22.04 amd64 (1,807 tests), with four ignored on each platform. Formatting and Clippy pass on both.
- Linux: 4,046 frontend tests pass with coverage. The production build, lint, bundle-size budgets, and all three editor-performance tests pass.

The process output regression test also allows for slower Node startup under emulation. It still verifies that regular output keeps the process alive beyond its idle timeout.

Linux checks ran under amd64 emulation with three frontend workers, four Rust test threads, and a 4 GiB Node heap allowance. Native Windows installation and hosted CI remain to be verified.

Fixes #147.
Fixes #146.
