### PR TITLE
ci: eight-way Linux and Windows e2e shards, a Windows e2e build job, and a packaged-app cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -973,6 +973,57 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  e2e-browser-harness:
+    # The four browser-harness specs drive Playwright's own Chromium against
+    # fixture pages that Vite serves from e2e/, with the Tauri bridge mocked
+    # inside the page. They need no app build, and every packaged shard skips
+    # them, so this lane is where they run now that Windows no longer runs the
+    # suite under `tauri dev`.
+    name: E2E (browser harness, Linux)
+    needs: frontend
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browser
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run the browser-harness specs
+        env:
+          CI: 1
+        run: bash scripts/e2e-browser-harness.sh
+
+      - name: Upload failure artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-test-results-browser-harness
+          path: |
+            test-results/**/error-context.md
+            test-results/**/trace.zip
+            test-results/**/*.log
+          if-no-files-found: ignore
+          retention-days: 3
+
   e2e-build-windows:
     # Builds the Windows e2e app once. Until now every Windows shard ran
     # `pnpm tauri dev`, which compiled the whole app before its first test, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The packaged app depends only on the sources listed here. When none of
+      # them changed since a cached build, the packed app is restored and the
+      # compile is skipped, which turns a spec-only or scripts-only push into a
+      # download instead of a build.
+      - name: Compute the packaged app cache key
+        id: e2e-app-key
+        run: echo "key=e2e-app-macos-v1-${{ hashFiles('src/**', 'packages/**', 'crates/**', 'vendor/**', 'src-tauri/src/**', 'src-tauri/Cargo.toml', 'src-tauri/build.rs', 'src-tauri/tauri.conf.json', 'src-tauri/capabilities/**', 'src-tauri/resources/**', 'src-tauri/icons/**', 'Cargo.toml', 'Cargo.lock', 'package.json', 'pnpm-lock.yaml', 'vite.config.ts', 'tsconfig.json', 'index.html', 'public/**', 'patches/**', 'scripts/fetch-tectonic.sh', 'scripts/fetch-biber.sh', 'scripts/fetch-typst.sh', 'scripts/fetch-language-servers.mjs', 'scripts/tauri-sandbox.mjs') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the packed app from the cache
+        id: e2e-app-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: oleafly-e2e-macos.tar.gz
+          key: ${{ steps.e2e-app-key.outputs.key }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -449,6 +464,7 @@ jobs:
           workspaces: . -> src-tauri/target
 
       - name: Cache Tectonic sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         id: cache-tectonic-e2e-build
         uses: actions/cache@v6
         with:
@@ -456,10 +472,11 @@ jobs:
           key: tectonic-${{ runner.os }}-${{ hashFiles('scripts/fetch-tectonic.sh') }}
 
       - name: Fetch Tectonic sidecar
-        if: steps.cache-tectonic-e2e-build.outputs.cache-hit != 'true'
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-tectonic-e2e-build.outputs.cache-hit != 'true'
         run: bash scripts/fetch-tectonic.sh aarch64-apple-darwin
 
       - name: Cache Biber sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         id: cache-biber-e2e-build
         uses: actions/cache@v6
         with:
@@ -467,10 +484,11 @@ jobs:
           key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
 
       - name: Fetch Biber sidecar
-        if: steps.cache-biber-e2e-build.outputs.cache-hit != 'true'
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-biber-e2e-build.outputs.cache-hit != 'true'
         run: bash scripts/fetch-biber.sh aarch64-apple-darwin
 
       - name: Cache Typst sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         id: cache-typst-e2e-build
         uses: actions/cache@v6
         with:
@@ -478,10 +496,11 @@ jobs:
           key: typst-${{ runner.os }}-${{ hashFiles('scripts/fetch-typst.sh') }}
 
       - name: Fetch Typst sidecar
-        if: steps.cache-typst-e2e-build.outputs.cache-hit != 'true'
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-typst-e2e-build.outputs.cache-hit != 'true'
         run: bash scripts/fetch-typst.sh aarch64-apple-darwin
 
       - name: Stage checksum-pinned Tinymist resource archive
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         run: node scripts/fetch-language-servers.mjs --server tinymist --target aarch64-apple-darwin --install-mode resource
 
       # Third-platform coverage for the shared crates, moved here from the
@@ -490,12 +509,21 @@ jobs:
         run: cargo test -p oleafly-core -p oleafly-cli --all-targets
 
       - name: Build the packaged e2e app
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         env:
           VITE_E2E_HOOKS: "1"
         run: pnpm tauri build --debug --features e2e-testing --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Pack the app bundle
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         run: tar -czf oleafly-e2e-macos.tar.gz -C src-tauri/target/debug/bundle/macos Oleafly.app
+
+      - name: Save the packed app to the cache
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: oleafly-e2e-macos.tar.gz
+          key: ${{ steps.e2e-app-key.outputs.key }}
 
       - name: Upload the app bundle
         uses: actions/upload-artifact@v7
@@ -530,7 +558,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The packaged app depends only on the sources listed here. When none of
+      # them changed since a cached build, the packed app is restored and the
+      # compile is skipped, which turns a spec-only or scripts-only push into a
+      # download instead of a build.
+      - name: Compute the packaged app cache key
+        id: e2e-app-key
+        run: echo "key=e2e-app-linux-v1-${{ hashFiles('src/**', 'packages/**', 'crates/**', 'vendor/**', 'src-tauri/src/**', 'src-tauri/Cargo.toml', 'src-tauri/build.rs', 'src-tauri/tauri.conf.json', 'src-tauri/capabilities/**', 'src-tauri/resources/**', 'src-tauri/icons/**', 'Cargo.toml', 'Cargo.lock', 'package.json', 'pnpm-lock.yaml', 'vite.config.ts', 'tsconfig.json', 'index.html', 'public/**', 'patches/**', 'scripts/fetch-tectonic.sh', 'scripts/fetch-biber.sh', 'scripts/fetch-typst.sh', 'scripts/fetch-language-servers.mjs', 'scripts/tauri-sandbox.mjs') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the packed app from the cache
+        id: e2e-app-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: oleafly-e2e-linux.deb
+          key: ${{ steps.e2e-app-key.outputs.key }}
+
       - name: Install Linux system dependencies (Tauri)
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -543,14 +587,17 @@ jobs:
             curl wget file
 
       - name: Install Rust toolchain
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> src-tauri/target
 
       - name: Cache Tectonic sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         id: cache-tectonic-e2e-build-linux
         uses: actions/cache@v6
         with:
@@ -558,10 +605,11 @@ jobs:
           key: tectonic-${{ runner.os }}-${{ hashFiles('scripts/fetch-tectonic.sh') }}
 
       - name: Fetch Tectonic sidecar
-        if: steps.cache-tectonic-e2e-build-linux.outputs.cache-hit != 'true'
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-tectonic-e2e-build-linux.outputs.cache-hit != 'true'
         run: bash scripts/fetch-tectonic.sh x86_64-unknown-linux-gnu
 
       - name: Cache Biber sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         id: cache-biber-e2e-build-linux
         uses: actions/cache@v6
         with:
@@ -569,10 +617,11 @@ jobs:
           key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
 
       - name: Fetch Biber sidecar
-        if: steps.cache-biber-e2e-build-linux.outputs.cache-hit != 'true'
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-biber-e2e-build-linux.outputs.cache-hit != 'true'
         run: bash scripts/fetch-biber.sh x86_64-unknown-linux-gnu
 
       - name: Cache Typst sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         id: cache-typst-e2e-build-linux
         uses: actions/cache@v6
         with:
@@ -580,16 +629,19 @@ jobs:
           key: typst-${{ runner.os }}-${{ hashFiles('scripts/fetch-typst.sh') }}
 
       - name: Fetch Typst sidecar
-        if: steps.cache-typst-e2e-build-linux.outputs.cache-hit != 'true'
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-typst-e2e-build-linux.outputs.cache-hit != 'true'
         run: bash scripts/fetch-typst.sh x86_64-unknown-linux-gnu
 
       - name: Smoke-test Typst sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         run: bash scripts/smoke-typst.sh x86_64-unknown-linux-gnu
 
       - name: Stage checksum-pinned Tinymist resource archive
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         run: node scripts/fetch-language-servers.mjs --server tinymist --target x86_64-unknown-linux-gnu --install-mode resource
 
       - name: Build the packaged e2e app
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         env:
           VITE_E2E_HOOKS: "1"
         run: pnpm tauri build --debug --features e2e-testing --bundles deb --config '{"bundle":{"createUpdaterArtifacts":false}}'
@@ -598,6 +650,7 @@ jobs:
       # is cheap to read. If a future Tauri release moves the binary or the
       # sidecars, this listing is the first place that shows it.
       - name: Stage and describe the package
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           deb="$(find src-tauri/target/debug/bundle/deb -name '*.deb' -print -quit)"
@@ -617,6 +670,13 @@ jobs:
           echo "--- libexec, resources, sidecars (first 25) ---"
           grep -E '/lib/' deb-contents.txt | sed -n '1,25p' || echo "(none matched /lib/)"
           echo "--- $(wc -l < deb-contents.txt) entries total ---"
+
+      - name: Save the packed app to the cache
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: oleafly-e2e-linux.deb
+          key: ${{ steps.e2e-app-key.outputs.key }}
 
       - name: Upload the app package
         uses: actions/upload-artifact@v7
@@ -759,12 +819,12 @@ jobs:
     # platform-neutral; the app runs under xvfb.
     # Fast lane: this is the per-push e2e signal, split across four parallel
     # shards so a full sweep lands in ~15-20 minutes instead of ~50.
-    name: E2E (real app, Linux, shard ${{ matrix.shard }}/4)
+    name: E2E (real app, Linux, shard ${{ matrix.shard }}/8)
     needs: e2e-build-linux
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     # 24.04, not 22.04: the upstream Tectonic release binary needs glibc 2.39.
     # Must match e2e-build-linux, which produced the .deb this installs.
     runs-on: ubuntu-24.04
@@ -891,7 +951,7 @@ jobs:
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           E2E_INTERACTION_SEED: ${{ github.event_name != 'schedule' && '62024' || '' }}
-        run: xvfb-run -a ./scripts/e2e.sh --shard=${{ matrix.shard }}/4 --suite-max-failures=6 --max-failures=10 --global-timeout=3000000
+        run: xvfb-run -a ./scripts/e2e.sh --shard=${{ matrix.shard }}/8 --suite-max-failures=6 --max-failures=10 --global-timeout=3000000
 
       - name: Upload failure artifacts
         # always(), not failure(): a shard killed by timeout-minutes ends as
@@ -913,19 +973,150 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  e2e-build-windows:
+    # Builds the Windows e2e app once. Until now every Windows shard ran
+    # `pnpm tauri dev`, which compiled the whole app before its first test, so
+    # four shards paid four compiles. The shards below download this build
+    # and hand it to scripts/e2e.ps1 through OLEAFLY_E2E_APP_BINARY, the path
+    # the runner already supports for a prebuilt binary.
+    name: E2E app build (Windows)
+    needs: [frontend, rust]
+    runs-on: windows-2022
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The packaged app depends only on the sources listed here. When none of
+      # them changed since a cached build, the packed app is restored and the
+      # compile is skipped, which turns a spec-only or scripts-only push into a
+      # download instead of a build.
+      - name: Compute the packaged app cache key
+        id: e2e-app-key
+        shell: bash
+        run: echo "key=e2e-app-windows-v1-${{ hashFiles('src/**', 'packages/**', 'crates/**', 'vendor/**', 'src-tauri/src/**', 'src-tauri/Cargo.toml', 'src-tauri/build.rs', 'src-tauri/tauri.conf.json', 'src-tauri/capabilities/**', 'src-tauri/resources/**', 'src-tauri/icons/**', 'Cargo.toml', 'Cargo.lock', 'package.json', 'pnpm-lock.yaml', 'vite.config.ts', 'tsconfig.json', 'index.html', 'public/**', 'patches/**', 'scripts/fetch-tectonic.sh', 'scripts/fetch-biber.sh', 'scripts/fetch-typst.sh', 'scripts/fetch-language-servers.mjs', 'scripts/tauri-sandbox.mjs') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the packed app from the cache
+        id: e2e-app-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: oleafly-e2e-windows.tar.gz
+          key: ${{ steps.e2e-app-key.outputs.key }}
+
+      - name: Install Rust toolchain
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> src-tauri/target
+
+      - name: Cache Tectonic sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        id: cache-tectonic-e2e-build-windows
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-*
+          key: tectonic-${{ runner.os }}-${{ hashFiles('scripts/fetch-tectonic.sh') }}
+
+      - name: Fetch Tectonic sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-tectonic-e2e-build-windows.outputs.cache-hit != 'true'
+        shell: bash
+        run: bash scripts/fetch-tectonic.sh x86_64-pc-windows-msvc
+
+      - name: Cache Biber sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        id: cache-biber-e2e-build-windows
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/tectonic-biber-*
+          key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
+
+      - name: Fetch Biber sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-biber-e2e-build-windows.outputs.cache-hit != 'true'
+        shell: bash
+        run: bash scripts/fetch-biber.sh x86_64-pc-windows-msvc
+
+      - name: Cache Typst sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        id: cache-typst-e2e-build-windows
+        uses: actions/cache@v6
+        with:
+          path: src-tauri/binaries/typst-*
+          key: typst-${{ runner.os }}-${{ hashFiles('scripts/fetch-typst.sh') }}
+
+      - name: Fetch Typst sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true' && steps.cache-typst-e2e-build-windows.outputs.cache-hit != 'true'
+        shell: bash
+        run: bash scripts/fetch-typst.sh x86_64-pc-windows-msvc
+
+      - name: Stage checksum-pinned Tinymist resource archive
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: node scripts/fetch-language-servers.mjs --server tinymist --target x86_64-pc-windows-msvc --install-mode resource
+
+      - name: Smoke-test Typst sidecar
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: bash scripts/smoke-typst.sh x86_64-pc-windows-msvc
+
+      - name: Build the packaged e2e app
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        env:
+          VITE_E2E_HOOKS: "1"
+        run: pnpm tauri build --debug --features e2e-testing --no-bundle
+
+      # Pack everything the debug build placed beside the executable: the app,
+      # the sidecar executables, any DLLs, and the resources directory. Cargo's
+      # own directories and the debug symbols stay out. The listing is printed
+      # so a layout change in a future Tauri release shows up here first, and
+      # every diagnostic is guarded so it can never fail the step by itself.
+      - name: Pack the app build
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: bash scripts/ci/pack-windows-e2e-app.sh src-tauri/target/debug oleafly-e2e-windows.tar.gz
+
+      - name: Save the packed app to the cache
+        if: steps.e2e-app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: oleafly-e2e-windows.tar.gz
+          key: ${{ steps.e2e-app-key.outputs.key }}
+
+      - name: Upload the app build
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-app-windows
+          path: oleafly-e2e-windows.tar.gz
+          retention-days: 1
+
   e2e-windows:
     # The same suite on Windows (WebView2 + Rust + Tectonic). The plugin
     # serves TCP there (no unix sockets); e2e/fixtures.ts connects over TCP
     # via its own fixture, and scripts/e2e.ps1 is the launcher.
-    name: E2E (real app, Windows, shard ${{ matrix.shard }}/4)
-    needs: [frontend, rust]
+    name: E2E (real app, Windows, shard ${{ matrix.shard }}/8)
+    needs: e2e-build-windows
     runs-on: windows-2022
     # Sharded like the Linux lane: serially this suite passed 246 tests and was
     # still killed at the ceiling with specs unrun, so the result said nothing.
+    # Eight shards, each a pure test runner against the build above.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
@@ -942,13 +1133,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      - name: Download the app build
+        uses: actions/download-artifact@v7
         with:
-          workspaces: . -> src-tauri/target
+          name: e2e-app-windows
+
+      - name: Unpack the app build
+        shell: bash
+        run: bash scripts/ci/unpack-windows-e2e-app.sh oleafly-e2e-windows.tar.gz e2e-app
 
       - name: Cache Tectonic sidecar
         id: cache-tectonic-e2e-windows
@@ -961,38 +1153,6 @@ jobs:
         if: steps.cache-tectonic-e2e-windows.outputs.cache-hit != 'true'
         shell: bash
         run: bash scripts/fetch-tectonic.sh x86_64-pc-windows-msvc
-
-      - name: Cache Biber sidecar
-        id: cache-biber-e2e-windows
-        uses: actions/cache@v6
-        with:
-          path: src-tauri/binaries/tectonic-biber-*
-          key: biber-${{ runner.os }}-${{ hashFiles('scripts/fetch-biber.sh') }}
-
-      - name: Fetch Biber sidecar
-        if: steps.cache-biber-e2e-windows.outputs.cache-hit != 'true'
-        shell: bash
-        run: bash scripts/fetch-biber.sh x86_64-pc-windows-msvc
-
-      - name: Cache Typst sidecar
-        id: cache-typst-e2e-windows
-        uses: actions/cache@v6
-        with:
-          path: src-tauri/binaries/typst-*
-          key: typst-${{ runner.os }}-${{ hashFiles('scripts/fetch-typst.sh') }}
-
-      - name: Fetch Typst sidecar
-        if: steps.cache-typst-e2e-windows.outputs.cache-hit != 'true'
-        shell: bash
-        run: bash scripts/fetch-typst.sh x86_64-pc-windows-msvc
-
-      - name: Stage checksum-pinned Tinymist resource archive
-        shell: bash
-        run: node scripts/fetch-language-servers.mjs --server tinymist --target x86_64-pc-windows-msvc --install-mode resource
-
-      - name: Smoke-test Typst sidecar
-        shell: bash
-        run: bash scripts/smoke-typst.sh x86_64-pc-windows-msvc
 
       - name: Restore Tectonic packages
         id: tectonic-pkgs-windows
@@ -1038,7 +1198,7 @@ jobs:
         # run instead of one per round.
         env:
           E2E_INTERACTION_SEED: ${{ github.event_name != 'schedule' && '62024' || '' }}
-        run: powershell -File scripts/e2e.ps1 --shard=${{ matrix.shard }}/4 --suite-max-failures=6 --max-failures=10 --global-timeout=3000000
+        run: powershell -File scripts/e2e.ps1 --shard=${{ matrix.shard }}/8 --suite-max-failures=6 --max-failures=10 --global-timeout=3000000
 
       - name: Upload failure artifacts
         # always(), not failure(): a shard killed by timeout-minutes ends as

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,6 +1139,7 @@ jobs:
           name: e2e-app-windows
 
       - name: Unpack the app build
+        id: unpack-app
         shell: bash
         run: bash scripts/ci/unpack-windows-e2e-app.sh oleafly-e2e-windows.tar.gz e2e-app
 
@@ -1197,6 +1198,7 @@ jobs:
         # Same reasoning as the macOS lane: report every failing spec in one
         # run instead of one per round.
         env:
+          OLEAFLY_E2E_APP_BINARY: ${{ steps.unpack-app.outputs.binary }}
           E2E_INTERACTION_SEED: ${{ github.event_name != 'schedule' && '62024' || '' }}
         run: powershell -File scripts/e2e.ps1 --shard=${{ matrix.shard }}/8 --suite-max-failures=6 --max-failures=10 --global-timeout=3000000
 

--- a/scripts/ci/pack-windows-e2e-app.sh
+++ b/scripts/ci/pack-windows-e2e-app.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Pack a `tauri build --debug --no-bundle` output directory into one archive
+# for the Windows e2e shards: the app, the sidecar executables, any DLLs and
+# the resources directory. Cargo's own directories and debug symbols stay out.
+# Usage: pack-windows-e2e-app.sh <target-debug-dir> <archive.tar.gz>
+set -euo pipefail
+
+dir="${1:-}"
+out="${2:-}"
+if [ -z "$dir" ] || [ -z "$out" ]; then
+  echo "usage: $0 <target-debug-dir> <archive.tar.gz>" >&2
+  exit 2
+fi
+if [ ! -d "$dir" ]; then
+  echo "pack: build directory $dir does not exist" >&2
+  exit 1
+fi
+
+app=""
+for candidate in "$dir"/*.exe; do
+  [ -f "$candidate" ] || continue
+  base="$(basename "$candidate" | tr '[:upper:]' '[:lower:]')"
+  if [ "$base" = "oleafly.exe" ]; then
+    app="$candidate"
+  fi
+done
+if [ -z "$app" ]; then
+  echo "pack: no oleafly.exe in $dir" >&2
+  ls -la "$dir" >&2 || true
+  exit 1
+fi
+
+entries=()
+for entry in "$dir"/*; do
+  [ -e "$entry" ] || continue
+  name="$(basename "$entry")"
+  case "$name" in
+    build|deps|incremental|examples|.fingerprint|.cargo-lock|*.d|*.pdb|*.rlib|*.rmeta) continue ;;
+  esac
+  entries+=("$name")
+done
+
+tar -czf "$out" -C "$dir" "${entries[@]}"
+echo "--- packed ${#entries[@]} entries into $out ---"
+printf '%s\n' "${entries[@]}" | sed -n '1,40p'

--- a/scripts/ci/pack-windows-e2e-app.sh
+++ b/scripts/ci/pack-windows-e2e-app.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-# Pack a `tauri build --debug --no-bundle` output directory into one archive
-# for the Windows e2e shards: the app, the sidecar executables, any DLLs and
-# the resources directory. Cargo's own directories and debug symbols stay out.
-# Usage: pack-windows-e2e-app.sh <target-debug-dir> <archive.tar.gz>
 set -euo pipefail
 
 dir="${1:-}"

--- a/scripts/ci/unpack-windows-e2e-app.sh
+++ b/scripts/ci/unpack-windows-e2e-app.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Unpack the archive produced by pack-windows-e2e-app.sh and point the e2e
+# runner at the app through OLEAFLY_E2E_APP_BINARY.
+# Usage: unpack-windows-e2e-app.sh <archive.tar.gz> <dest-dir>
+set -euo pipefail
+
+archive="${1:-}"
+dest="${2:-}"
+if [ -z "$archive" ] || [ -z "$dest" ]; then
+  echo "usage: $0 <archive.tar.gz> <dest-dir>" >&2
+  exit 2
+fi
+if [ ! -f "$archive" ]; then
+  echo "unpack: $archive is missing" >&2
+  exit 1
+fi
+
+mkdir -p "$dest"
+tar -xzf "$archive" -C "$dest"
+
+app=""
+for candidate in "$dest"/*.exe; do
+  [ -f "$candidate" ] || continue
+  base="$(basename "$candidate" | tr '[:upper:]' '[:lower:]')"
+  if [ "$base" = "oleafly.exe" ]; then
+    app="$candidate"
+  fi
+done
+if [ -z "$app" ]; then
+  echo "unpack: no oleafly.exe inside $archive" >&2
+  ls -la "$dest" >&2 || true
+  exit 1
+fi
+
+app="$(cd "$(dirname "$app")" && pwd)/$(basename "$app")"
+if command -v cygpath >/dev/null 2>&1; then
+  app="$(cygpath -w "$app")"
+fi
+echo "OLEAFLY_E2E_APP_BINARY=$app" >> "${GITHUB_ENV:-/dev/null}"
+echo "app binary: $app"
+echo "--- unpacked into $dest ---"
+ls -la "$dest" | sed -n '1,40p'

--- a/scripts/ci/unpack-windows-e2e-app.sh
+++ b/scripts/ci/unpack-windows-e2e-app.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Unpack the archive produced by pack-windows-e2e-app.sh and point the e2e
-# runner at the app through OLEAFLY_E2E_APP_BINARY.
-# Usage: unpack-windows-e2e-app.sh <archive.tar.gz> <dest-dir>
 set -euo pipefail
 
 archive="${1:-}"
@@ -36,7 +33,7 @@ app="$(cd "$(dirname "$app")" && pwd)/$(basename "$app")"
 if command -v cygpath >/dev/null 2>&1; then
   app="$(cygpath -w "$app")"
 fi
-echo "OLEAFLY_E2E_APP_BINARY=$app" >> "${GITHUB_ENV:-/dev/null}"
+echo "binary=$app" >> "${GITHUB_OUTPUT:-/dev/null}"
 echo "app binary: $app"
 echo "--- unpacked into $dest ---"
 ls -la "$dest" | sed -n '1,40p'

--- a/scripts/e2e-browser-harness.sh
+++ b/scripts/e2e-browser-harness.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SPECS=(
+  "e2e/tests/24-pdf-selection-browser.spec.ts"
+  "e2e/tests/27-markdown-rendering-browser.spec.ts"
+  "e2e/tests/56-preview-window-browser.spec.ts"
+  "e2e/tests/84-settings-install-browser.spec.ts"
+)
+PROBE_URL="http://localhost:1420/e2e/settings-install-harness.html"
+
+if lsof -ti :1420 >/dev/null 2>&1; then
+  echo "e2e-browser-harness: port 1420 is already owned by pid(s): $(lsof -ti :1420 | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+VITE_LOG="$(mktemp)"
+pnpm exec vite --port 1420 --strictPort >"$VITE_LOG" 2>&1 &
+VITE_PID=$!
+
+cleanup() {
+  local pids
+  pids="$(lsof -ti :1420 2>/dev/null | tr '\n' ' ')"
+  kill "$VITE_PID" $pids 2>/dev/null || true
+  wait "$VITE_PID" 2>/dev/null || true
+  rm -f "$VITE_LOG"
+}
+trap cleanup EXIT
+
+ready=0
+for _ in $(seq 1 120); do
+  if curl -fsS -o /dev/null "$PROBE_URL"; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$VITE_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+  echo "e2e-browser-harness: Vite never served $PROBE_URL" >&2
+  tail -n 40 "$VITE_LOG" >&2
+  exit 1
+fi
+echo "e2e-browser-harness: Vite is serving $PROBE_URL"
+
+status=0
+pnpm exec playwright test -c e2e/playwright.config.ts "${SPECS[@]}" "$@" || status=$?
+if [ "$status" -ne 0 ]; then
+  echo "e2e-browser-harness: Playwright exited with $status; last Vite output:" >&2
+  tail -n 40 "$VITE_LOG" >&2
+fi
+exit "$status"

--- a/scripts/e2e-browser-harness.sh
+++ b/scripts/e2e-browser-harness.sh
@@ -3,12 +3,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-SPECS=(
-  "e2e/tests/24-pdf-selection-browser.spec.ts"
-  "e2e/tests/27-markdown-rendering-browser.spec.ts"
-  "e2e/tests/56-preview-window-browser.spec.ts"
-  "e2e/tests/84-settings-install-browser.spec.ts"
-)
+SPECS=(e2e/tests/*-browser.spec.ts)
+if [ "${#SPECS[@]}" -eq 0 ] || [ ! -f "${SPECS[0]}" ]; then
+  echo "e2e-browser-harness: no e2e/tests/*-browser.spec.ts files found" >&2
+  exit 1
+fi
 PROBE_URL="http://localhost:1420/e2e/settings-install-harness.html"
 
 if lsof -ti :1420 >/dev/null 2>&1; then
@@ -46,6 +45,7 @@ if [ "$ready" -ne 1 ]; then
   exit 1
 fi
 echo "e2e-browser-harness: Vite is serving $PROBE_URL"
+printf 'e2e-browser-harness: spec %s\n' "${SPECS[@]}"
 
 status=0
 pnpm exec playwright test -c e2e/playwright.config.ts "${SPECS[@]}" "$@" || status=$?

--- a/scripts/e2e.ps1
+++ b/scripts/e2e.ps1
@@ -290,10 +290,10 @@ try {
     $failures = 0
     $specs = Get-ChildItem -Path "e2e/tests" -Filter "*.spec.ts" | Sort-Object Name
     if ($appBinary) {
-      $devOnly = @("24-pdf-selection-browser.spec.ts", "27-markdown-rendering-browser.spec.ts", "56-preview-window-browser.spec.ts")
+      $devOnly = @("24-pdf-selection-browser.spec.ts", "27-markdown-rendering-browser.spec.ts", "56-preview-window-browser.spec.ts", "84-settings-install-browser.spec.ts")
       $specs = $specs | Where-Object {
         if ($_.Name -in $devOnly) {
-          Write-Host "e2e: skipping $($_.Name) in packaged mode (requires the dev-server harness)"
+          Write-Host "e2e: skipping $($_.Name) in packaged mode (dev-server harness; covered by the browser-harness job)"
           $false
         } else { $true }
       }

--- a/scripts/e2e.ps1
+++ b/scripts/e2e.ps1
@@ -290,9 +290,8 @@ try {
     $failures = 0
     $specs = Get-ChildItem -Path "e2e/tests" -Filter "*.spec.ts" | Sort-Object Name
     if ($appBinary) {
-      $devOnly = @("24-pdf-selection-browser.spec.ts", "27-markdown-rendering-browser.spec.ts", "56-preview-window-browser.spec.ts", "84-settings-install-browser.spec.ts")
       $specs = $specs | Where-Object {
-        if ($_.Name -in $devOnly) {
+        if ($_.Name -like "*-browser.spec.ts") {
           Write-Host "e2e: skipping $($_.Name) in packaged mode (dev-server harness; covered by the browser-harness job)"
           $false
         } else { $true }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -386,28 +386,22 @@ else
       SUITE_SPECS+=("$spec")
     done
   fi
-  # Browser-harness specs load TSX fixtures through the Vite dev server, so a
-  # packaged run cannot serve them. Their subject is Playwright's own
-  # Chromium/WebKit (platform-independent), and scripts/e2e-browser-harness.sh
-  # runs them in their own CI job — skipping here loses no coverage, and the
-  # log says so out loud.
-  PACKAGED_UNSERVABLE=(
-    "e2e/tests/24-pdf-selection-browser.spec.ts"
-    "e2e/tests/27-markdown-rendering-browser.spec.ts"
-    "e2e/tests/56-preview-window-browser.spec.ts"
-    "e2e/tests/84-settings-install-browser.spec.ts"
-  )
+  # Browser-harness specs (the *-browser.spec.ts files) load TSX fixtures
+  # through the Vite dev server, so a packaged run cannot serve them. Their
+  # subject is Playwright's own Chromium/WebKit (platform-independent), and
+  # scripts/e2e-browser-harness.sh runs them in their own CI job — skipping
+  # here loses no coverage, and the log says so out loud.
   if [ -n "$APP_BINARY" ]; then
     filtered=()
     for spec in "${SUITE_SPECS[@]}"; do
-      skip_this=0
-      for unservable in "${PACKAGED_UNSERVABLE[@]}"; do
-        if [ "$spec" = "$unservable" ]; then
-          skip_this=1
+      case "$spec" in
+        *-browser.spec.ts)
           echo "e2e: skipping $(basename "$spec") in packaged mode (dev-server harness; covered by the browser-harness job)"
-        fi
-      done
-      [ "$skip_this" -eq 1 ] || filtered+=("$spec")
+          ;;
+        *)
+          filtered+=("$spec")
+          ;;
+      esac
     done
     SUITE_SPECS=("${filtered[@]}")
   fi

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -388,8 +388,9 @@ else
   fi
   # Browser-harness specs load TSX fixtures through the Vite dev server, so a
   # packaged run cannot serve them. Their subject is Playwright's own
-  # Chromium/WebKit (platform-independent), and the Windows dev-mode lane runs
-  # them — skipping here loses no coverage, and the log says so out loud.
+  # Chromium/WebKit (platform-independent), and scripts/e2e-browser-harness.sh
+  # runs them in their own CI job — skipping here loses no coverage, and the
+  # log says so out loud.
   PACKAGED_UNSERVABLE=(
     "e2e/tests/24-pdf-selection-browser.spec.ts"
     "e2e/tests/27-markdown-rendering-browser.spec.ts"
@@ -403,7 +404,7 @@ else
       for unservable in "${PACKAGED_UNSERVABLE[@]}"; do
         if [ "$spec" = "$unservable" ]; then
           skip_this=1
-          echo "e2e: skipping $(basename "$spec") in packaged mode (dev-server harness; covered by the Windows dev-mode lane)"
+          echo "e2e: skipping $(basename "$spec") in packaged mode (dev-server harness; covered by the browser-harness job)"
         fi
       done
       [ "$skip_this" -eq 1 ] || filtered+=("$spec")

--- a/scripts/fetch-language-servers.node-tests.mjs
+++ b/scripts/fetch-language-servers.node-tests.mjs
@@ -857,8 +857,8 @@ test("every clean CI and release Tauri build fetches only pinned Tinymist", asyn
     "x86_64-pc-windows-msvc",
     cargoBuildPattern,
   );
-  // The macOS and Linux shards consume a prebuilt app; the staging obligation
-  // follows the build, so it lives in the job that actually compiles.
+  // Every e2e shard consumes a prebuilt app; the staging obligation follows
+  // the build, so it lives in the three jobs that actually compile.
   assertTinymistFetchBeforeBuild(
     ciWorkflow,
     "e2e-build-macos",
@@ -873,9 +873,9 @@ test("every clean CI and release Tauri build fetches only pinned Tinymist", asyn
   );
   assertTinymistFetchBeforeBuild(
     ciWorkflow,
-    "e2e-windows",
+    "e2e-build-windows",
     "x86_64-pc-windows-msvc",
-    e2eBuildPattern,
+    packagedE2eBuildPattern,
   );
 
   const exactFetchPattern =
@@ -888,7 +888,7 @@ test("every clean CI and release Tauri build fetches only pinned Tinymist", asyn
       .split("\n")
       .map((line) => line.trim())
       .filter((line) =>
-        line.includes("scripts/fetch-language-servers.mjs") &&
+        /^(?:run: )?node scripts\/fetch-language-servers\.mjs\b/.test(line) &&
         !line.includes("--check"),
       );
     assert.equal(


### PR DESCRIPTION
A green CI round took about 44 minutes, and the long pole was the Linux and Windows e2e lanes: four shards each, 15 to 20 minutes per shard. On Windows every shard also ran `pnpm tauri dev`, so four shards paid four compiles before their first test. This PR changes four things about that.

## What changed

Linux and Windows e2e now run eight shards instead of four. Both runners already accept any `--shard=K/N`, so this is the matrix and the divisor. macOS stays at four because the free plan allows five concurrent macOS jobs.

Windows gets an `E2E app build (Windows)` job that runs `pnpm tauri build --debug --features e2e-testing --no-bundle` once, packs the executable, the sidecars, any DLLs and the resources directory, and uploads them. The shards download that build, and the unpack step publishes the executable's path as a step output that the run step hands to `scripts/e2e.ps1` through `OLEAFLY_E2E_APP_BINARY`. The shards drop the Rust toolchain, the Biber and Typst fetches and the Tinymist stage; they keep the Tectonic sidecar because the pre-warm step uses it.

All three build jobs cache the packed app under a key made from the sources that go into it (app and package sources, the Rust crates, the Tauri config and resources, lockfiles, the fetch scripts). A push that changes only specs, scripts or docs restores the packed app instead of compiling it: the platform setup, the sidecar fetches and the build steps are skipped on a hit and the artifact is uploaded from the cache. The macOS job still runs the shared-crate tests on every run.

The four browser-harness specs (`*-browser.spec.ts`) get their own job. They drive Playwright's Chromium against fixture pages that Vite serves from `e2e/`, with the Tauri bridge mocked inside the page, so they need no app at all. Until now the Windows dev-mode lane was the only place they ran, and turning that lane into packaged shards would have left them unrun. `scripts/e2e-browser-harness.sh` starts Vite, waits for the settings fixture to answer, runs the specs and tears Vite down; the `E2E (browser harness, Linux)` job runs it after the frontend job. Both packaged launchers now skip those specs by their file suffix instead of by hand-kept lists, which is what let spec 84 slip into a Windows shard on this branch's first round.

## Measured effect

Two full rounds ran on this branch, both with every app build on a cache miss. The first ended in 35 minutes and the second, after the rebase onto main, in 32 minutes, against 44 before. Shard times on the second round:

| Lane | Shards | Longest | Shortest |
|---|---|---|---|
| Linux | 8 | 12 min 55 s | 8 min 20 s |
| macOS | 4 | 10 min 16 s | 8 min 49 s |
| Windows | 8 | 10 min 42 s | 6 min 34 s |

The build jobs took 7 minutes on Windows, 9 on macOS and 5 on Linux. The browser-harness job takes about a minute and a half, 35 seconds of which is the specs themselves. Eight plus eight plus four shards briefly exceed the free plan's 20 concurrent jobs, so a few shards queue for a minute or two. A push that hits the app cache skips all three builds, which should take the round below 25 minutes; that case has not run yet.

## Verification

- `pnpm language-servers:test` passes; it checks the workflow text for the Tinymist staging order and now points at the Windows build job. Its fetch counter only counts `run:` invocations, since the cache-key lines mention the fetch script's path.
- The workflow parses, every `needs` names an existing job, and every `steps.<id>` reference resolves inside its job.
- The two bash helpers under `scripts/ci` were run here against stub layouts: a normal debug directory, an executable with different casing and no resources, an empty directory, and a missing archive. The last two fail loudly with the listing. On the runner, the Windows debug build without a bundle produced exactly the app, the three sidecars and `resources`, and every Windows shard started it.
- `scripts/e2e-browser-harness.sh` was run here against Vite (9 passed, the Firefox and WebKit variants skipped because those browsers are not installed, the port freed afterwards) and refused to start while another process held port 1420. On CI it passed with the same 9 tests.
- The Bash launcher's suffix filter was exercised on a mixed list and kept `73-browser-dock.spec.ts`, which is an app spec despite its name.

## Not in this PR

The WebKit and Firefox variants of the harness specs still skip everywhere, as they did on the old Windows lane. Installing those browsers in the harness job would run them for about two more minutes; that is a separate decision.
